### PR TITLE
use ISO-8601 format for date part in log message timestamp

### DIFF
--- a/utils/skygw_utils.cc
+++ b/utils/skygw_utils.cc
@@ -28,7 +28,7 @@
 #include "skygw_types.h"
 #include "skygw_utils.h"
 
-const char*  timestamp_formatstr = "%04d %02d/%02d %02d:%02d:%02d   ";
+const char*  timestamp_formatstr = "%04d-%02d-%02d %02d:%02d:%02d   ";
 /** One for terminating '\0' */
 const int    timestamp_len       =    4+1 +2+1 +2+1 +2+1 +2+1 +2+3  +1;
 


### PR DESCRIPTION
I've never seen the current "YYYY MM/DD" format before and wouldn't be sure which part is month or day from just looking at it. By changing the format to ISO-8601 style "YYYY-MM-DD" it becomes more clear

That's the format used in MySQLs SQL, too, unfortunately mysqld uses YYMMDD in log files instead. Changing it to that format would also be possible for consistency reasons, but I'd prefer ISO 8601 style ...
