### PR TITLE
Fix to bug #479, http://bugs.skysql.com/show_bug.cgi?id=479

### DIFF
--- a/server/core/service.c
+++ b/server/core/service.c
@@ -675,6 +675,7 @@ int		n = 0;
 				"Unable to find filter '%s' for service '%s'\n",
 					trim(ptr), service->name
 					)));
+			n--;
 		}
 		flist[n] = NULL;
 		ptr = strtok_r(NULL, "|", &brkt);


### PR DESCRIPTION
service.c was counting unfound filters towards the filter chain size.
