### PR TITLE
Save time when domain name contains wildcard '%'

### DIFF
--- a/server/core/gw_utils.c
+++ b/server/core/gw_utils.c
@@ -61,6 +61,12 @@ setipaddress(struct in_addr *a, char *p)
 
     hint.ai_socktype = SOCK_STREAM;
 
+    if (strchr(p, '%') != NULL)
+    {
+        MXS_INFO("Host %s contains wildcard, return", p);
+        return 0;
+    }
+
     /*
      * This is for the listening socket, matching INADDR_ANY only for now.
      * For future specific addresses bind, a dedicated routine woulbd be better


### PR DESCRIPTION
This pull request is to saving time when MySQL user's domain name contains wildcard '%'.

I encounter an issue when using maxscale as binlog server. There are many users with wildcard domain name in my MySQL, so maxscale spent 5 minutes plus to get ip address of wildcard domain name at startup. As I know maxscale does not support wildcard hosts currently, so I add this patch to saving time for wildcard hosts.