### PR TITLE
CentOS 7 systemd service file fixes

### DIFF
--- a/etc/maxscale.service.in
+++ b/etc/maxscale.service.in
@@ -9,7 +9,7 @@ PIDFile=@MAXSCALE_VARDIR@/run/maxscale/maxscale.pid
 ExecStartPre=-/usr/bin/mkdir @MAXSCALE_VARDIR@/run/maxscale
 ExecStartPre=/usr/bin/chown -R maxscale:maxscale @MAXSCALE_VARDIR@/run/maxscale
 ExecStart=@CMAKE_INSTALL_PREFIX@/@MAXSCALE_BINDIR@/maxscale --user=maxscale
-LimitNOFILE=4096
+LimitNOFILE=65535
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/maxscale.service.in
+++ b/etc/maxscale.service.in
@@ -6,8 +6,7 @@ After=network.target
 Type=forking
 Restart=on-failure
 PIDFile=@MAXSCALE_VARDIR@/run/maxscale/maxscale.pid
-ExecStartPre=-/usr/bin/mkdir @MAXSCALE_VARDIR@/run/maxscale
-ExecStartPre=/usr/bin/chown -R maxscale:maxscale @MAXSCALE_VARDIR@/run/maxscale
+ExecStartPre=/usr/bin/install -d @MAXSCALE_VARDIR@/run/maxscale -o maxscale -g maxscale
 ExecStart=@CMAKE_INSTALL_PREFIX@/@MAXSCALE_BINDIR@/maxscale --user=maxscale
 LimitNOFILE=65535
 

--- a/etc/maxscale.service.in
+++ b/etc/maxscale.service.in
@@ -9,6 +9,7 @@ PIDFile=@MAXSCALE_VARDIR@/run/maxscale/maxscale.pid
 ExecStartPre=-/usr/bin/mkdir @MAXSCALE_VARDIR@/run/maxscale
 ExecStartPre=/usr/bin/chown -R maxscale:maxscale @MAXSCALE_VARDIR@/run/maxscale
 ExecStart=@CMAKE_INSTALL_PREFIX@/@MAXSCALE_BINDIR@/maxscale --user=maxscale
+LimitNOFILE=4096
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/maxscale.service.in
+++ b/etc/maxscale.service.in
@@ -6,6 +6,8 @@ After=network.target
 Type=forking
 Restart=on-failure
 PIDFile=@MAXSCALE_VARDIR@/run/maxscale/maxscale.pid
+ExecStartPre=-/usr/bin/mkdir @MAXSCALE_VARDIR@/run/maxscale
+ExecStartPre=/usr/bin/chown -R maxscale:maxscale @MAXSCALE_VARDIR@/run/maxscale
 ExecStart=@CMAKE_INSTALL_PREFIX@/@MAXSCALE_BINDIR@/maxscale --user=maxscale
 
 [Install]


### PR DESCRIPTION
This PR includes small changes in the systemd service file in order to make the systemd PID integration work.
/var/run (or /run) is a temporary filesystem in CentOS 7, so directories will be wiped out on server reboot. Either /run must be used as basedir or the directory must be created by the service itself. I have taken the latter approach.
Also this PR includes a modification to the limit of open files in the service file, as we found out that this caused service failure for some users.