### PR TITLE
Create PID dir on initialization

### DIFF
--- a/etc/init.d/maxscale.in
+++ b/etc/init.d/maxscale.in
@@ -37,6 +37,9 @@ _RETVAL_NOT_RUNNING=7
 _RETVAL_STATUS_OK=0
 _RETVAL_STATUS_NOT_RUNNING=3
 
+# Create PID directory if not exists
+/usr/bin/install -o maxscale -g maxscale @MAXSCALE_VARDIR@/run/maxscale
+
 # Sanity checks.
 [ -x @CMAKE_INSTALL_PREFIX@/@MAXSCALE_BINDIR@/maxscale ] || exit $_RETVAL_NOT_INSTALLED
 


### PR DESCRIPTION
Fix for MXS-184 when PID dir is wiped out on reboot.