### PR TITLE
Fix to bug # 565, http://bugs.mariadb.com/show_bug.cgi?id=565

### DIFF
--- a/log_manager/log_manager.cc
+++ b/log_manager/log_manager.cc
@@ -2073,7 +2073,7 @@ static bool logfile_init(
 		char* c;
 		pid_t pid = getpid();
 		int   len = strlen(shm_pathname_prefix)+
-			get_decimal_len((size_t)pid);
+			get_decimal_len((size_t)pid) + 1;
 			
 		c = (char *)calloc(len, sizeof(char));
 		

--- a/server/modules/protocol/mysql_backend.c
+++ b/server/modules/protocol/mysql_backend.c
@@ -880,6 +880,10 @@ static int gw_create_backend_connection(
                 goto return_fd;
         }
         
+        /** Copy client flags to backend protocol */
+	protocol->client_capabilities = 
+	((MySQLProtocol *)(backend_dcb->session->client->protocol))->client_capabilities;
+	
         /*< if succeed, fd > 0, -1 otherwise */
         rv = gw_do_connect_to_backend(server->name, server->port, &fd);
         /*< Assign protocol with backend_dcb */

--- a/server/modules/protocol/mysql_client.c
+++ b/server/modules/protocol/mysql_client.c
@@ -520,7 +520,7 @@ static char* get_username_from_auth(
 	
 	if (ptr == NULL)
 	{
-		if ((rval = (char *)malloc(MYSQL_USER_MAXLEN)) == NULL)
+		if ((rval = (char *)malloc(MYSQL_USER_MAXLEN+1)) == NULL)
 		{
 			goto retblock;
 		}
@@ -529,7 +529,7 @@ static char* get_username_from_auth(
 	{
 		rval = ptr;
 	}
-	strncpy(rval, first_letter, MYSQL_USER_MAXLEN);
+	snprintf(rval, MYSQL_USER_MAXLEN+1, "%s", first_letter);
 	
 retblock:
 

--- a/server/modules/protocol/mysql_common.c
+++ b/server/modules/protocol/mysql_common.c
@@ -538,9 +538,9 @@ int gw_receive_backend_auth(
  * @return 0 on success, 1 on failure
  */
 int gw_send_authentication_to_backend(
-        char *dbname,
-        char *user,
-        uint8_t *passwd,
+        char	*dbname,
+        char	*user,
+        uint8_t	*passwd,
         MySQLProtocol *conn)
 {
         int compress = 0;
@@ -572,11 +572,10 @@ int gw_send_authentication_to_backend(
 	memset(&final_capabilities, '\0', sizeof(final_capabilities));
 
         final_capabilities = gw_mysql_get_byte4((uint8_t *)&server_capabilities);
+	/** Copy client's flags to backend */
+	final_capabilities |= conn->client_capabilities;;
 
-        final_capabilities |= GW_MYSQL_CAPABILITIES_PROTOCOL_41;
-        final_capabilities |= GW_MYSQL_CAPABILITIES_CLIENT;
-
-        if (compress) {
+	if (compress) {
                 final_capabilities |= GW_MYSQL_CAPABILITIES_COMPRESS;
 #ifdef DEBUG_MYSQL_CONN
                 fprintf(stderr, ">>>> Backend Connection with compression\n");
@@ -1362,8 +1361,10 @@ int gw_find_mysql_user_password_sha1(char *username, uint8_t *gateway_password, 
 			LOGIF(LE,
 				(skygw_log_write_flush(
 					LOGFILE_ERROR,
-					"%lu [MySQL Client Auth], user [%s@%s] not found, please try with 'localhost_match_wildcard_host=1' in service definition",
-					pthread_self(),
+					"Error : user %s@%s not found, try set "
+					"'localhost_match_wildcard_host=1' in "
+					"service definition of the configuration "
+					"file.",
 					key.user,
 					dcb->remote)));
 


### PR DESCRIPTION
Client flags are now copied to each backend and used in their connections.

log_manager.cc: fixed string allocation where one byte was missing.
mysql_client.c: fixed string allocation where one byte was missing.
