### PR TITLE
SQL comments require whitespace between "--" and comment text

### DIFF
--- a/server/modules/routing/readwritesplit/test/test_implicit_commit1.sql
+++ b/server/modules/routing/readwritesplit/test/test_implicit_commit1.sql
@@ -3,6 +3,6 @@ SET autocommit=1;
 BEGIN;
 CREATE DATABASE FOO; -- implicit commit
 SELECT (@@server_id) INTO @a;
-SELECT @a; --should read from slave
+SELECT @a; -- should read from slave
 DROP DATABASE If EXISTS FOO;
 COMMIT;

--- a/server/modules/routing/readwritesplit/test/test_implicit_commit2.sql
+++ b/server/modules/routing/readwritesplit/test/test_implicit_commit2.sql
@@ -9,7 +9,7 @@ ON SCHEDULE AT CURRENT_TIMESTAMP + INTERVAL 1 HOUR
 DO
 UPDATE t1 SET id = id + 1;
 SELECT (@@server_id) INTO @a;
-SELECT @a; --should read from slave
+SELECT @a; -- should read from slave
 DROP TABLE IF EXISTS T1;
 DROP EVENT IF EXISTS myevent;
 COMMIT;

--- a/server/modules/routing/readwritesplit/test/test_implicit_commit3.sql
+++ b/server/modules/routing/readwritesplit/test/test_implicit_commit3.sql
@@ -4,6 +4,6 @@ SET autocommit=1;
 BEGIN;
 CREATE TABLE T1 (id integer); -- implicit commit
 SELECT (@@server_id) INTO @a;
-SELECT @a; --should read from slave
+SELECT @a; -- should read from slave
 DROP TABLE IF EXISTS T1;
 COMMIT;

--- a/server/modules/routing/readwritesplit/test/test_implicit_commit4.sql
+++ b/server/modules/routing/readwritesplit/test/test_implicit_commit4.sql
@@ -4,6 +4,6 @@ SET autocommit=0;
 BEGIN;
 CREATE TEMPORARY TABLE T1 (id integer); -- NO implicit commit
 SELECT (@@server_id) INTO @a;
-SELECT @a; --should read from master
+SELECT @a; -- should read from master
 DROP TABLE IF EXISTS T1;
 COMMIT;

--- a/server/modules/routing/readwritesplit/test/test_implicit_commit5.sql
+++ b/server/modules/routing/readwritesplit/test/test_implicit_commit5.sql
@@ -9,6 +9,6 @@ BEGIN
 END //
 DELIMITER ;
 SELECT (@@server_id) INTO @a;
-SELECT @a; --should read from slave
+SELECT @a; -- should read from slave
 DROP PROCEDURE IF EXISTS simpleproc;
 COMMIT;

--- a/server/modules/routing/readwritesplit/test/test_implicit_commit6.sql
+++ b/server/modules/routing/readwritesplit/test/test_implicit_commit6.sql
@@ -6,6 +6,6 @@ CREATE FUNCTION hello (s CHAR(20))
 RETURNS CHAR(50) DETERMINISTIC
 RETURN CONCAT('Hello, ',s,'!'); -- implicit COMMIT
 SELECT (@@server_id) INTO @a;
-SELECT @a; --should read from slave
+SELECT @a; -- should read from slave
 DROP FUNCTION IF EXISTS hello;
 COMMIT;

--- a/server/modules/routing/readwritesplit/test/test_implicit_commit7.sql
+++ b/server/modules/routing/readwritesplit/test/test_implicit_commit7.sql
@@ -5,6 +5,6 @@ SET autocommit=1;
 BEGIN;
 CREATE INDEX foo_t1 on T1 (id); -- implicit commit
 SELECT (@@server_id) INTO @a;
-SELECT @a; --should read from slave
+SELECT @a; -- should read from slave
 DROP TABLE IF EXISTS T1;
 COMMIT;


### PR DESCRIPTION
fix whitespace issue reported in bugzilla bug report #435
