### PR TITLE
support both "quit" and "exit" to leave maxadmin

### DIFF
--- a/client/maxadmin.c
+++ b/client/maxadmin.c
@@ -289,7 +289,7 @@ int		argno = 0;
 		history(hist, &ev, H_ENTER, buf);
 #endif
 
-		if (!strcasecmp(buf, "quit"))
+		if ((!strcasecmp(buf, "quit")) || (!strcasecmp(buf, "exit")))
 		{
 			break;
 		}


### PR DESCRIPTION
mysql command line client understands both, too,
so we should be consistent with that
