### PR TITLE
Update Hint-Syntax.md

### DIFF
--- a/Documentation/Reference/Hint-Syntax.md
+++ b/Documentation/Reference/Hint-Syntax.md
@@ -14,7 +14,7 @@ router_options=master
 servers=server1
 user=maxuser
 passwd=maxpwd
-filter=Hint
+filters=Hint
 
 [Hint]
 type=filter


### PR DESCRIPTION
Added "s" to filters in example [Read Service] as it was confusing trying to get hint routing working correctly.