### PR TITLE
properly zero-terminate input buffer -  Bug #605

### DIFF
--- a/query_classifier/test/canonical_tests/canonizer.c
+++ b/query_classifier/test/canonical_tests/canonizer.c
@@ -51,12 +51,13 @@ int main(int argc, char** argv)
   fsz = lseek(fdin,0,SEEK_END);
   lseek(fdin,0,SEEK_SET);
 
-  if(!(buffer = malloc(sizeof(char)*fsz))){
+  if(!(buffer = malloc(sizeof(char)*fsz + 1))){
     printf("Error: Failed to allocate memory.");
     return 1;
   }
 
   read(fdin,buffer,fsz);
+  buffer[fsz] = '\0';
   
 
 


### PR DESCRIPTION
http://bugs.mariadb.com/show_bug.cgi?id=605

this fixes test errors I had where the output file had an extra "lugin-innodb-re" line at the end of the output file
