### PR TITLE
make default build warning-free

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,8 @@ configure_file(${CMAKE_SOURCE_DIR}/etc/init.d/maxscale.in ${CMAKE_SOURCE_DIR}/et
 configure_file(${CMAKE_SOURCE_DIR}/etc/ubuntu/init.d/maxscale.in ${CMAKE_SOURCE_DIR}/etc/ubuntu/init.d/maxscale.prep @ONLY)
 
 
-set(CMAKE_C_FLAGS "-Wall -fPIC")
-set(CMAKE_CXX_FLAGS "-Wall -fPIC")
+set(CMAKE_C_FLAGS   "-Wall -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unused-function -fPIC")
+set(CMAKE_CXX_FLAGS "-Wall -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unused-function -fPIC")
 
 if(BUILD_TYPE MATCHES Debug)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ggdb -pthread -pipe -DSS_DEBUG -Wformat -Werror=format-security -fstack-protector --param=ssp-buffer-size=4")

--- a/log_manager/log_manager.cc
+++ b/log_manager/log_manager.cc
@@ -160,7 +160,7 @@ struct logfile_st {
         size_t           lf_file_size;
         /** list of block-sized log buffers */
         mlist_t          lf_blockbuf_list;
-        int              lf_buf_size;
+        size_t           lf_buf_size;
         bool             lf_flushflag;
         int              lf_spinlock; /**< lf_flushflag */
         int              lf_npending_writes;

--- a/log_manager/test/testlog.c
+++ b/log_manager/test/testlog.c
@@ -89,7 +89,7 @@ int main(int argc, char* argv[])
                 goto return_err;
         }
 
-        thr = (thread_t*)calloc(1, nthr*sizeof(thread_t*));
+        thr = (thread_t**)calloc(1, nthr*sizeof(thread_t*));
         
         if (thr == NULL)
         {

--- a/log_manager/test/testlog.c
+++ b/log_manager/test/testlog.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <getopt.h>
 #include <skygw_utils.h>
 #include <log_manager.h>
 

--- a/query_classifier/query_classifier.cc
+++ b/query_classifier/query_classifier.cc
@@ -30,12 +30,6 @@
 # undef MYSQL_CLIENT
 #endif
 
-#include <query_classifier.h>
-#include "../utils/skygw_types.h"
-#include "../utils/skygw_debug.h"
-#include <log_manager.h>
-#include <mysql_client_server_protocol.h>
-
 #include <mysql.h>
 #include <my_sys.h>
 #include <my_global.h>
@@ -59,6 +53,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>
+
+#include <query_classifier.h>
+#include "../utils/skygw_types.h"
+#include "../utils/skygw_debug.h"
+#include <log_manager.h>
+#include <mysql_client_server_protocol.h>
 
 extern int lm_enabled_logfiles_bitmask;
 

--- a/server/core/config.c
+++ b/server/core/config.c
@@ -54,6 +54,7 @@
 #include <skygw_utils.h>
 #include <log_manager.h>
 #include <mysql.h>
+#include <mysql_client_server_protocol.h>
 
 extern int lm_enabled_logfiles_bitmask;
 

--- a/server/core/gateway.c
+++ b/server/core/gateway.c
@@ -1678,7 +1678,7 @@ static void log_flush_cb(
             skygw_log_flush(LOGFILE_MESSAGE);
             skygw_log_flush(LOGFILE_TRACE);
             skygw_log_flush(LOGFILE_DEBUG);
-            usleep(timeout_ms*1000);
+            thread_millisleep(timeout_ms);
         }
         LOGIF(LM, (skygw_log_write(LOGFILE_MESSAGE,
                                    "Finished MaxScale log flusher.")));

--- a/server/core/gateway.c
+++ b/server/core/gateway.c
@@ -948,6 +948,7 @@ int main(int argc, char **argv)
         int 	 l;
         int	 i;
         int      n;
+        intptr_t thread_id;
         int      n_threads; /*< number of epoll listener threads */ 
         int      n_services;
         int      eno = 0;   /*< local variable for errno */
@@ -1591,9 +1592,9 @@ int main(int argc, char **argv)
         /*<
          * Start server threads.
          */
-        for (n = 0; n < n_threads - 1; n++)
+        for (thread_id = 0; thread_id < n_threads - 1; thread_id++)
         {
-                threads[n] = thread_start(poll_waitevents, (void *)(n + 1));
+                threads[thread_id] = thread_start(poll_waitevents, (void *)(thread_id + 1));
         }
         LOGIF(LM, (skygw_log_write(LOGFILE_MESSAGE,
                         "MaxScale started with %d server threads.",
@@ -1606,9 +1607,9 @@ int main(int argc, char **argv)
         /*<
          * Wait server threads' completion.
          */
-        for (n = 0; n < n_threads - 1; n++)
+        for (thread_id = 0; thread_id < n_threads - 1; thread_id++)
         {
-                thread_wait(threads[n]);
+                thread_wait(threads[thread_id]);
         }
         free(threads);
         free(home_dir);

--- a/server/core/gateway.c
+++ b/server/core/gateway.c
@@ -42,6 +42,7 @@
 #define _XOPEN_SOURCE 700
 #include <ftw.h>
 #include <string.h>
+#include <strings.h>
 #include <gw.h>
 #include <unistd.h>
 #include <getopt.h>
@@ -1088,9 +1089,9 @@ int main(int argc, char **argv)
                   goto return_main;		  
 
 		case 'l':
-			if (strncasecmp(optarg, "file") == 0)
+			if (strncasecmp(optarg, "file", 4) == 0)
 				logtofile = 1;
-			else if (strncasecmp(optarg, "shm") == 0)
+			else if (strncasecmp(optarg, "shm", 3) == 0)
 				logtofile = 0;
 			else
 			{

--- a/server/core/maxkeys.c
+++ b/server/core/maxkeys.c
@@ -30,7 +30,7 @@
 #include	<stdio.h>
 #include	<secrets.h>
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
 	if (argc != 2)
 	{

--- a/server/core/poll.c
+++ b/server/core/poll.c
@@ -375,7 +375,7 @@ poll_waitevents(void *arg)
 {
 struct epoll_event events[MAX_EVENTS];
 int		   i, nfds;
-int		   thread_id = (int)arg;
+intptr_t	   thread_id = (intptr_t)arg;
 DCB                *zombies = NULL;
 
 	/** Add this thread to the bitmask of running polling threads */

--- a/server/core/test/testhash.c
+++ b/server/core/test/testhash.c
@@ -157,7 +157,7 @@ static bool do_hashtest(
         CHK_HASHTABLE(h);
         hashtable_free(h);
         
-return_succp:
+return_succp: __attribute__ ((unused))
         return succp;
 }
 

--- a/server/core/test/testspinlock.c
+++ b/server/core/test/testspinlock.c
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <spinlock.h>
 #include <thread.h>

--- a/server/core/test/testspinlock.c
+++ b/server/core/test/testspinlock.c
@@ -122,7 +122,7 @@ void		*handle;
 	return 0;
 }
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
 int	result = 0;
 

--- a/server/core/thread.c
+++ b/server/core/thread.c
@@ -17,6 +17,8 @@
  */
 #include <thread.h>
 #include <pthread.h>
+#include <time.h>
+
 /**
  * @file thread.c  - Implementation of thread related operations
  *

--- a/server/include/server.h
+++ b/server/include/server.h
@@ -85,7 +85,7 @@ typedef struct server {
 	char		*server_string;	/**< Server version string, i.e. MySQL server version */
 	long		node_id;	/**< Node id, server_id for M/S or local_index for Galera */
 	int		rlag;		/**< Replication Lag for Master / Slave replication */
-	unsigned long	node_ts;	/**< Last timestamp set from M/S monitor module */
+	time_t    	node_ts;	/**< Last timestamp set from M/S monitor module */
 	SERVER_PARAM	*parameters;	/**< Parameters of a server that may be used to weight routing decisions */
 	long		master_id;	/**< Master server id of this node */
 	int		depth;		/**< Replication level in the tree */

--- a/server/modules/filter/hint/hintparser.c
+++ b/server/modules/filter/hint/hintparser.c
@@ -210,7 +210,7 @@ HINT_MODE	mode = HM_EXECUTE;
 	/*
 	 * If we have got here then we have a comment, ptr point to
 	 * the comment character if it is a '#' comment or the second
-	 * character of the comment if it is a -- or /* comment
+	 * character of the comment if it is a -- or slash-asterisk comment
 	 *
 	 * Move to the next character in the SQL.
 	 */

--- a/server/modules/filter/hint/hintparser.c
+++ b/server/modules/filter/hint/hintparser.c
@@ -550,7 +550,7 @@ HINT_TOKEN	*tok;
                 else if (!inword && inquote == '\0' && **ptr == '=')
                 {
                         *dest = **ptr;
-                        *dest++;
+                        dest++;
                         (*ptr)++;
                         break;
                 }

--- a/server/modules/filter/topfilter.c
+++ b/server/modules/filter/topfilter.c
@@ -476,8 +476,11 @@ int		length;
 }
 
 static int
-cmp_topn(TOPNQ **a, TOPNQ **b)
+cmp_topn(const void *va, const void *vb)
 {
+        TOPNQ **a = (TOPNQ **)va;
+        TOPNQ **b = (TOPNQ **)vb;
+
 	if ((*b)->duration.tv_sec == (*a)->duration.tv_sec)
 		return (*b)->duration.tv_usec - (*a)->duration.tv_usec;
 	return (*b)->duration.tv_sec - (*a)->duration.tv_sec;

--- a/server/modules/include/mysql_client_server_protocol.h
+++ b/server/modules/include/mysql_client_server_protocol.h
@@ -298,7 +298,6 @@ typedef struct {
 #define MYSQL_IS_COM_QUIT(payload)              (MYSQL_GET_COMMAND(payload)==0x01)
 #define MYSQL_GET_NATTR(payload)                ((int)payload[4])
 
-#endif /** _MYSQL_PROTOCOL_H */
 
 void gw_mysql_close(MySQLProtocol **ptr);
 MySQLProtocol* mysql_protocol_init(DCB* dcb, int fd);
@@ -390,4 +389,5 @@ void init_response_status (
         int* npackets, 
         size_t* nbytes);
 
+#endif /** _MYSQL_PROTOCOL_H */
 

--- a/utils/skygw_utils.cc
+++ b/utils/skygw_utils.cc
@@ -31,7 +31,7 @@
 
 const char*  timestamp_formatstr = "%04d-%02d-%02d %02d:%02d:%02d   ";
 /** One for terminating '\0' */
-const int    timestamp_len       =    4+1 +2+1 +2+1 +2+1 +2+1 +2+3  +1;
+const size_t    timestamp_len       =    4+1 +2+1 +2+1 +2+1 +2+1 +2+3  +1;
 
 /** Single-linked list for storing test cases */
 
@@ -632,7 +632,7 @@ bool mlist_cursor_move_to_first(
 /** End of mlist */
 
 
-int get_timestamp_len(void)
+size_t get_timestamp_len(void)
 {
         return timestamp_len;
 }
@@ -654,7 +654,7 @@ int get_timestamp_len(void)
  */
 int snprint_timestamp(
         char* p_ts,
-        int   tslen)
+        size_t   tslen)
 {
         time_t       t;
         struct tm    tm;

--- a/utils/skygw_utils.cc
+++ b/utils/skygw_utils.cc
@@ -1264,7 +1264,7 @@ simple_mutex_t* simple_mutex_init(
                 
                 /** Write zeroes if flat, free otherwise. */
                 if (sm->sm_flat) {
-                        memset(sm, 0, sizeof(sm));
+                        memset(sm, 0, sizeof(simple_mutex_t));
                 } else {
                         simple_mutex_free_memory(sm);
                         sm = NULL;

--- a/utils/skygw_utils.h
+++ b/utils/skygw_utils.h
@@ -126,8 +126,8 @@ int               skygw_thread_start(skygw_thread_t* thr);
 skygw_thr_state_t skygw_thread_get_state(skygw_thread_t* thr);
 pthread_t         skygw_thread_gettid(skygw_thread_t* thr);
 
-int get_timestamp_len(void);
-int snprint_timestamp(char* p_ts, int tslen);
+size_t get_timestamp_len(void);
+int snprint_timestamp(char* p_ts, size_t tslen);
 
 EXTERN_C_BLOCK_BEGIN
 


### PR DESCRIPTION
Fixed a lot of warnings (at least two might have been actual bugs),

and silenced a lot of "variable is never used", "(static) function is never used" and "assigned value is never used" warnings for now with extra CFLAGS

  -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unused-function

as these don't seem to be critical / hiding actual bugs ...
