### PR TITLE
Zendesk's Maxwell Compatibility

### DIFF
--- a/server/modules/routing/binlogrouter/blr.h
+++ b/server/modules/routing/binlogrouter/blr.h
@@ -496,6 +496,7 @@ typedef struct
     GWBUF           *mariadb10;         /*< set @mariadb_slave_capability */
     GWBUF           *server_vars;       /*< MySQL Connector master server variables */
     GWBUF           *results_charset;   /*< SET character_set_results = NULL */
+    GWBUF           *sql_mode;          /*< SET sql_mode='...' */
     uint8_t         *fde_event;         /*< Format Description Event */
     int             fde_len;            /*< Length of fde_event */
 } MASTER_RESPONSES;
@@ -667,20 +668,21 @@ typedef struct binlog_encryption_ctx
 #define BLRM_LATIN1             0x000D
 #define BLRM_UTF8               0x000E
 #define BLRM_RESULTS_CHARSET    0x000F
-#define BLRM_SELECT1            0x0010
-#define BLRM_SELECTVER          0x0011
-#define BLRM_SELECTVERCOM       0x0012
-#define BLRM_SELECTHOSTNAME     0x0013
-#define BLRM_MAP                0x0014
-#define BLRM_SERVER_VARS        0x0015
-#define BLRM_REGISTER           0x0016
-#define BLRM_CHECK_SEMISYNC     0x0017
-#define BLRM_REQUEST_SEMISYNC   0x0018
-#define BLRM_REQUEST_BINLOGDUMP 0x0019
-#define BLRM_BINLOGDUMP         0x001A
-#define BLRM_SLAVE_STOPPED      0x001B
+#define BLRM_SQL_MODE           0x0010
+#define BLRM_SELECT1            0x0011
+#define BLRM_SELECTVER          0x0012
+#define BLRM_SELECTVERCOM       0x0013
+#define BLRM_SELECTHOSTNAME     0x0014
+#define BLRM_MAP                0x0015
+#define BLRM_SERVER_VARS        0x0016
+#define BLRM_REGISTER           0x0017
+#define BLRM_CHECK_SEMISYNC     0x0018
+#define BLRM_REQUEST_SEMISYNC   0x0019
+#define BLRM_REQUEST_BINLOGDUMP 0x001a
+#define BLRM_BINLOGDUMP         0x001B
+#define BLRM_SLAVE_STOPPED      0x001C
 
-#define BLRM_MAXSTATE           0x001B
+#define BLRM_MAXSTATE           0x001C
 
 static char *blrm_states[] =
 {
@@ -700,6 +702,7 @@ static char *blrm_states[] =
     "Set Names latin1",
     "Set Names utf8",
     "Set results charset null",
+    "Set sql_mode",
     "select 1",
     "select version()",
     "select @@version_comment",

--- a/server/modules/routing/binlogrouter/blr.h
+++ b/server/modules/routing/binlogrouter/blr.h
@@ -494,6 +494,7 @@ typedef struct
     GWBUF           *selecthostname;/*< select @@hostname */
     GWBUF           *map;           /*< select @@max_allowed_packet */
     GWBUF           *mariadb10;     /*< set @mariadb_slave_capability */
+    GWBUF           *server_vars;   /*< MySQL Connector master server variables */
     uint8_t         *fde_event;     /*< Format Description Event */
     int             fde_len;        /*< Length of fde_event */
 } MASTER_RESPONSES;
@@ -669,14 +670,15 @@ typedef struct binlog_encryption_ctx
 #define BLRM_SELECTVERCOM       0x0011
 #define BLRM_SELECTHOSTNAME     0x0012
 #define BLRM_MAP                0x0013
-#define BLRM_REGISTER           0x0014
-#define BLRM_CHECK_SEMISYNC     0x0015
-#define BLRM_REQUEST_SEMISYNC   0x0016
-#define BLRM_REQUEST_BINLOGDUMP 0x0017
-#define BLRM_BINLOGDUMP         0x0018
-#define BLRM_SLAVE_STOPPED      0x0019
+#define BLRM_SERVER_VARS        0x0014
+#define BLRM_REGISTER           0x0015
+#define BLRM_CHECK_SEMISYNC     0x0016
+#define BLRM_REQUEST_SEMISYNC   0x0017
+#define BLRM_REQUEST_BINLOGDUMP 0x0018
+#define BLRM_BINLOGDUMP         0x0019
+#define BLRM_SLAVE_STOPPED      0x001A
 
-#define BLRM_MAXSTATE           0x0019
+#define BLRM_MAXSTATE           0x001A
 
 static char *blrm_states[] =
 {
@@ -685,7 +687,7 @@ static char *blrm_states[] =
     "binlog checksum rerieval", "Set MariaDB slave capability", "GTID Mode retrieval",
     "Master UUID retrieval", "Set Slave UUID", "Set Names latin1", "Set Names utf8", "select 1",
     "select version()", "select @@version_comment", "select @@hostname",
-    "select @@max_allowed_packet", "Register slave", "Semi-Sync Support retrivial",
+    "select @@max_allowed_packet", "Query server variables", "Register slave", "Semi-Sync Support retrivial",
     "Request Semi-Sync Replication", "Request Binlog Dump", "Binlog Dump", "Slave stopped"
 };
 

--- a/server/modules/routing/binlogrouter/blr.h
+++ b/server/modules/routing/binlogrouter/blr.h
@@ -479,24 +479,25 @@ typedef struct
  */
 typedef struct
 {
-    GWBUF           *server_id;     /*< Master server id */
-    GWBUF           *heartbeat;     /*< Heartbeat period */
-    GWBUF           *chksum1;       /*< Binlog checksum 1st response */
-    GWBUF           *chksum2;       /*< Binlog checksum 2nd response */
-    GWBUF           *gtid_mode;     /*< GTID Mode response */
-    GWBUF           *uuid;          /*< Master UUID */
-    GWBUF           *setslaveuuid;  /*< Set Slave UUID */
-    GWBUF           *setnames;      /*< Set NAMES latin1 */
-    GWBUF           *utf8;          /*< Set NAMES utf8 */
-    GWBUF           *select1;       /*< select 1 */
-    GWBUF           *selectver;     /*< select version() */
-    GWBUF           *selectvercom;  /*< select @@version_comment */
-    GWBUF           *selecthostname;/*< select @@hostname */
-    GWBUF           *map;           /*< select @@max_allowed_packet */
-    GWBUF           *mariadb10;     /*< set @mariadb_slave_capability */
-    GWBUF           *server_vars;   /*< MySQL Connector master server variables */
-    uint8_t         *fde_event;     /*< Format Description Event */
-    int             fde_len;        /*< Length of fde_event */
+    GWBUF           *server_id;         /*< Master server id */
+    GWBUF           *heartbeat;         /*< Heartbeat period */
+    GWBUF           *chksum1;           /*< Binlog checksum 1st response */
+    GWBUF           *chksum2;           /*< Binlog checksum 2nd response */
+    GWBUF           *gtid_mode;         /*< GTID Mode response */
+    GWBUF           *uuid;              /*< Master UUID */
+    GWBUF           *setslaveuuid;      /*< Set Slave UUID */
+    GWBUF           *setnames;          /*< Set NAMES latin1 */
+    GWBUF           *utf8;              /*< Set NAMES utf8 */
+    GWBUF           *select1;           /*< select 1 */
+    GWBUF           *selectver;         /*< select version() */
+    GWBUF           *selectvercom;      /*< select @@version_comment */
+    GWBUF           *selecthostname;    /*< select @@hostname */
+    GWBUF           *map;               /*< select @@max_allowed_packet */
+    GWBUF           *mariadb10;         /*< set @mariadb_slave_capability */
+    GWBUF           *server_vars;       /*< MySQL Connector master server variables */
+    GWBUF           *results_charset;   /*< SET character_set_results = NULL */
+    uint8_t         *fde_event;         /*< Format Description Event */
+    int             fde_len;            /*< Length of fde_event */
 } MASTER_RESPONSES;
 
 /**
@@ -665,30 +666,52 @@ typedef struct binlog_encryption_ctx
 #define BLRM_SUUID              0x000C
 #define BLRM_LATIN1             0x000D
 #define BLRM_UTF8               0x000E
-#define BLRM_SELECT1            0x000F
-#define BLRM_SELECTVER          0x0010
-#define BLRM_SELECTVERCOM       0x0011
-#define BLRM_SELECTHOSTNAME     0x0012
-#define BLRM_MAP                0x0013
-#define BLRM_SERVER_VARS        0x0014
-#define BLRM_REGISTER           0x0015
-#define BLRM_CHECK_SEMISYNC     0x0016
-#define BLRM_REQUEST_SEMISYNC   0x0017
-#define BLRM_REQUEST_BINLOGDUMP 0x0018
-#define BLRM_BINLOGDUMP         0x0019
-#define BLRM_SLAVE_STOPPED      0x001A
+#define BLRM_RESULTS_CHARSET    0x000F
+#define BLRM_SELECT1            0x0010
+#define BLRM_SELECTVER          0x0011
+#define BLRM_SELECTVERCOM       0x0012
+#define BLRM_SELECTHOSTNAME     0x0013
+#define BLRM_MAP                0x0014
+#define BLRM_SERVER_VARS        0x0015
+#define BLRM_REGISTER           0x0016
+#define BLRM_CHECK_SEMISYNC     0x0017
+#define BLRM_REQUEST_SEMISYNC   0x0018
+#define BLRM_REQUEST_BINLOGDUMP 0x0019
+#define BLRM_BINLOGDUMP         0x001A
+#define BLRM_SLAVE_STOPPED      0x001B
 
-#define BLRM_MAXSTATE           0x001A
+#define BLRM_MAXSTATE           0x001B
 
 static char *blrm_states[] =
 {
-    "Unconfigured", "Unconnected", "Connecting", "Authenticated", "Timestamp retrieval",
-    "Server ID retrieval", "HeartBeat Period setup", "binlog checksum config",
-    "binlog checksum rerieval", "Set MariaDB slave capability", "GTID Mode retrieval",
-    "Master UUID retrieval", "Set Slave UUID", "Set Names latin1", "Set Names utf8", "select 1",
-    "select version()", "select @@version_comment", "select @@hostname",
-    "select @@max_allowed_packet", "Query server variables", "Register slave", "Semi-Sync Support retrivial",
-    "Request Semi-Sync Replication", "Request Binlog Dump", "Binlog Dump", "Slave stopped"
+    "Unconfigured",
+    "Unconnected",
+    "Connecting",
+    "Authenticated",
+    "Timestamp retrieval",
+    "Server ID retrieval",
+    "HeartBeat Period setup",
+    "binlog checksum config",
+    "binlog checksum rerieval",
+    "Set MariaDB slave capability",
+    "GTID Mode retrieval",
+    "Master UUID retrieval",
+    "Set Slave UUID",
+    "Set Names latin1",
+    "Set Names utf8",
+    "Set results charset null",
+    "select 1",
+    "select version()",
+    "select @@version_comment",
+    "select @@hostname",
+    "select @@max_allowed_packet",
+    "Query server variables",
+    "Register slave",
+    "Semi-Sync Support retrivial",
+    "Request Semi-Sync Replication",
+    "Request Binlog Dump",
+    "Binlog Dump",
+    "Slave stopped"
 };
 
 #define BLRS_CREATED            0x0000

--- a/server/modules/routing/binlogrouter/blr.h
+++ b/server/modules/routing/binlogrouter/blr.h
@@ -501,6 +501,7 @@ typedef struct
     GWBUF           *binlog_format;     /*< SHOW VARIABLES LIKE 'binlog_format' */
     GWBUF           *binlog_row_image;  /*< SHOW VARIABLES LIKE 'binlog_row_image' */
     GWBUF           *lower_case_tables; /*< select @@lower_case_table_names */
+    GWBUF           *binlog_checksum;   /*< select @@binlog_checksum */
     uint8_t         *fde_event;         /*< Format Description Event */
     int             fde_len;            /*< Length of fde_event */
 } MASTER_RESPONSES;
@@ -683,14 +684,15 @@ typedef struct binlog_encryption_ctx
 #define BLRM_BINLOG_FORMAT      0x0018
 #define BLRM_BINLOG_ROW_IMAGE   0x0019
 #define BLRM_LOWER_CASE_TABLES  0x001A
-#define BLRM_REGISTER           0x001B
-#define BLRM_CHECK_SEMISYNC     0x001C
-#define BLRM_REQUEST_SEMISYNC   0x001D
-#define BLRM_REQUEST_BINLOGDUMP 0x001E
-#define BLRM_BINLOGDUMP         0x001F
-#define BLRM_SLAVE_STOPPED      0x0020
+#define BLRM_BINLOG_CHECKSUM    0x001B
+#define BLRM_REGISTER           0x001C
+#define BLRM_CHECK_SEMISYNC     0x001D
+#define BLRM_REQUEST_SEMISYNC   0x001E
+#define BLRM_REQUEST_BINLOGDUMP 0x001F
+#define BLRM_BINLOGDUMP         0x0020
+#define BLRM_SLAVE_STOPPED      0x0021
 
-#define BLRM_MAXSTATE           0x0020
+#define BLRM_MAXSTATE           0x0021
 
 static char *blrm_states[] =
 {
@@ -721,6 +723,7 @@ static char *blrm_states[] =
     "Query binlog_format variable",
     "Query binlog_row_image variable",
     "Query @@lower_case_table_names",
+    "Query @@global.binlog_checksum",
     "Register slave",
     "Semi-Sync Support retrivial",
     "Request Semi-Sync Replication",

--- a/server/modules/routing/binlogrouter/blr.h
+++ b/server/modules/routing/binlogrouter/blr.h
@@ -498,6 +498,8 @@ typedef struct
     GWBUF           *results_charset;   /*< SET character_set_results = NULL */
     GWBUF           *sql_mode;          /*< SET sql_mode='...' */
     GWBUF           *log_bin;           /*< SHOW VARIABLES LIKE 'log_bin' */
+    GWBUF           *binlog_format;     /*< SHOW VARIABLES LIKE 'binlog_format' */
+    GWBUF           *binlog_row_image;  /*< SHOW VARIABLES LIKE 'binlog_row_image' */
     uint8_t         *fde_event;         /*< Format Description Event */
     int             fde_len;            /*< Length of fde_event */
 } MASTER_RESPONSES;
@@ -677,14 +679,16 @@ typedef struct binlog_encryption_ctx
 #define BLRM_MAP                0x0015
 #define BLRM_SERVER_VARS        0x0016
 #define BLRM_LOG_BIN            0x0017
-#define BLRM_REGISTER           0x0018
-#define BLRM_CHECK_SEMISYNC     0x0019
-#define BLRM_REQUEST_SEMISYNC   0x001A
-#define BLRM_REQUEST_BINLOGDUMP 0x001B
-#define BLRM_BINLOGDUMP         0x001C
-#define BLRM_SLAVE_STOPPED      0x001D
+#define BLRM_BINLOG_FORMAT      0x0018
+#define BLRM_BINLOG_ROW_IMAGE   0x0019
+#define BLRM_REGISTER           0x001A
+#define BLRM_CHECK_SEMISYNC     0x001B
+#define BLRM_REQUEST_SEMISYNC   0x001C
+#define BLRM_REQUEST_BINLOGDUMP 0x001D
+#define BLRM_BINLOGDUMP         0x001E
+#define BLRM_SLAVE_STOPPED      0x001F
 
-#define BLRM_MAXSTATE           0x001D
+#define BLRM_MAXSTATE           0x001F
 
 static char *blrm_states[] =
 {
@@ -712,6 +716,8 @@ static char *blrm_states[] =
     "select @@max_allowed_packet",
     "Query server variables",
     "Query log_bin variable",
+    "Query binlog_format variable",
+    "Query binlog_row_image variable",
     "Register slave",
     "Semi-Sync Support retrivial",
     "Request Semi-Sync Replication",

--- a/server/modules/routing/binlogrouter/blr.h
+++ b/server/modules/routing/binlogrouter/blr.h
@@ -497,6 +497,7 @@ typedef struct
     GWBUF           *server_vars;       /*< MySQL Connector master server variables */
     GWBUF           *results_charset;   /*< SET character_set_results = NULL */
     GWBUF           *sql_mode;          /*< SET sql_mode='...' */
+    GWBUF           *log_bin;           /*< SHOW VARIABLES LIKE 'log_bin' */
     uint8_t         *fde_event;         /*< Format Description Event */
     int             fde_len;            /*< Length of fde_event */
 } MASTER_RESPONSES;
@@ -675,14 +676,15 @@ typedef struct binlog_encryption_ctx
 #define BLRM_SELECTHOSTNAME     0x0014
 #define BLRM_MAP                0x0015
 #define BLRM_SERVER_VARS        0x0016
-#define BLRM_REGISTER           0x0017
-#define BLRM_CHECK_SEMISYNC     0x0018
-#define BLRM_REQUEST_SEMISYNC   0x0019
-#define BLRM_REQUEST_BINLOGDUMP 0x001a
-#define BLRM_BINLOGDUMP         0x001B
-#define BLRM_SLAVE_STOPPED      0x001C
+#define BLRM_LOG_BIN            0x0017
+#define BLRM_REGISTER           0x0018
+#define BLRM_CHECK_SEMISYNC     0x0019
+#define BLRM_REQUEST_SEMISYNC   0x001A
+#define BLRM_REQUEST_BINLOGDUMP 0x001B
+#define BLRM_BINLOGDUMP         0x001C
+#define BLRM_SLAVE_STOPPED      0x001D
 
-#define BLRM_MAXSTATE           0x001C
+#define BLRM_MAXSTATE           0x001D
 
 static char *blrm_states[] =
 {
@@ -709,6 +711,7 @@ static char *blrm_states[] =
     "select @@hostname",
     "select @@max_allowed_packet",
     "Query server variables",
+    "Query log_bin variable",
     "Register slave",
     "Semi-Sync Support retrivial",
     "Request Semi-Sync Replication",

--- a/server/modules/routing/binlogrouter/blr.h
+++ b/server/modules/routing/binlogrouter/blr.h
@@ -500,6 +500,7 @@ typedef struct
     GWBUF           *log_bin;           /*< SHOW VARIABLES LIKE 'log_bin' */
     GWBUF           *binlog_format;     /*< SHOW VARIABLES LIKE 'binlog_format' */
     GWBUF           *binlog_row_image;  /*< SHOW VARIABLES LIKE 'binlog_row_image' */
+    GWBUF           *lower_case_tables; /*< select @@lower_case_table_names */
     uint8_t         *fde_event;         /*< Format Description Event */
     int             fde_len;            /*< Length of fde_event */
 } MASTER_RESPONSES;
@@ -681,14 +682,15 @@ typedef struct binlog_encryption_ctx
 #define BLRM_LOG_BIN            0x0017
 #define BLRM_BINLOG_FORMAT      0x0018
 #define BLRM_BINLOG_ROW_IMAGE   0x0019
-#define BLRM_REGISTER           0x001A
-#define BLRM_CHECK_SEMISYNC     0x001B
-#define BLRM_REQUEST_SEMISYNC   0x001C
-#define BLRM_REQUEST_BINLOGDUMP 0x001D
-#define BLRM_BINLOGDUMP         0x001E
-#define BLRM_SLAVE_STOPPED      0x001F
+#define BLRM_LOWER_CASE_TABLES  0x001A
+#define BLRM_REGISTER           0x001B
+#define BLRM_CHECK_SEMISYNC     0x001C
+#define BLRM_REQUEST_SEMISYNC   0x001D
+#define BLRM_REQUEST_BINLOGDUMP 0x001E
+#define BLRM_BINLOGDUMP         0x001F
+#define BLRM_SLAVE_STOPPED      0x0020
 
-#define BLRM_MAXSTATE           0x001F
+#define BLRM_MAXSTATE           0x0020
 
 static char *blrm_states[] =
 {
@@ -718,6 +720,7 @@ static char *blrm_states[] =
     "Query log_bin variable",
     "Query binlog_format variable",
     "Query binlog_row_image variable",
+    "Query @@lower_case_table_names",
     "Register slave",
     "Semi-Sync Support retrivial",
     "Request Semi-Sync Replication",

--- a/server/modules/routing/binlogrouter/blr_file.c
+++ b/server/modules/routing/binlogrouter/blr_file.c
@@ -2301,6 +2301,8 @@ blr_cache_read_master_data(ROUTER_INSTANCE *router)
     router->saved_master.results_charset = blr_cache_read_response(router, "results_charset");
     router->saved_master.sql_mode = blr_cache_read_response(router, "sql_mode");
     router->saved_master.log_bin = blr_cache_read_response(router, "log_bin");
+    router->saved_master.binlog_format = blr_cache_read_response(router, "binlog_format");
+    router->saved_master.binlog_row_image = blr_cache_read_response(router, "binlog_row_image");
 }
 
 /**

--- a/server/modules/routing/binlogrouter/blr_file.c
+++ b/server/modules/routing/binlogrouter/blr_file.c
@@ -2303,6 +2303,7 @@ blr_cache_read_master_data(ROUTER_INSTANCE *router)
     router->saved_master.log_bin = blr_cache_read_response(router, "log_bin");
     router->saved_master.binlog_format = blr_cache_read_response(router, "binlog_format");
     router->saved_master.binlog_row_image = blr_cache_read_response(router, "binlog_row_image");
+    router->saved_master.lower_case_tables = blr_cache_read_response(router, "lower_case_tables");
 }
 
 /**

--- a/server/modules/routing/binlogrouter/blr_file.c
+++ b/server/modules/routing/binlogrouter/blr_file.c
@@ -2300,6 +2300,7 @@ blr_cache_read_master_data(ROUTER_INSTANCE *router)
     router->saved_master.server_vars = blr_cache_read_response(router, "server_vars");
     router->saved_master.results_charset = blr_cache_read_response(router, "results_charset");
     router->saved_master.sql_mode = blr_cache_read_response(router, "sql_mode");
+    router->saved_master.log_bin = blr_cache_read_response(router, "log_bin");
 }
 
 /**

--- a/server/modules/routing/binlogrouter/blr_file.c
+++ b/server/modules/routing/binlogrouter/blr_file.c
@@ -2297,6 +2297,7 @@ blr_cache_read_master_data(ROUTER_INSTANCE *router)
     router->saved_master.selecthostname = blr_cache_read_response(router, "selecthostname");
     router->saved_master.map = blr_cache_read_response(router, "map");
     router->saved_master.mariadb10 = blr_cache_read_response(router, "mariadb10");
+    router->saved_master.server_vars = blr_cache_read_response(router, "server_vars");
 }
 
 /**

--- a/server/modules/routing/binlogrouter/blr_file.c
+++ b/server/modules/routing/binlogrouter/blr_file.c
@@ -2304,6 +2304,7 @@ blr_cache_read_master_data(ROUTER_INSTANCE *router)
     router->saved_master.binlog_format = blr_cache_read_response(router, "binlog_format");
     router->saved_master.binlog_row_image = blr_cache_read_response(router, "binlog_row_image");
     router->saved_master.lower_case_tables = blr_cache_read_response(router, "lower_case_tables");
+    router->saved_master.binlog_checksum = blr_cache_read_response(router, "binlog_checksum");
 }
 
 /**

--- a/server/modules/routing/binlogrouter/blr_file.c
+++ b/server/modules/routing/binlogrouter/blr_file.c
@@ -2298,6 +2298,7 @@ blr_cache_read_master_data(ROUTER_INSTANCE *router)
     router->saved_master.map = blr_cache_read_response(router, "map");
     router->saved_master.mariadb10 = blr_cache_read_response(router, "mariadb10");
     router->saved_master.server_vars = blr_cache_read_response(router, "server_vars");
+    router->saved_master.server_vars = blr_cache_read_response(router, "results_charset");
 }
 
 /**

--- a/server/modules/routing/binlogrouter/blr_file.c
+++ b/server/modules/routing/binlogrouter/blr_file.c
@@ -2298,7 +2298,8 @@ blr_cache_read_master_data(ROUTER_INSTANCE *router)
     router->saved_master.map = blr_cache_read_response(router, "map");
     router->saved_master.mariadb10 = blr_cache_read_response(router, "mariadb10");
     router->saved_master.server_vars = blr_cache_read_response(router, "server_vars");
-    router->saved_master.server_vars = blr_cache_read_response(router, "results_charset");
+    router->saved_master.results_charset = blr_cache_read_response(router, "results_charset");
+    router->saved_master.sql_mode = blr_cache_read_response(router, "sql_mode");
 }
 
 /**

--- a/server/modules/routing/binlogrouter/blr_master.c
+++ b/server/modules/routing/binlogrouter/blr_master.c
@@ -735,6 +735,18 @@ blr_master_response(ROUTER_INSTANCE *router, GWBUF *buf)
         router->saved_master.server_vars = buf;
         blr_cache_response(router, "server_vars", buf);
 
+        buf = blr_make_query(router->master, "SHOW VARIABLES LIKE 'log_bin'");
+        router->master_state = BLRM_LOG_BIN;
+        router->master->func.write(router->master, buf);
+        break;
+    case BLRM_LOG_BIN:
+        if (router->saved_master.log_bin)
+        {
+            GWBUF_CONSUME_ALL(router->saved_master.log_bin);
+        }
+        router->saved_master.log_bin = buf;
+        blr_cache_response(router, "log_bin", buf);
+
         buf = blr_make_registration(router);
         router->master_state = BLRM_REGISTER;
         router->master->func.write(router->master, buf);

--- a/server/modules/routing/binlogrouter/blr_master.c
+++ b/server/modules/routing/binlogrouter/blr_master.c
@@ -747,6 +747,30 @@ blr_master_response(ROUTER_INSTANCE *router, GWBUF *buf)
         router->saved_master.log_bin = buf;
         blr_cache_response(router, "log_bin", buf);
 
+        buf = blr_make_query(router->master, "SHOW VARIABLES LIKE 'binlog_format'");
+        router->master_state = BLRM_BINLOG_FORMAT;
+        router->master->func.write(router->master, buf);
+        break;
+    case BLRM_BINLOG_FORMAT:
+        if (router->saved_master.binlog_format)
+        {
+            GWBUF_CONSUME_ALL(router->saved_master.binlog_format);
+        }
+        router->saved_master.binlog_format = buf;
+        blr_cache_response(router, "binlog_format", buf);
+
+        buf = blr_make_query(router->master, "SHOW VARIABLES LIKE 'binlog_row_image'");
+        router->master_state = BLRM_BINLOG_ROW_IMAGE;
+        router->master->func.write(router->master, buf);
+        break;
+    case BLRM_BINLOG_ROW_IMAGE:
+        if (router->saved_master.binlog_row_image)
+        {
+            GWBUF_CONSUME_ALL(router->saved_master.binlog_row_image);
+        }
+        router->saved_master.binlog_row_image = buf;
+        blr_cache_response(router, "binlog_row_image", buf);
+
         buf = blr_make_registration(router);
         router->master_state = BLRM_REGISTER;
         router->master->func.write(router->master, buf);

--- a/server/modules/routing/binlogrouter/blr_master.c
+++ b/server/modules/routing/binlogrouter/blr_master.c
@@ -635,6 +635,20 @@ blr_master_response(ROUTER_INSTANCE *router, GWBUF *buf)
         }
         router->saved_master.utf8 = buf;
         blr_cache_response(router, "utf8", buf);
+
+        buf = blr_make_query(router->master, "SET character_set_results = NULL");
+        router->master_state = BLRM_RESULTS_CHARSET;
+        router->master->func.write(router->master, buf);
+        break;
+    case BLRM_RESULTS_CHARSET:
+        // Response to  "SET character_set_results = NULL" query
+        if (router->saved_master.results_charset)
+        {
+            GWBUF_CONSUME_ALL(router->saved_master.results_charset);
+        }
+        router->saved_master.results_charset = buf;
+        blr_cache_response(router, "results_charset", buf);
+
         buf = blr_make_query(router->master, "SELECT 1");
         router->master_state = BLRM_SELECT1;
         router->master->func.write(router->master, buf);

--- a/server/modules/routing/binlogrouter/blr_master.c
+++ b/server/modules/routing/binlogrouter/blr_master.c
@@ -771,6 +771,18 @@ blr_master_response(ROUTER_INSTANCE *router, GWBUF *buf)
         router->saved_master.binlog_row_image = buf;
         blr_cache_response(router, "binlog_row_image", buf);
 
+        buf = blr_make_query(router->master, "select @@lower_case_table_names");
+        router->master_state = BLRM_LOWER_CASE_TABLES;
+        router->master->func.write(router->master, buf);
+        break;
+    case BLRM_LOWER_CASE_TABLES:
+        if (router->saved_master.lower_case_tables)
+        {
+            GWBUF_CONSUME_ALL(router->saved_master.lower_case_tables);
+        }
+        router->saved_master.lower_case_tables = buf;
+        blr_cache_response(router, "lower_case_tables", buf);
+
         buf = blr_make_registration(router);
         router->master_state = BLRM_REGISTER;
         router->master->func.write(router->master, buf);

--- a/server/modules/routing/binlogrouter/blr_master.c
+++ b/server/modules/routing/binlogrouter/blr_master.c
@@ -695,6 +695,20 @@ blr_master_response(ROUTER_INSTANCE *router, GWBUF *buf)
         }
         router->saved_master.map = buf;
         blr_cache_response(router, "map", buf);
+
+        // Query for Server Variables
+        buf = blr_make_query(router->master, "SELECT  @@session.auto_increment_increment AS auto_increment_increment, @@character_set_client AS character_set_client, @@character_set_connection AS character_set_connection, @@character_set_results AS character_set_results, @@character_set_server AS character_set_server, @@init_connect AS init_connect, @@interactive_timeout AS interactive_timeout, @@license AS license, @@lower_case_table_names AS lower_case_table_names, @@max_allowed_packet AS max_allowed_packet, @@net_buffer_length AS net_buffer_length, @@net_write_timeout AS net_write_timeout, @@query_cache_size AS query_cache_size, @@query_cache_type AS query_cache_type, @@sql_mode AS sql_mode, @@system_time_zone AS system_time_zone, @@time_zone AS time_zone, @@tx_isolation AS tx_isolation, @@wait_timeout AS wait_timeout");
+        router->master_state = BLRM_SERVER_VARS;
+        router->master->func.write(router->master, buf);
+        break;
+    case BLRM_SERVER_VARS:
+        if (router->saved_master.server_vars)
+        {
+            GWBUF_CONSUME_ALL(router->saved_master.server_vars);
+        }
+        router->saved_master.server_vars = buf;
+        blr_cache_response(router, "server_vars", buf);
+
         buf = blr_make_registration(router);
         router->master_state = BLRM_REGISTER;
         router->master->func.write(router->master, buf);

--- a/server/modules/routing/binlogrouter/blr_master.c
+++ b/server/modules/routing/binlogrouter/blr_master.c
@@ -649,6 +649,18 @@ blr_master_response(ROUTER_INSTANCE *router, GWBUF *buf)
         router->saved_master.results_charset = buf;
         blr_cache_response(router, "results_charset", buf);
 
+        buf = blr_make_query(router->master, "SET sql_mode='NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES'");
+        router->master_state = BLRM_SQL_MODE;
+        router->master->func.write(router->master, buf);
+        break;
+    case BLRM_SQL_MODE:
+        if (router->saved_master.sql_mode)
+        {
+            GWBUF_CONSUME_ALL(router->saved_master.sql_mode);
+        }
+        router->saved_master.sql_mode = buf;
+        blr_cache_response(router, "sql_mode", buf);
+
         buf = blr_make_query(router->master, "SELECT 1");
         router->master_state = BLRM_SELECT1;
         router->master->func.write(router->master, buf);

--- a/server/modules/routing/binlogrouter/blr_master.c
+++ b/server/modules/routing/binlogrouter/blr_master.c
@@ -783,6 +783,18 @@ blr_master_response(ROUTER_INSTANCE *router, GWBUF *buf)
         router->saved_master.lower_case_tables = buf;
         blr_cache_response(router, "lower_case_tables", buf);
 
+        buf = blr_make_query(router->master, "SELECT @@global.binlog_checksum");
+        router->master_state = BLRM_BINLOG_CHECKSUM;
+        router->master->func.write(router->master, buf);
+        break;
+    case BLRM_BINLOG_CHECKSUM:
+        if (router->saved_master.binlog_checksum)
+        {
+            GWBUF_CONSUME_ALL(router->saved_master.binlog_checksum);
+        }
+        router->saved_master.binlog_checksum = buf;
+        blr_cache_response(router, "binlog_checksum", buf);
+
         buf = blr_make_registration(router);
         router->master_state = BLRM_REGISTER;
         router->master->func.write(router->master, buf);

--- a/server/modules/routing/binlogrouter/blr_slave.c
+++ b/server/modules/routing/binlogrouter/blr_slave.c
@@ -358,6 +358,7 @@ blr_slave_query(ROUTER_INSTANCE *router, ROUTER_SLAVE *slave, GWBUF *queue)
     static const char maxwell_binlog_format_query[] = "SHOW VARIABLES LIKE 'binlog_format'";
     static const char maxwell_binlog_row_image_query[] = "SHOW VARIABLES LIKE 'binlog_row_image'";
     static const char maxwell_lower_case_tables_query[] = "select @@lower_case_table_names";
+    static const char maxwell_binlog_checksum_query[] = "SELECT @@global.binlog_checksum";
 
 
     qtext = (char*)GWBUF_DATA(queue);
@@ -481,6 +482,16 @@ blr_slave_query(ROUTER_INSTANCE *router, ROUTER_SLAVE *slave, GWBUF *queue)
             return 1;
         }
         MXS_ERROR("Error sending lower_case_tables query response");
+    }
+    else if (strcmp(query_text, maxwell_binlog_checksum_query) == 0)
+    {
+        int rc = blr_slave_replay(router, slave, router->saved_master.binlog_checksum);
+        if (rc >= 0)
+        {
+            MXS_FREE(query_text);
+            return 1;
+        }
+        MXS_ERROR("Error sending binlog_checksum query response");
     }
     else if ((word = strtok_r(query_text, sep, &brkb)) == NULL)
     {

--- a/server/modules/routing/binlogrouter/blr_slave.c
+++ b/server/modules/routing/binlogrouter/blr_slave.c
@@ -355,6 +355,8 @@ blr_slave_query(ROUTER_INSTANCE *router, ROUTER_SLAVE *slave, GWBUF *queue)
     static const char mysql_connector_sql_mode_query[] = "SET sql_mode='NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES'";
     static const char maxwell_server_id_query[] = "SELECT @@server_id as server_id";
     static const char maxwell_log_bin_query[] = "SHOW VARIABLES LIKE 'log_bin'";
+    static const char maxwell_binlog_format_query[] = "SHOW VARIABLES LIKE 'binlog_format'";
+    static const char maxwell_binlog_row_image_query[] = "SHOW VARIABLES LIKE 'binlog_row_image'";
 
 
     qtext = (char*)GWBUF_DATA(queue);
@@ -448,6 +450,26 @@ blr_slave_query(ROUTER_INSTANCE *router, ROUTER_SLAVE *slave, GWBUF *queue)
             return 1;
         }
         MXS_ERROR("Error sending log_bin query response");
+    }
+    else if (strcmp(query_text, maxwell_binlog_format_query) == 0)
+    {
+        int rc = blr_slave_replay(router, slave, router->saved_master.binlog_format);
+        if (rc >= 0)
+        {
+            MXS_FREE(query_text);
+            return 1;
+        }
+        MXS_ERROR("Error sending binlog_format query response");
+    }
+    else if (strcmp(query_text, maxwell_binlog_row_image_query) == 0)
+    {
+        int rc = blr_slave_replay(router, slave, router->saved_master.binlog_row_image);
+        if (rc >= 0)
+        {
+            MXS_FREE(query_text);
+            return 1;
+        }
+        MXS_ERROR("Error sending binlog_row_image query response");
     }
     else if ((word = strtok_r(query_text, sep, &brkb)) == NULL)
     {

--- a/server/modules/routing/binlogrouter/blr_slave.c
+++ b/server/modules/routing/binlogrouter/blr_slave.c
@@ -353,6 +353,7 @@ blr_slave_query(ROUTER_INSTANCE *router, ROUTER_SLAVE *slave, GWBUF *queue)
     static const char mysql_connector_server_variables_query[] = "/* mysql-connector-java-5.1.39 ( Revision: 3289a357af6d09ecc1a10fd3c26e95183e5790ad ) */SELECT  @@session.auto_increment_increment AS auto_increment_increment, @@character_set_client AS character_set_client, @@character_set_connection AS character_set_connection, @@character_set_results AS character_set_results, @@character_set_server AS character_set_server, @@init_connect AS init_connect, @@interactive_timeout AS interactive_timeout, @@license AS license, @@lower_case_table_names AS lower_case_table_names, @@max_allowed_packet AS max_allowed_packet, @@net_buffer_length AS net_buffer_length, @@net_write_timeout AS net_write_timeout, @@query_cache_size AS query_cache_size, @@query_cache_type AS query_cache_type, @@sql_mode AS sql_mode, @@system_time_zone AS system_time_zone, @@time_zone AS time_zone, @@tx_isolation AS tx_isolation, @@wait_timeout AS wait_timeout";
     static const char mysql_connector_results_charset_query[] = "SET character_set_results = NULL";
     static const char mysql_connector_sql_mode_query[] = "SET sql_mode='NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES'";
+    static const char maxwell_server_id_query[] = "SELECT @@server_id as server_id";
 
     qtext = (char*)GWBUF_DATA(queue);
     query_len = extract_field((uint8_t *)qtext, 24) - 1;
@@ -428,6 +429,13 @@ blr_slave_query(ROUTER_INSTANCE *router, ROUTER_SLAVE *slave, GWBUF *queue)
             return 1;
         }
         MXS_ERROR("Error sending sql_mode query response");
+    }
+    else if (strcmp(query_text, maxwell_server_id_query) == 0)
+    {
+        char server_id[40];
+        sprintf(server_id, "%d", router->masterid);
+        MXS_FREE(query_text);
+        return blr_slave_send_var_value(router, slave, "server_id", server_id, BLR_TYPE_STRING);
     }
     else if ((word = strtok_r(query_text, sep, &brkb)) == NULL)
     {

--- a/server/modules/routing/binlogrouter/blr_slave.c
+++ b/server/modules/routing/binlogrouter/blr_slave.c
@@ -357,6 +357,7 @@ blr_slave_query(ROUTER_INSTANCE *router, ROUTER_SLAVE *slave, GWBUF *queue)
     static const char maxwell_log_bin_query[] = "SHOW VARIABLES LIKE 'log_bin'";
     static const char maxwell_binlog_format_query[] = "SHOW VARIABLES LIKE 'binlog_format'";
     static const char maxwell_binlog_row_image_query[] = "SHOW VARIABLES LIKE 'binlog_row_image'";
+    static const char maxwell_lower_case_tables_query[] = "select @@lower_case_table_names";
 
 
     qtext = (char*)GWBUF_DATA(queue);
@@ -470,6 +471,16 @@ blr_slave_query(ROUTER_INSTANCE *router, ROUTER_SLAVE *slave, GWBUF *queue)
             return 1;
         }
         MXS_ERROR("Error sending binlog_row_image query response");
+    }
+    else if (strcmp(query_text, maxwell_lower_case_tables_query) == 0)
+    {
+        int rc = blr_slave_replay(router, slave, router->saved_master.lower_case_tables);
+        if (rc >= 0)
+        {
+            MXS_FREE(query_text);
+            return 1;
+        }
+        MXS_ERROR("Error sending lower_case_tables query response");
     }
     else if ((word = strtok_r(query_text, sep, &brkb)) == NULL)
     {

--- a/server/modules/routing/binlogrouter/blr_slave.c
+++ b/server/modules/routing/binlogrouter/blr_slave.c
@@ -350,6 +350,7 @@ blr_slave_query(ROUTER_INSTANCE *router, ROUTER_SLAVE *slave, GWBUF *queue)
     char *ptr;
     extern char *strcasestr();
     bool unexpected = true;
+    static const char mysql_connector_server_variables_query[] = "/* mysql-connector-java-5.1.39 ( Revision: 3289a357af6d09ecc1a10fd3c26e95183e5790ad ) */SELECT  @@session.auto_increment_increment AS auto_increment_increment, @@character_set_client AS character_set_client, @@character_set_connection AS character_set_connection, @@character_set_results AS character_set_results, @@character_set_server AS character_set_server, @@init_connect AS init_connect, @@interactive_timeout AS interactive_timeout, @@license AS license, @@lower_case_table_names AS lower_case_table_names, @@max_allowed_packet AS max_allowed_packet, @@net_buffer_length AS net_buffer_length, @@net_write_timeout AS net_write_timeout, @@query_cache_size AS query_cache_size, @@query_cache_type AS query_cache_type, @@sql_mode AS sql_mode, @@system_time_zone AS system_time_zone, @@time_zone AS time_zone, @@tx_isolation AS tx_isolation, @@wait_timeout AS wait_timeout";
 
     qtext = (char*)GWBUF_DATA(queue);
     query_len = extract_field((uint8_t *)qtext, 24) - 1;
@@ -396,7 +397,17 @@ blr_slave_query(ROUTER_INSTANCE *router, ROUTER_SLAVE *slave, GWBUF *queue)
      * own interaction with the real master. We simply replay these saved responses
      * to the slave.
      */
-    if ((word = strtok_r(query_text, sep, &brkb)) == NULL)
+    if (strcmp(query_text, mysql_connector_server_variables_query) == 0)
+    {
+        int rc = blr_slave_replay(router, slave, router->saved_master.server_vars);
+        if (rc >= 0)
+        {
+            MXS_FREE(query_text);
+            return 1;
+        }
+        MXS_ERROR("Error sending mysql-connector-j server variables");
+    }
+    else if ((word = strtok_r(query_text, sep, &brkb)) == NULL)
     {
         MXS_ERROR("%s: Incomplete query.", router->service->name);
     }

--- a/server/modules/routing/binlogrouter/blr_slave.c
+++ b/server/modules/routing/binlogrouter/blr_slave.c
@@ -351,6 +351,7 @@ blr_slave_query(ROUTER_INSTANCE *router, ROUTER_SLAVE *slave, GWBUF *queue)
     extern char *strcasestr();
     bool unexpected = true;
     static const char mysql_connector_server_variables_query[] = "/* mysql-connector-java-5.1.39 ( Revision: 3289a357af6d09ecc1a10fd3c26e95183e5790ad ) */SELECT  @@session.auto_increment_increment AS auto_increment_increment, @@character_set_client AS character_set_client, @@character_set_connection AS character_set_connection, @@character_set_results AS character_set_results, @@character_set_server AS character_set_server, @@init_connect AS init_connect, @@interactive_timeout AS interactive_timeout, @@license AS license, @@lower_case_table_names AS lower_case_table_names, @@max_allowed_packet AS max_allowed_packet, @@net_buffer_length AS net_buffer_length, @@net_write_timeout AS net_write_timeout, @@query_cache_size AS query_cache_size, @@query_cache_type AS query_cache_type, @@sql_mode AS sql_mode, @@system_time_zone AS system_time_zone, @@time_zone AS time_zone, @@tx_isolation AS tx_isolation, @@wait_timeout AS wait_timeout";
+    static const char mysql_connector_results_charset_query[] = "SET character_set_results = NULL";
 
     qtext = (char*)GWBUF_DATA(queue);
     query_len = extract_field((uint8_t *)qtext, 24) - 1;
@@ -400,6 +401,16 @@ blr_slave_query(ROUTER_INSTANCE *router, ROUTER_SLAVE *slave, GWBUF *queue)
     if (strcmp(query_text, mysql_connector_server_variables_query) == 0)
     {
         int rc = blr_slave_replay(router, slave, router->saved_master.server_vars);
+        if (rc >= 0)
+        {
+            MXS_FREE(query_text);
+            return 1;
+        }
+        MXS_ERROR("Error sending mysql-connector-j server variables");
+    }
+    else if (strcmp(query_text, mysql_connector_results_charset_query) == 0)
+    {
+        int rc = blr_slave_replay(router, slave, router->saved_master.results_charset);
         if (rc >= 0)
         {
             MXS_FREE(query_text);

--- a/server/modules/routing/binlogrouter/blr_slave.c
+++ b/server/modules/routing/binlogrouter/blr_slave.c
@@ -352,6 +352,7 @@ blr_slave_query(ROUTER_INSTANCE *router, ROUTER_SLAVE *slave, GWBUF *queue)
     bool unexpected = true;
     static const char mysql_connector_server_variables_query[] = "/* mysql-connector-java-5.1.39 ( Revision: 3289a357af6d09ecc1a10fd3c26e95183e5790ad ) */SELECT  @@session.auto_increment_increment AS auto_increment_increment, @@character_set_client AS character_set_client, @@character_set_connection AS character_set_connection, @@character_set_results AS character_set_results, @@character_set_server AS character_set_server, @@init_connect AS init_connect, @@interactive_timeout AS interactive_timeout, @@license AS license, @@lower_case_table_names AS lower_case_table_names, @@max_allowed_packet AS max_allowed_packet, @@net_buffer_length AS net_buffer_length, @@net_write_timeout AS net_write_timeout, @@query_cache_size AS query_cache_size, @@query_cache_type AS query_cache_type, @@sql_mode AS sql_mode, @@system_time_zone AS system_time_zone, @@time_zone AS time_zone, @@tx_isolation AS tx_isolation, @@wait_timeout AS wait_timeout";
     static const char mysql_connector_results_charset_query[] = "SET character_set_results = NULL";
+    static const char mysql_connector_sql_mode_query[] = "SET sql_mode='NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES'";
 
     qtext = (char*)GWBUF_DATA(queue);
     query_len = extract_field((uint8_t *)qtext, 24) - 1;
@@ -416,7 +417,17 @@ blr_slave_query(ROUTER_INSTANCE *router, ROUTER_SLAVE *slave, GWBUF *queue)
             MXS_FREE(query_text);
             return 1;
         }
-        MXS_ERROR("Error sending mysql-connector-j server variables");
+        MXS_ERROR("Error sending results charset response");
+    }
+    else if (strcmp(query_text, mysql_connector_sql_mode_query) == 0)
+    {
+        int rc = blr_slave_replay(router, slave, router->saved_master.sql_mode);
+        if (rc >= 0)
+        {
+            MXS_FREE(query_text);
+            return 1;
+        }
+        MXS_ERROR("Error sending sql_mode query response");
     }
     else if ((word = strtok_r(query_text, sep, &brkb)) == NULL)
     {


### PR DESCRIPTION
Greetings!

Here are the changes I needed to apply in order to get Maxwell working with MaxScale.

They're exclusively about handling few SQL queries that Maxwell expects MaxScale to handle.  I leveraged the existing infrastructure to issue the queries known a priori, on MaxScale's startup, cache the responses from master and then replay the responses to Maxwell when it asks for them.

This PR may have few rough edges.  The worst part being hard-coded comment in a SQL query containing mysql-connector-j version string (!).  The reason I create the PR so early is I want to get the discussion started whether there's any intention of merging these changes.  For example, if the plan is to wait on https://jira.mariadb.org/browse/MXS-448 being implemented instead, there's no point in me working on this any further.