### PR TITLE
Hartmut warnings 2nd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,8 @@ configure_file(${CMAKE_SOURCE_DIR}/server/test/maxscale_test.h.in ${CMAKE_BINARY
 configure_file(${CMAKE_SOURCE_DIR}/etc/postinst.in ${CMAKE_BINARY_DIR}/postinst)
 configure_file(${CMAKE_SOURCE_DIR}/etc/postrm.in ${CMAKE_BINARY_DIR}/postrm)
 
-set(CMAKE_C_FLAGS "-Wall -fPIC")
-set(CMAKE_CXX_FLAGS "-Wall -fPIC")
+set(CMAKE_C_FLAGS "-Wall -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unused-function -fPIC")
+set(CMAKE_CXX_FLAGS "-Wall -Wno-unused-variable -Wno-unused-but-set-variable -fPIC")
 set(DEBUG_FLAGS "-ggdb -pthread -pipe -Wformat -fstack-protector --param=ssp-buffer-size=4")
 
 if(CMAKE_VERSION VERSION_GREATER 2.6)

--- a/log_manager/log_manager.cc
+++ b/log_manager/log_manager.cc
@@ -167,7 +167,7 @@ struct logfile_st {
         size_t           lf_file_size;
         /** list of block-sized log buffers */
         mlist_t          lf_blockbuf_list;
-        int              lf_buf_size;
+        size_t           lf_buf_size;
         bool             lf_flushflag;
 	bool		 lf_rotateflag;
 	int              lf_spinlock; /**< lf_flushflag & lf_rotateflag */
@@ -633,7 +633,7 @@ static int logmanager_write_log(
         int          err = 0;
         blockbuf_t*  bb;
         blockbuf_t*  bb_c;
-        int          timestamp_len;
+        size_t       timestamp_len;
         int          i;
 
         CHK_LOGMANAGER(lm);
@@ -680,9 +680,9 @@ static int logmanager_write_log(
         else
 	{
                 /** Length of string that will be written, limited by bufsize */
-                int safe_str_len; 
+                size_t safe_str_len; 
 		/** Length of session id */
-		int sesid_str_len;
+		size_t sesid_str_len;
 
 		/** 
 		 * 2 braces, 2 spaces and terminating char

--- a/query_classifier/query_classifier.cc
+++ b/query_classifier/query_classifier.cc
@@ -1253,7 +1253,7 @@ char* skygw_get_affected_fields(GWBUF* buf)
 			
 			List_iterator<Item> ilist(lex->current_select->item_list);
 			item = (Item*)ilist.next();
-			for (item; item != NULL; item=(Item*)ilist.next()) 
+			for (; item != NULL; item=(Item*)ilist.next()) 
 				{
 
 					itype = item->type();

--- a/server/core/gateway.c
+++ b/server/core/gateway.c
@@ -1039,6 +1039,7 @@ int main(int argc, char **argv)
         int 	 l;
         int	 i;
         int      n;
+	intptr_t thread_id;
         int      n_threads; /*< number of epoll listener threads */ 
         int      n_services;
         int      eno = 0;   /*< local variable for errno */
@@ -1788,9 +1789,9 @@ int main(int argc, char **argv)
         /*<
          * Start server threads.
          */
-        for (n = 0; n < n_threads - 1; n++)
+        for (thread_id = 0; thread_id < n_threads - 1; thread_id++)
         {
-                threads[n] = thread_start(poll_waitevents, (void *)(n + 1));
+                threads[thread_id] = thread_start(poll_waitevents, (void *)(thread_id + 1));
         }
         LOGIF(LM, (skygw_log_write(LOGFILE_MESSAGE,
                         "MaxScale started with %d server threads.",
@@ -1803,9 +1804,9 @@ int main(int argc, char **argv)
         /*<
          * Wait server threads' completion.
          */
-        for (n = 0; n < n_threads - 1; n++)
+        for (thread_id = 0; thread_id < n_threads - 1; thread_id++)
         {
-                thread_wait(threads[n]);
+                thread_wait(threads[thread_id]);
         }        
         /*<
          * Wait the flush thread.

--- a/server/core/maxkeys.c
+++ b/server/core/maxkeys.c
@@ -30,7 +30,7 @@
 #include	<stdio.h>
 #include	<secrets.h>
 
-main(int argc, char **argv)
+int main(int argc, char **argv)
 {
 	if (argc != 2)
 	{

--- a/server/core/memlog.c
+++ b/server/core/memlog.c
@@ -28,6 +28,7 @@
  * @endverbatim
  */
 #include <memlog.h>
+#include <stdlib.h>
 #include <stdio.h>
 
 static	MEMLOG		*memlogs = NULL;

--- a/server/core/memlog.c
+++ b/server/core/memlog.c
@@ -30,6 +30,7 @@
 #include <memlog.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 
 static	MEMLOG		*memlogs = NULL;
 static	SPINLOCK	*memlock = SPINLOCK_INIT;

--- a/server/core/memlog.c
+++ b/server/core/memlog.c
@@ -33,7 +33,7 @@
 #include <string.h>
 
 static	MEMLOG		*memlogs = NULL;
-static	SPINLOCK	*memlock = SPINLOCK_INIT;
+static	SPINLOCK	memlock = SPINLOCK_INIT;
 
 /**
  * Create a new instance of a memory logger.

--- a/server/core/modutil.c
+++ b/server/core/modutil.c
@@ -237,7 +237,7 @@ char *
 modutil_get_SQL(GWBUF *buf)
 {
 unsigned int	len, length;
-unsigned char	*ptr, *dptr, *rval = NULL;
+char	*ptr, *dptr, *rval = NULL;
 
 	if (!modutil_is_SQL(buf))
 		return rval;

--- a/server/core/poll.c
+++ b/server/core/poll.c
@@ -438,7 +438,7 @@ poll_waitevents(void *arg)
 {
 struct epoll_event events[MAX_EVENTS];
 int		   i, nfds, timeout_bias = 1;
-int		   thread_id = (int)arg;
+intptr_t	   thread_id = (intptr_t)arg;
 DCB                *zombies = NULL;
 int		   poll_spins = 0;
 

--- a/server/modules/filter/topfilter.c
+++ b/server/modules/filter/topfilter.c
@@ -488,8 +488,11 @@ char		*ptr;
 }
 
 static int
-cmp_topn(TOPNQ **a, TOPNQ **b)
+cmp_topn(const void *va, const void *vb)
 {
+        TOPNQ **a = (TOPNQ **)va;
+        TOPNQ **b = (TOPNQ **)vb;
+
 	if ((*b)->duration.tv_sec == (*a)->duration.tv_sec)
 		return (*b)->duration.tv_usec - (*a)->duration.tv_usec;
 	return (*b)->duration.tv_sec - (*a)->duration.tv_sec;


### PR DESCRIPTION
2nd try at fixing most warnings:

First of all there are a lot of "Unused Variable" and "Unused Function"
warnings. These are usually rather safe to ignore, so for now I'd add

  -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unused-function

to CFLAGS and CXXFLAGS. This already brings down the warning count to 28:

  https://github.com/hholzgra/MaxScale/commit/b4cb252f91d233c9262bb18acbdc1e65b035b9e8



Next there's one "Statement has no effect" warning in query_classifier.cc.
This can be fixed by either removing the first for() expression completely
or by folding the for() and the initialization statement on top of it into
a single line. I took the easier route for now:

  https://github.com/hholzgra/MaxScale/commit/792d4e9c8ca3be76f73836a958c5211105d893c6



Another easy one: the main() function in maxkeys.c is missing a return type:

  https://github.com/hholzgra/MaxScale/commit/a3a7aae1d2cb39b6d8436d4b4b389f21374ebea0



And another easy one: server/core/memlog.c is using malloc() without prototype.
Solution: include <stdlib.h>

  https://github.com/hholzgra/MaxScale/commit/c992b53750ba1e6e7a2bf0217a90891071986719

... and it is missing <string.h> for the prototype for strdup(), too

  https://github.com/hholzgra/MaxScale/commit/56ab0efbb3853c63369fdffa2586726e6c5e27e8



There's a mix of "size_t" and "int" variables used for string and buffer length
calculations in log_manager.cc, leading to a "comparison between signed and unsigned integer"
warning at some point. Consistently using "size_t" only fixes this and prevents potential
future problems:

  https://github.com/hholzgra/MaxScale/commit/216688338387dadf86f7c11ded6a73cb7c6fc6cd



In the topfilter there is a warning about "passing argument 4 of ‘qsort’ from incompatible 
pointer type". This is about the prototype of the custom comparison function which can be
fixed by taking pointer arguments as void* first and then casting them to the 'correct'
type inside the function. A rather cosmetic issue, but to make the compiler happy:

  https://github.com/hholzgra/MaxScale/commit/21613cb03d0b5a45cfba4f23bdf1a2b624cd0336



modutil_get_SQL() in modutil.c is defined as returning "char *" but internally uses
"unsigned char *" explicitly, leading to a "signed vs. unsigned" warning. Fixed by
dropping the "unsigned" in the internal variables declarations (alternative: 
change function prototype, that may lead to extra warnings at invocation points
though):

  https://github.com/hholzgra/MaxScale/commit/3ecf9260923848d74293e850ae8cf03da7e126d1


At several points casting thread IDs from "void *" to "int" causes "cast from pointer 
to integer of different size" warnings. There is a special type definition "intptr_t" 
that can be used instad of "int" to prevent this as it is always defined as the correct
integer type with the same bit size as a pointer:

  https://github.com/hholzgra/MaxScale/commit/617f44c9c98221648201b21745d4779b0a2bc78f


Now we're down to a bunch of warnings about SPINLOCK * vs ** use. All of these come
down to a wrong declaration in memlog.c: where in all other cases spinlocks are created as 

  static SPINLOCK variable_name = SPINLOCK_INIT;

we here see 

  static SPINLOCK *memlock = SPINLOCK_INIT;

That * is definitely wrong here, and I think all those other warnings have been hiding
a serious thing here (as already mentioned in my previous mail on compiler warnings
in october ...)

  https://github.com/hholzgra/MaxScale/commit/eedcd44e954a54f869467db318f347ea68d43e6c


After all this only one warning is left:

  server/core/memlog.c: In function ‘memlog_log’:
  server/core/memlog.c:136:41: warning: cast from pointer to integer of different size [-Wpointer-to-int-cast]
   ((int *)(log->values))[log->offset] = (int)value;
                                         ^
Here it's probably better to pass the 2nd argument to memlog_log()
as a union instead of a void*? Or use C++ and overloading?