### PR TITLE
Properly set STATUS when maxscale_wait_stop fails to stop Maxscale in ubuntu init script

### DIFF
--- a/etc/ubuntu/init.d/maxscale.in
+++ b/etc/ubuntu/init.d/maxscale.in
@@ -124,8 +124,8 @@ maxscale_wait_stop() {
                 local i=0
                 while kill -0 "${PIDTMP:-}" 2> /dev/null;  do
                         if [ $i = '60' ]; then
-                                break
                                 STATUS=2
+                                break
                         fi
                         [ "$VERBOSE" != no ] && log_progress_msg "."
                         sleep 1


### PR DESCRIPTION
`STATUS` was being set after a `break` statement, and was unreachable code. 