### PR TITLE
Galera monitor improvement (MXS-95)

### DIFF
--- a/Documentation/Getting-Started/Configuration-Guide.md
+++ b/Documentation/Getting-Started/Configuration-Guide.md
@@ -435,6 +435,7 @@ backend_write_timeout=2
 
 # galeramon specific options
 disable_master_failback=0
+available_when_donor=0
 ```
 
 #### `module`
@@ -498,6 +499,12 @@ By default, if a node takes a lower index than the current master one the monito
 The server status field may have the `SERVER_MASTER_STICKINESS` bit, meaning the current master selection is not based on the available rules but it's the one previously selected and then kept, accordingly to option value equal 1.
 
 Anyway, a new master will be selected in case of current master failure, regardless the option value.
+
+#### `available_when_donor`
+
+This option if set to 1 will allow Galera monitor to keep a node in `Donor` status in the server pool if it is using any xtrabackup method for SST, e.g. `wsrep_sst_method` equal to `xtrabackup` or `xtrabackup-v2`.
+
+As xtrabackup is a non-locking SST method, a node in `Donor` status can still be considered in sync. This option is not enabled by default and should be used as the administrator's discretion.
 
 #### `backend_connect_timeout`
 

--- a/server/core/config.c
+++ b/server/core/config.c
@@ -42,6 +42,7 @@
  * 07/11/14	Massimiliano Pinto	Addition of monitor timeouts for connect/read/write
  * 20/02/15	Markus Mäkelä		Added connection_timeout parameter for services
  * 05/03/15	Massimiliano	Pinto	Added notification_feedback support
+ * 20/04/15	Guillaume Lefranc	Added available_when_donor parameter
  *
  * @endverbatim
  */
@@ -1893,6 +1894,7 @@ static char *monitor_params[] =
 		"backend_connect_timeout",
 		"backend_read_timeout",
 		"backend_write_timeout",
+		"available_when_donor",
                 NULL
         };
 /**

--- a/server/modules/monitor/mysqlmon.h
+++ b/server/modules/monitor/mysqlmon.h
@@ -35,6 +35,7 @@
  * 28/08/14	Massimiliano	Pinto	Addition of detectStaleMaster
  * 30/10/14	Massimiliano	Pinto	Addition of disableMasterFailback
  * 07/11/14	Massimiliano	Pinto	Addition of NetworkTimeout: connect, read, write
+ * 20/05/15	Guillaume Lefranc	Addition of availableWhenDonor
  *
  * @endverbatim
  */
@@ -68,6 +69,7 @@ typedef struct {
 	int	replicationHeartbeat;	/**< Monitor flag for MySQL replication heartbeat */
 	int	detectStaleMaster;	/**< Monitor flag for MySQL replication Stale Master detection */
 	int	disableMasterFailback;	/**< Monitor flag for Galera Cluster Master failback */
+	int	availableWhenDonor;	/**< Monitor flag for Galera Cluster Donor availability */
 	MONITOR_SERVERS *master;	/**< Master server for MySQL Master/Slave replication */
 	MONITOR_SERVERS	*databases;     /**< Linked list of servers to monitor */
 	int	connect_timeout;	/**< Connect timeout in seconds for mysql_real_connect */


### PR DESCRIPTION
**MXS-95: Add support for Galera xtrabackup donor availability**

A Galera node can now be recognized as Synced by the monitor if it's using xtrabackup or xtrabackup-v2 as SST method. For backwards compatibility, I have added a configuration option:
`available_when_donor` = `0 (default) | 1 (as described)`
