### PR TITLE
Spinlock bugfix: Add missing volatile qualifier

### DIFF
--- a/include/maxscale/spinlock.h
+++ b/include/maxscale/spinlock.h
@@ -42,7 +42,7 @@ MXS_BEGIN_DECLS
  */
 typedef struct spinlock
 {
-    int lock;         /*< Is the lock held? */
+    volatile int lock;         /*< Is the lock held? */
 #if SPINLOCK_PROFILE
     int spins;        /*< Number of spins on this lock */
     int maxspins;     /*< Max no of spins to acquire lock */


### PR DESCRIPTION
I happened to set `heartbeat=1` in `maxscale.cnf`.  This made master reconnects more frequent and increased contention on binlog router spinlock.  That, in turn, has resulted in MaxScale completely freezing (didn't even respond to maxadmin commands) around the time of a reconnect.  I investigated and tracked it down to a bug in the spinlock implementation.  The lack of `volatile` qualifier causes gcc optimizer to assume that the `while (lock->lock) {}` loop in `spinlock.c` is (roughly) equivalent to `for (;;);` (the `=>` arrow).  Here's the disassembly I got from gdb:

```
(gdb) disassemble spinlock_acquire
Dump of assembler code for function spinlock_acquire:
   0x00007fe401344e40 <+0>:	mov    $0x1,%edx
   0x00007fe401344e45 <+5>:	jmp    0x7fe401344e56 <spinlock_acquire+22>
   0x00007fe401344e47 <+7>:	nopw   0x0(%rax,%rax,1)
   0x00007fe401344e50 <+16>:	mov    (%rdi),%eax
   0x00007fe401344e52 <+18>:	test   %eax,%eax
   0x00007fe401344e54 <+20>:	jne    0x7fe401344e60 <spinlock_acquire+32>
   0x00007fe401344e56 <+22>:	mov    %edx,%eax
   0x00007fe401344e58 <+24>:	xchg   %eax,(%rdi)
   0x00007fe401344e5a <+26>:	test   %eax,%eax
   0x00007fe401344e5c <+28>:	jne    0x7fe401344e50 <spinlock_acquire+16>
   0x00007fe401344e5e <+30>:	repz retq
=> 0x00007fe401344e60 <+32>:	jmp    0x7fe401344e60 <spinlock_acquire+32>
End of assembler dump.
```

With `volatile` OTOH:

```C
typedef struct spinlock
{
    volatile int lock;         /*< Is the lock held? */
    ...
} SPINLOCK;
```

the contents of `lock->lock` are re-fetched on every loop iteration:

```
(gdb) disas spinlock_acquire
Dump of assembler code for function spinlock_acquire:
   0x00007f198461be40 <+0>:	mov    $0x1,%edx
   0x00007f198461be45 <+5>:	nopl   (%rax)
   0x00007f198461be48 <+8>:	mov    %edx,%eax
   0x00007f198461be4a <+10>:	xchg   %eax,(%rdi)
   0x00007f198461be4c <+12>:	test   %eax,%eax
   0x00007f198461be4e <+14>:	je     0x7f198461be58 <spinlock_acquire+24>
   0x00007f198461be50 <+16>:	mov    (%rdi),%eax
   0x00007f198461be52 <+18>:	test   %eax,%eax
   0x00007f198461be54 <+20>:	jne    0x7f198461be50 <spinlock_acquire+16>
   0x00007f198461be56 <+22>:	jmp    0x7f198461be48 <spinlock_acquire+8>
   0x00007f198461be58 <+24>:	repz retq
End of assembler dump.
```

This change fixed the freezing problem.