### PR TITLE
add MDBCI test scripts

### DIFF
--- a/maxscale-system-test/mdbci/add_core_cnf.sh
+++ b/maxscale-system-test/mdbci/add_core_cnf.sh
@@ -1,0 +1,23 @@
+set -x
+chmod 777 /tmp/
+echo 2 > /proc/sys/fs/suid_dumpable
+sed -i "s/start() {/start() { \n export DAEMON_COREFILE_LIMIT='unlimited'; ulimit -c unlimited; /" /etc/init.d/maxscale
+sed -i "s/log_daemon_msg \"Starting MaxScale\"/export DAEMON_COREFILE_LIMIT='unlimited'; ulimit -c unlimited; log_daemon_msg \"Starting MaxScale\" /" /etc/init.d/maxscale
+echo /tmp/core-%e-%s-%u-%g-%p-%t > /proc/sys/kernel/core_pattern
+
+echo "kernel.core_pattern = /tmp/core-%e-sig%s-user%u-group%g-pid%p-time%t" >> /etc/sysctl.d/core.conf
+echo "kernel.core_uses_pid = 1" >> /etc/sysctl.d/core.conf
+echo "fs.suid_dumpable = 2" >> /etc/sysctl.d/core.conf
+
+echo "DefaultLimitCORE=infinity" >> /etc/systemd/system.conf
+
+echo "*       hard        core        unlimited" >> /etc/security/limits.d/core.conf
+echo "*       soft        core        unlimited" >> /etc/security/limits.d/core.conf
+echo "*       soft     nofile           65536" >> /etc/security/limits.d/core.conf
+echo "*       hard     nofile           65536" >> /etc/security/limits.d/core.conf
+
+
+echo "fs.file-max = 65536" >>  /etc/sysctl.conf
+
+systemctl daemon-reexec
+sysctl -p

--- a/maxscale-system-test/mdbci/backend/create_repl_user.sql
+++ b/maxscale-system-test/mdbci/backend/create_repl_user.sql
@@ -1,0 +1,4 @@
+#create user repl@'%' identified by 'repl'; 
+grant replication slave on *.* to repl@'%' identified by 'repl'; 
+
+FLUSH PRIVILEGES;

--- a/maxscale-system-test/mdbci/backend/create_skysql_user.sql
+++ b/maxscale-system-test/mdbci/backend/create_skysql_user.sql
@@ -1,0 +1,18 @@
+create user skysql@'%' identified by 'skysql';
+create user skysql@'localhost' identified by 'skysql';
+GRANT ALL PRIVILEGES ON *.* TO skysql@'%' WITH GRANT OPTION; 
+GRANT ALL PRIVILEGES ON *.* TO skysql@'localhost' WITH GRANT OPTION;
+
+create user maxuser@'%' identified by 'maxpwd';
+create user maxuser@'localhost' identified by 'maxpwd';
+GRANT ALL PRIVILEGES ON *.* TO maxuser@'%' WITH GRANT OPTION;
+GRANT ALL PRIVILEGES ON *.* TO maxuser@'localhost' WITH GRANT OPTION;
+
+create user maxskysql@'%' identified by 'skysql';
+create user maxskysql@'localhost' identified by 'skysql';
+GRANT ALL PRIVILEGES ON *.* TO maxskysql@'%' WITH GRANT OPTION;
+GRANT ALL PRIVILEGES ON *.* TO maxskysql@'localhost' WITH GRANT OPTION;
+
+
+FLUSH PRIVILEGES;
+CREATE DATABASE IF NOT EXISTS test;

--- a/maxscale-system-test/mdbci/backend/galera/setup_galera.sh
+++ b/maxscale-system-test/mdbci/backend/galera/setup_galera.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+N=$galera_N
+
+x=`expr $N - 1`
+for i in $(seq 0 $x)
+do
+	num=`printf "%03d" $i`
+	sshkey_var=galera_"$num"_keyfile
+	user_var=galera_"$num"_whoami
+	IP_var=galera_"$num"_network
+
+	sshkey=${!sshkey_var}
+	user=${!user_var}
+	IP=${!IP_var}
+
+    ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP "sudo mysql_install_db; sudo chown -R mysql:mysql /var/lib/mysql"
+done

--- a/maxscale-system-test/mdbci/backend/setup_repl.sh
+++ b/maxscale-system-test/mdbci/backend/setup_repl.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -x
+
+x=`expr $node_N - 1`
+for i in $(seq 0 $x)
+do
+        num=`printf "%03d" $i`
+        sshkey_var=node_"$num"_keyfile
+        user_var=node_"$num"_whoami
+        IP_var=node_"$num"_network
+	start_cmd_var=node_"$num"_start_db_command
+	stop_cmd_var=node_"$num"_stop_db_command
+
+        sshkey=${!sshkey_var}
+        user=${!user_var}
+        IP=${!IP_var}
+	start_cmd=${!start_cmd_var}
+	stop_cmd=${!stop_cmd_var}
+
+	ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP "sudo  $stop_cmd" 
+	sleep 5
+	ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP 'sudo sed -i "s/bind-address/#bind-address/g" /etc/mysql/my.cnf'
+	ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP 'sudo ln -s /etc/apparmor.d/usr.sbin.mysqld /etc/apparmor.d/disable/usr.sbin.mysqld; sudo service apparmor restart'
+
+	mysql_version=`ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP  'mysql --version'`
+        echo $mysql_version | grep "5\."
+        if [ $? == 0 ] ; then
+		ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP "sudo sed -i \"s/binlog_row_image=full//\" /etc/my.cnf.d/*.cnf"
+        fi
+
+	echo $mysql_version | grep "5\.7"
+	if [ $? == 0 ] ; then
+#		ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP "sudo sed -i \"s/## x001/validate-password=OFF/\" /etc/my.cnf.d/*.cnf"
+                ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP "sudo mysqld --initialize; sudo chown -R mysql:mysql /var/lib/mysql"
+                ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP "sudo $start_cmd" 
+
+		mysql_root_password=`ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP "sudo cat /var/log/mysqld.log | grep \"temporary password\" | sed -n -e 's/^.*: //p'"`
+
+		ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP "sudo mysqladmin -uroot -p'$mysql_root_password' password '$mysql_root_password'"
+		ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP "echo \"UNINSTALL PLUGIN validate_password\" | sudo mysql -uroot -p'$mysql_root_password' "
+
+
+		ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP "sudo $stop_cmd"
+#		ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP "sudo sed -i \"s/## x001/validate-password=OFF/\" /etc/my.cnf.d/*.cnf"
+
+		ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP "sudo $start_cmd"
+
+#		mysql_root_password=`ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP "sudo cat /var/log/mysqld.log | grep \"temporary password\" | sed -n -e 's/^.*: //p'"`
+		ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP "echo \"show plugins\" | sudo mysql -uroot -p'$mysql_root_password' " 
+		ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP "sudo mysqladmin -uroot -p'$mysql_root_password' password ''" 
+#		ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP "sudo $start_cmd"
+	else
+		ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP "sudo mysql_install_db; sudo chown -R mysql:mysql /var/lib/mysql"
+		ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP "sudo $start_cmd" 
+	fi
+	sleep 15
+        scp -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${script_dir}/create_*_user.sql $user@$IP://home/$user/
+        ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP "sudo mysql < /home/$user/create_repl_user.sql"
+        ssh -i $sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $user@$IP "sudo mysql < /home/$user/create_skysql_user.sql"
+done

--- a/maxscale-system-test/mdbci/cnf/galera_server1.cnf
+++ b/maxscale-system-test/mdbci/cnf/galera_server1.cnf
@@ -1,0 +1,130 @@
+[mysqld]
+expire_logs_days=7
+user=mysql
+server_id=1
+wsrep_on=ON
+
+# Row binary log format is required by Galera
+binlog_format=ROW
+
+log-bin
+
+# InnoDB is currently the only storage engine supported by Galera
+default-storage-engine=innodb
+innodb_file_per_table
+
+# To avoid issues with 'bulk mode inserts' using autoincrement fields
+innodb_autoinc_lock_mode=2
+
+# Required to prevent deadlocks on parallel transaction execution
+innodb_locks_unsafe_for_binlog=1
+
+# Query Cache is not supported by Galera wsrep replication
+query_cache_size=0
+query_cache_type=0
+
+# INITIAL SETUP
+# In some systems bind-address defaults to 127.0.0.1, and with mysqldump SST
+# it will have (most likely) disastrous consequences on donor node
+bind-address=###NODE-ADDRESS###
+
+##
+## WSREP options
+##
+
+# INITIAL SETUP
+# For the initial setup, wsrep should be disabled
+wsrep_provider=none
+# After initial setup, parameter should have full path to wsrep provider library
+wsrep_provider=###GALERA-LIB-PATH###
+
+# Provider specific configuration options
+wsrep_provider_options = "evs.keepalive_period = PT3S; evs.inactive_check_period = PT10S; evs.suspect_timeout = PT30S; evs.inactive_timeout = PT1M; evs.install_timeout = PT1M"
+
+# Logical cluster name. Should be the same for all nodes in the same cluster.
+wsrep_cluster_name=skycluster
+
+# INITIAL SETUP
+# Group communication system handle: for the first node to be launched, the value should be "gcomm://", indicating creation of a new cluster;
+# for the other nodes joining the cluster, the value should be "gcomm://xxx.xxx.xxx.xxx:4567", where xxx.xxx.xxx.xxx should be the ip of a node
+# already on the cluster (usually the first one)
+# DEPRECATED
+# wsrep_cluster_address=gcomm://
+
+# Human-readable node name (non-unique). Hostname by default.
+#wsrep_node_name=###NODE-NAME###
+wsrep_node_name=galera000
+
+# INITIAL SETUP
+# Base replication <address|hostname>[:port] of the node.
+# The values supplied will be used as defaults for state transfer receiving,
+# listening ports and so on. Default: address of the first network interface.
+wsrep_node_address=###NODE-ADDRESS###
+
+# INITIAL SETUP
+# Address for incoming client connections. Autodetect by default.
+wsrep_node_incoming_address=###NODE-ADDRESS###
+
+# Number of threads that will process writesets from other nodes
+wsrep_slave_threads=1
+
+# Generate fake primary keys for non-PK tables (required for multi-master
+# and parallel applying operation)
+wsrep_certify_nonPK=1
+
+# Debug level logging (1 = enabled)
+wsrep_debug=1
+
+# Convert locking sessions into transactions
+wsrep_convert_LOCK_to_trx=0
+
+# Number of retries for deadlocked autocommits
+wsrep_retry_autocommit=1
+
+# Change auto_increment_increment and auto_increment_offset automatically
+wsrep_auto_increment_control=1
+
+# Retry autoinc insert, when the insert failed for "duplicate key error"
+wsrep_drupal_282555_workaround=0
+
+# Enable "strictly synchronous" semantics for read operations
+wsrep_causal_reads=1
+
+# Command to call when node status or cluster membership changes.
+# Will be passed all or some of the following options:
+# --status  - new status of this node
+# --uuid    - UUID of the cluster
+# --primary - whether the component is primary or not ("yes"/"no")
+# --members - comma-separated list of members
+# --index   - index of this node in the list
+wsrep_notify_cmd=
+
+##
+## WSREP State Transfer options
+##
+
+# State Snapshot Transfer method
+#wsrep_sst_method=mysqldump
+#wsrep_sst_method=xtrabackup
+wsrep_sst_method=rsync
+
+# INITIAL SETUP
+# Address which donor should send State Snapshot to.
+# Should be the address of the CURRENT node. DON'T SET IT TO DONOR ADDRESS!!!
+# (SST method dependent. Defaults to the first IP of the first interface)
+wsrep_sst_receive_address=###NODE-ADDRESS###
+
+# INITIAL SETUP
+# SST authentication string. This will be used to send SST to joining nodes.
+# Depends on SST method. For mysqldump method it is root:<root password>
+#wsrep_sst_auth=###REP-USERNAME###:###REP-PASSWORD###
+wsrep_sst_auth=repl:repl
+
+# Desired SST donor name.
+#wsrep_sst_donor=
+
+# Reject client queries when donating SST (false)
+#wsrep_sst_donor_rejects_queries=0
+
+# Protocol version to use
+# wsrep_protocol_version=

--- a/maxscale-system-test/mdbci/cnf/galera_server2.cnf
+++ b/maxscale-system-test/mdbci/cnf/galera_server2.cnf
@@ -1,0 +1,130 @@
+[mysqld]
+expire_logs_days=7
+user=mysql
+server_id=2
+wsrep_on=ON
+
+# Row binary log format is required by Galera
+binlog_format=ROW
+
+log-bin
+
+# InnoDB is currently the only storage engine supported by Galera
+default-storage-engine=innodb
+innodb_file_per_table
+
+# To avoid issues with 'bulk mode inserts' using autoincrement fields
+innodb_autoinc_lock_mode=2
+
+# Required to prevent deadlocks on parallel transaction execution
+innodb_locks_unsafe_for_binlog=1
+
+# Query Cache is not supported by Galera wsrep replication
+query_cache_size=0
+query_cache_type=0
+
+# INITIAL SETUP
+# In some systems bind-address defaults to 127.0.0.1, and with mysqldump SST
+# it will have (most likely) disastrous consequences on donor node
+bind-address=###NODE-ADDRESS###
+
+##
+## WSREP options
+##
+
+# INITIAL SETUP
+# For the initial setup, wsrep should be disabled
+wsrep_provider=none
+# After initial setup, parameter should have full path to wsrep provider library
+wsrep_provider=###GALERA-LIB-PATH###
+
+# Provider specific configuration options
+wsrep_provider_options = "evs.keepalive_period = PT3S; evs.inactive_check_period = PT10S; evs.suspect_timeout = PT30S; evs.inactive_timeout = PT1M; evs.install_timeout = PT1M"
+
+# Logical cluster name. Should be the same for all nodes in the same cluster.
+wsrep_cluster_name=skycluster
+
+# INITIAL SETUP
+# Group communication system handle: for the first node to be launched, the value should be "gcomm://", indicating creation of a new cluster;
+# for the other nodes joining the cluster, the value should be "gcomm://xxx.xxx.xxx.xxx:4567", where xxx.xxx.xxx.xxx should be the ip of a node
+# already on the cluster (usually the first one)
+# DEPRECATED
+# wsrep_cluster_address=gcomm://
+
+# Human-readable node name (non-unique). Hostname by default.
+#wsrep_node_name=###NODE-NAME###
+wsrep_node_name=galera001
+
+# INITIAL SETUP
+# Base replication <address|hostname>[:port] of the node.
+# The values supplied will be used as defaults for state transfer receiving,
+# listening ports and so on. Default: address of the first network interface.
+wsrep_node_address=###NODE-ADDRESS###
+
+# INITIAL SETUP
+# Address for incoming client connections. Autodetect by default.
+wsrep_node_incoming_address=###NODE-ADDRESS###
+
+# Number of threads that will process writesets from other nodes
+wsrep_slave_threads=1
+
+# Generate fake primary keys for non-PK tables (required for multi-master
+# and parallel applying operation)
+wsrep_certify_nonPK=1
+
+# Debug level logging (1 = enabled)
+wsrep_debug=1
+
+# Convert locking sessions into transactions
+wsrep_convert_LOCK_to_trx=0
+
+# Number of retries for deadlocked autocommits
+wsrep_retry_autocommit=1
+
+# Change auto_increment_increment and auto_increment_offset automatically
+wsrep_auto_increment_control=1
+
+# Retry autoinc insert, when the insert failed for "duplicate key error"
+wsrep_drupal_282555_workaround=0
+
+# Enable "strictly synchronous" semantics for read operations
+wsrep_causal_reads=1
+
+# Command to call when node status or cluster membership changes.
+# Will be passed all or some of the following options:
+# --status  - new status of this node
+# --uuid    - UUID of the cluster
+# --primary - whether the component is primary or not ("yes"/"no")
+# --members - comma-separated list of members
+# --index   - index of this node in the list
+wsrep_notify_cmd=
+
+##
+## WSREP State Transfer options
+##
+
+# State Snapshot Transfer method
+#wsrep_sst_method=mysqldump
+#wsrep_sst_method=xtrabackup
+wsrep_sst_method=rsync
+
+# INITIAL SETUP
+# Address which donor should send State Snapshot to.
+# Should be the address of the CURRENT node. DON'T SET IT TO DONOR ADDRESS!!!
+# (SST method dependent. Defaults to the first IP of the first interface)
+wsrep_sst_receive_address=###NODE-ADDRESS###
+
+# INITIAL SETUP
+# SST authentication string. This will be used to send SST to joining nodes.
+# Depends on SST method. For mysqldump method it is root:<root password>
+#wsrep_sst_auth=###REP-USERNAME###:###REP-PASSWORD###
+wsrep_sst_auth=repl:repl
+
+# Desired SST donor name.
+#wsrep_sst_donor=
+
+# Reject client queries when donating SST (false)
+#wsrep_sst_donor_rejects_queries=0
+
+# Protocol version to use
+# wsrep_protocol_version=

--- a/maxscale-system-test/mdbci/cnf/galera_server3.cnf
+++ b/maxscale-system-test/mdbci/cnf/galera_server3.cnf
@@ -1,0 +1,130 @@
+[mysqld]
+expire_logs_days=7
+user=mysql
+server_id=3
+wsrep_on=ON
+
+# Row binary log format is required by Galera
+binlog_format=ROW
+
+log-bin
+
+# InnoDB is currently the only storage engine supported by Galera
+default-storage-engine=innodb
+innodb_file_per_table
+
+# To avoid issues with 'bulk mode inserts' using autoincrement fields
+innodb_autoinc_lock_mode=2
+
+# Required to prevent deadlocks on parallel transaction execution
+innodb_locks_unsafe_for_binlog=1
+
+# Query Cache is not supported by Galera wsrep replication
+query_cache_size=0
+query_cache_type=0
+
+# INITIAL SETUP
+# In some systems bind-address defaults to 127.0.0.1, and with mysqldump SST
+# it will have (most likely) disastrous consequences on donor node
+bind-address=###NODE-ADDRESS###
+
+##
+## WSREP options
+##
+
+# INITIAL SETUP
+# For the initial setup, wsrep should be disabled
+wsrep_provider=none
+# After initial setup, parameter should have full path to wsrep provider library
+wsrep_provider=###GALERA-LIB-PATH###
+
+# Provider specific configuration options
+wsrep_provider_options = "evs.keepalive_period = PT3S; evs.inactive_check_period = PT10S; evs.suspect_timeout = PT30S; evs.inactive_timeout = PT1M; evs.install_timeout = PT1M"
+
+# Logical cluster name. Should be the same for all nodes in the same cluster.
+wsrep_cluster_name=skycluster
+
+# INITIAL SETUP
+# Group communication system handle: for the first node to be launched, the value should be "gcomm://", indicating creation of a new cluster;
+# for the other nodes joining the cluster, the value should be "gcomm://xxx.xxx.xxx.xxx:4567", where xxx.xxx.xxx.xxx should be the ip of a node
+# already on the cluster (usually the first one)
+# DEPRECATED
+# wsrep_cluster_address=gcomm://
+
+# Human-readable node name (non-unique). Hostname by default.
+#wsrep_node_name=###NODE-NAME###
+wsrep_node_name=galera002
+
+# INITIAL SETUP
+# Base replication <address|hostname>[:port] of the node.
+# The values supplied will be used as defaults for state transfer receiving,
+# listening ports and so on. Default: address of the first network interface.
+wsrep_node_address=###NODE-ADDRESS###
+
+# INITIAL SETUP
+# Address for incoming client connections. Autodetect by default.
+wsrep_node_incoming_address=###NODE-ADDRESS###
+
+# Number of threads that will process writesets from other nodes
+wsrep_slave_threads=1
+
+# Generate fake primary keys for non-PK tables (required for multi-master
+# and parallel applying operation)
+wsrep_certify_nonPK=1
+
+# Debug level logging (1 = enabled)
+wsrep_debug=1
+
+# Convert locking sessions into transactions
+wsrep_convert_LOCK_to_trx=0
+
+# Number of retries for deadlocked autocommits
+wsrep_retry_autocommit=1
+
+# Change auto_increment_increment and auto_increment_offset automatically
+wsrep_auto_increment_control=1
+
+# Retry autoinc insert, when the insert failed for "duplicate key error"
+wsrep_drupal_282555_workaround=0
+
+# Enable "strictly synchronous" semantics for read operations
+wsrep_causal_reads=1
+
+# Command to call when node status or cluster membership changes.
+# Will be passed all or some of the following options:
+# --status  - new status of this node
+# --uuid    - UUID of the cluster
+# --primary - whether the component is primary or not ("yes"/"no")
+# --members - comma-separated list of members
+# --index   - index of this node in the list
+wsrep_notify_cmd=
+
+##
+## WSREP State Transfer options
+##
+
+# State Snapshot Transfer method
+#wsrep_sst_method=mysqldump
+#wsrep_sst_method=xtrabackup
+wsrep_sst_method=rsync
+
+# INITIAL SETUP
+# Address which donor should send State Snapshot to.
+# Should be the address of the CURRENT node. DON'T SET IT TO DONOR ADDRESS!!!
+# (SST method dependent. Defaults to the first IP of the first interface)
+wsrep_sst_receive_address=###NODE-ADDRESS###
+
+# INITIAL SETUP
+# SST authentication string. This will be used to send SST to joining nodes.
+# Depends on SST method. For mysqldump method it is root:<root password>
+#wsrep_sst_auth=###REP-USERNAME###:###REP-PASSWORD###
+wsrep_sst_auth=repl:repl
+
+# Desired SST donor name.
+#wsrep_sst_donor=
+
+# Reject client queries when donating SST (false)
+#wsrep_sst_donor_rejects_queries=0
+
+# Protocol version to use
+# wsrep_protocol_version=

--- a/maxscale-system-test/mdbci/cnf/galera_server4.cnf
+++ b/maxscale-system-test/mdbci/cnf/galera_server4.cnf
@@ -1,0 +1,130 @@
+[mysqld]
+expire_logs_days=7
+user=mysql
+server_id=4
+wsrep_on=ON
+
+# Row binary log format is required by Galera
+binlog_format=ROW
+
+log-bin
+
+# InnoDB is currently the only storage engine supported by Galera
+default-storage-engine=innodb
+innodb_file_per_table
+
+# To avoid issues with 'bulk mode inserts' using autoincrement fields
+innodb_autoinc_lock_mode=2
+
+# Required to prevent deadlocks on parallel transaction execution
+innodb_locks_unsafe_for_binlog=1
+
+# Query Cache is not supported by Galera wsrep replication
+query_cache_size=0
+query_cache_type=0
+
+# INITIAL SETUP
+# In some systems bind-address defaults to 127.0.0.1, and with mysqldump SST
+# it will have (most likely) disastrous consequences on donor node
+bind-address=###NODE-ADDRESS###
+
+##
+## WSREP options
+##
+
+# INITIAL SETUP
+# For the initial setup, wsrep should be disabled
+wsrep_provider=none
+# After initial setup, parameter should have full path to wsrep provider library
+wsrep_provider=###GALERA-LIB-PATH###
+
+# Provider specific configuration options
+wsrep_provider_options = "evs.keepalive_period = PT3S; evs.inactive_check_period = PT10S; evs.suspect_timeout = PT30S; evs.inactive_timeout = PT1M; evs.install_timeout = PT1M"
+
+# Logical cluster name. Should be the same for all nodes in the same cluster.
+wsrep_cluster_name=skycluster
+
+# INITIAL SETUP
+# Group communication system handle: for the first node to be launched, the value should be "gcomm://", indicating creation of a new cluster;
+# for the other nodes joining the cluster, the value should be "gcomm://xxx.xxx.xxx.xxx:4567", where xxx.xxx.xxx.xxx should be the ip of a node
+# already on the cluster (usually the first one)
+# DEPRECATED
+# wsrep_cluster_address=gcomm://
+
+# Human-readable node name (non-unique). Hostname by default.
+#wsrep_node_name=###NODE-NAME###
+wsrep_node_name=galera003
+
+# INITIAL SETUP
+# Base replication <address|hostname>[:port] of the node.
+# The values supplied will be used as defaults for state transfer receiving,
+# listening ports and so on. Default: address of the first network interface.
+wsrep_node_address=###NODE-ADDRESS###
+
+# INITIAL SETUP
+# Address for incoming client connections. Autodetect by default.
+wsrep_node_incoming_address=###NODE-ADDRESS###
+
+# Number of threads that will process writesets from other nodes
+wsrep_slave_threads=1
+
+# Generate fake primary keys for non-PK tables (required for multi-master
+# and parallel applying operation)
+wsrep_certify_nonPK=1
+
+# Debug level logging (1 = enabled)
+wsrep_debug=1
+
+# Convert locking sessions into transactions
+wsrep_convert_LOCK_to_trx=0
+
+# Number of retries for deadlocked autocommits
+wsrep_retry_autocommit=1
+
+# Change auto_increment_increment and auto_increment_offset automatically
+wsrep_auto_increment_control=1
+
+# Retry autoinc insert, when the insert failed for "duplicate key error"
+wsrep_drupal_282555_workaround=0
+
+# Enable "strictly synchronous" semantics for read operations
+wsrep_causal_reads=1
+
+# Command to call when node status or cluster membership changes.
+# Will be passed all or some of the following options:
+# --status  - new status of this node
+# --uuid    - UUID of the cluster
+# --primary - whether the component is primary or not ("yes"/"no")
+# --members - comma-separated list of members
+# --index   - index of this node in the list
+wsrep_notify_cmd=
+
+##
+## WSREP State Transfer options
+##
+
+# State Snapshot Transfer method
+#wsrep_sst_method=mysqldump
+#wsrep_sst_method=xtrabackup
+wsrep_sst_method=rsync
+
+# INITIAL SETUP
+# Address which donor should send State Snapshot to.
+# Should be the address of the CURRENT node. DON'T SET IT TO DONOR ADDRESS!!!
+# (SST method dependent. Defaults to the first IP of the first interface)
+wsrep_sst_receive_address=###NODE-ADDRESS###
+
+# INITIAL SETUP
+# SST authentication string. This will be used to send SST to joining nodes.
+# Depends on SST method. For mysqldump method it is root:<root password>
+#wsrep_sst_auth=###REP-USERNAME###:###REP-PASSWORD###
+wsrep_sst_auth=repl:repl
+
+# Desired SST donor name.
+#wsrep_sst_donor=
+
+# Reject client queries when donating SST (false)
+#wsrep_sst_donor_rejects_queries=0
+
+# Protocol version to use
+# wsrep_protocol_version=

--- a/maxscale-system-test/mdbci/cnf/mysql56/galera_server1.cnf
+++ b/maxscale-system-test/mdbci/cnf/mysql56/galera_server1.cnf
@@ -1,0 +1,135 @@
+[mysqld]
+expire_logs_days=7
+user=mysql
+server_id=1
+
+# Row binary log format is required by Galera
+binlog_format=ROW
+
+log-bin
+
+# InnoDB is currently the only storage engine supported by Galera
+default-storage-engine=innodb
+innodb_file_per_table
+
+# To avoid issues with 'bulk mode inserts' using autoincrement fields
+innodb_autoinc_lock_mode=2
+
+# Required to prevent deadlocks on parallel transaction execution
+innodb_locks_unsafe_for_binlog=1
+
+# Query Cache is not supported by Galera wsrep replication
+query_cache_size=0
+query_cache_type=0
+
+# INITIAL SETUP
+# In some systems bind-address defaults to 127.0.0.1, and with mysqldump SST
+# it will have (most likely) disastrous consequences on donor node
+bind-address=###NODE-ADDRESS###
+
+##
+## WSREP options
+##
+
+# INITIAL SETUP
+# For the initial setup, wsrep should be disabled
+wsrep_provider=none
+# After initial setup, parameter should have full path to wsrep provider library
+wsrep_provider=###GALERA-LIB-PATH###
+
+# Provider specific configuration options
+wsrep_provider_options = "evs.keepalive_period = PT3S; evs.inactive_check_period = PT10S; evs.suspect_timeout = PT30S; evs.inactive_timeout = PT1M; evs.install_timeout = PT1M"
+
+# Logical cluster name. Should be the same for all nodes in the same cluster.
+wsrep_cluster_name=skycluster
+
+# INITIAL SETUP
+# Group communication system handle: for the first node to be launched, the value should be "gcomm://", indicating creation of a new cluster;
+# for the other nodes joining the cluster, the value should be "gcomm://xxx.xxx.xxx.xxx:4567", where xxx.xxx.xxx.xxx should be the ip of a node
+# already on the cluster (usually the first one)
+# DEPRECATED
+# wsrep_cluster_address=gcomm://
+
+# Human-readable node name (non-unique). Hostname by default.
+#wsrep_node_name=###NODE-NAME###
+wsrep_node_name=galera000
+
+# INITIAL SETUP
+# Base replication <address|hostname>[:port] of the node.
+# The values supplied will be used as defaults for state transfer receiving,
+# listening ports and so on. Default: address of the first network interface.
+wsrep_node_address=###NODE-ADDRESS###
+
+# INITIAL SETUP
+# Address for incoming client connections. Autodetect by default.
+wsrep_node_incoming_address=###NODE-ADDRESS###
+
+# Number of threads that will process writesets from other nodes
+wsrep_slave_threads=1
+
+# Generate fake primary keys for non-PK tables (required for multi-master
+# and parallel applying operation)
+wsrep_certify_nonPK=1
+
+# Maximum number of rows in write set
+wsrep_max_ws_rows=131072
+
+# Maximum size of write set
+wsrep_max_ws_size=1073741824
+
+# Debug level logging (1 = enabled)
+wsrep_debug=1
+
+# Convert locking sessions into transactions
+wsrep_convert_LOCK_to_trx=0
+
+# Number of retries for deadlocked autocommits
+wsrep_retry_autocommit=1
+
+# Change auto_increment_increment and auto_increment_offset automatically
+wsrep_auto_increment_control=1
+
+# Retry autoinc insert, when the insert failed for "duplicate key error"
+wsrep_drupal_282555_workaround=0
+
+# Enable "strictly synchronous" semantics for read operations
+wsrep_causal_reads=0
+
+# Command to call when node status or cluster membership changes.
+# Will be passed all or some of the following options:
+# --status  - new status of this node
+# --uuid    - UUID of the cluster
+# --primary - whether the component is primary or not ("yes"/"no")
+# --members - comma-separated list of members
+# --index   - index of this node in the list
+wsrep_notify_cmd=
+
+##
+## WSREP State Transfer options
+##
+
+# State Snapshot Transfer method
+#wsrep_sst_method=mysqldump
+#wsrep_sst_method=xtrabackup
+wsrep_sst_method=rsync
+
+# INITIAL SETUP
+# Address which donor should send State Snapshot to.
+# Should be the address of the CURRENT node. DON'T SET IT TO DONOR ADDRESS!!!
+# (SST method dependent. Defaults to the first IP of the first interface)
+wsrep_sst_receive_address=###NODE-ADDRESS###
+
+# INITIAL SETUP
+# SST authentication string. This will be used to send SST to joining nodes.
+# Depends on SST method. For mysqldump method it is root:<root password>
+#wsrep_sst_auth=###REP-USERNAME###:###REP-PASSWORD###
+wsrep_sst_auth=repl:repl
+
+# Desired SST donor name.
+#wsrep_sst_donor=
+
+# Reject client queries when donating SST (false)
+#wsrep_sst_donor_rejects_queries=0
+
+# Protocol version to use
+# wsrep_protocol_version=

--- a/maxscale-system-test/mdbci/cnf/mysql56/galera_server2.cnf
+++ b/maxscale-system-test/mdbci/cnf/mysql56/galera_server2.cnf
@@ -1,0 +1,135 @@
+[mysqld]
+expire_logs_days=7
+user=mysql
+server_id=2
+
+# Row binary log format is required by Galera
+binlog_format=ROW
+
+log-bin
+
+# InnoDB is currently the only storage engine supported by Galera
+default-storage-engine=innodb
+innodb_file_per_table
+
+# To avoid issues with 'bulk mode inserts' using autoincrement fields
+innodb_autoinc_lock_mode=2
+
+# Required to prevent deadlocks on parallel transaction execution
+innodb_locks_unsafe_for_binlog=1
+
+# Query Cache is not supported by Galera wsrep replication
+query_cache_size=0
+query_cache_type=0
+
+# INITIAL SETUP
+# In some systems bind-address defaults to 127.0.0.1, and with mysqldump SST
+# it will have (most likely) disastrous consequences on donor node
+bind-address=###NODE-ADDRESS###
+
+##
+## WSREP options
+##
+
+# INITIAL SETUP
+# For the initial setup, wsrep should be disabled
+wsrep_provider=none
+# After initial setup, parameter should have full path to wsrep provider library
+wsrep_provider=###GALERA-LIB-PATH###
+
+# Provider specific configuration options
+wsrep_provider_options = "evs.keepalive_period = PT3S; evs.inactive_check_period = PT10S; evs.suspect_timeout = PT30S; evs.inactive_timeout = PT1M; evs.install_timeout = PT1M"
+
+# Logical cluster name. Should be the same for all nodes in the same cluster.
+wsrep_cluster_name=skycluster
+
+# INITIAL SETUP
+# Group communication system handle: for the first node to be launched, the value should be "gcomm://", indicating creation of a new cluster;
+# for the other nodes joining the cluster, the value should be "gcomm://xxx.xxx.xxx.xxx:4567", where xxx.xxx.xxx.xxx should be the ip of a node
+# already on the cluster (usually the first one)
+# DEPRECATED
+# wsrep_cluster_address=gcomm://
+
+# Human-readable node name (non-unique). Hostname by default.
+#wsrep_node_name=###NODE-NAME###
+wsrep_node_name=galera001
+
+# INITIAL SETUP
+# Base replication <address|hostname>[:port] of the node.
+# The values supplied will be used as defaults for state transfer receiving,
+# listening ports and so on. Default: address of the first network interface.
+wsrep_node_address=###NODE-ADDRESS###
+
+# INITIAL SETUP
+# Address for incoming client connections. Autodetect by default.
+wsrep_node_incoming_address=###NODE-ADDRESS###
+
+# Number of threads that will process writesets from other nodes
+wsrep_slave_threads=1
+
+# Generate fake primary keys for non-PK tables (required for multi-master
+# and parallel applying operation)
+wsrep_certify_nonPK=1
+
+# Maximum number of rows in write set
+wsrep_max_ws_rows=131072
+
+# Maximum size of write set
+wsrep_max_ws_size=1073741824
+
+# Debug level logging (1 = enabled)
+wsrep_debug=1
+
+# Convert locking sessions into transactions
+wsrep_convert_LOCK_to_trx=0
+
+# Number of retries for deadlocked autocommits
+wsrep_retry_autocommit=1
+
+# Change auto_increment_increment and auto_increment_offset automatically
+wsrep_auto_increment_control=1
+
+# Retry autoinc insert, when the insert failed for "duplicate key error"
+wsrep_drupal_282555_workaround=0
+
+# Enable "strictly synchronous" semantics for read operations
+wsrep_causal_reads=0
+
+# Command to call when node status or cluster membership changes.
+# Will be passed all or some of the following options:
+# --status  - new status of this node
+# --uuid    - UUID of the cluster
+# --primary - whether the component is primary or not ("yes"/"no")
+# --members - comma-separated list of members
+# --index   - index of this node in the list
+wsrep_notify_cmd=
+
+##
+## WSREP State Transfer options
+##
+
+# State Snapshot Transfer method
+#wsrep_sst_method=mysqldump
+#wsrep_sst_method=xtrabackup
+wsrep_sst_method=rsync
+
+# INITIAL SETUP
+# Address which donor should send State Snapshot to.
+# Should be the address of the CURRENT node. DON'T SET IT TO DONOR ADDRESS!!!
+# (SST method dependent. Defaults to the first IP of the first interface)
+wsrep_sst_receive_address=###NODE-ADDRESS###
+
+# INITIAL SETUP
+# SST authentication string. This will be used to send SST to joining nodes.
+# Depends on SST method. For mysqldump method it is root:<root password>
+#wsrep_sst_auth=###REP-USERNAME###:###REP-PASSWORD###
+wsrep_sst_auth=repl:repl
+
+# Desired SST donor name.
+#wsrep_sst_donor=
+
+# Reject client queries when donating SST (false)
+#wsrep_sst_donor_rejects_queries=0
+
+# Protocol version to use
+# wsrep_protocol_version=

--- a/maxscale-system-test/mdbci/cnf/mysql56/galera_server3.cnf
+++ b/maxscale-system-test/mdbci/cnf/mysql56/galera_server3.cnf
@@ -1,0 +1,135 @@
+[mysqld]
+expire_logs_days=7
+user=mysql
+server_id=3
+
+# Row binary log format is required by Galera
+binlog_format=ROW
+
+log-bin
+
+# InnoDB is currently the only storage engine supported by Galera
+default-storage-engine=innodb
+innodb_file_per_table
+
+# To avoid issues with 'bulk mode inserts' using autoincrement fields
+innodb_autoinc_lock_mode=2
+
+# Required to prevent deadlocks on parallel transaction execution
+innodb_locks_unsafe_for_binlog=1
+
+# Query Cache is not supported by Galera wsrep replication
+query_cache_size=0
+query_cache_type=0
+
+# INITIAL SETUP
+# In some systems bind-address defaults to 127.0.0.1, and with mysqldump SST
+# it will have (most likely) disastrous consequences on donor node
+bind-address=###NODE-ADDRESS###
+
+##
+## WSREP options
+##
+
+# INITIAL SETUP
+# For the initial setup, wsrep should be disabled
+wsrep_provider=none
+# After initial setup, parameter should have full path to wsrep provider library
+wsrep_provider=###GALERA-LIB-PATH###
+
+# Provider specific configuration options
+wsrep_provider_options = "evs.keepalive_period = PT3S; evs.inactive_check_period = PT10S; evs.suspect_timeout = PT30S; evs.inactive_timeout = PT1M; evs.install_timeout = PT1M"
+
+# Logical cluster name. Should be the same for all nodes in the same cluster.
+wsrep_cluster_name=skycluster
+
+# INITIAL SETUP
+# Group communication system handle: for the first node to be launched, the value should be "gcomm://", indicating creation of a new cluster;
+# for the other nodes joining the cluster, the value should be "gcomm://xxx.xxx.xxx.xxx:4567", where xxx.xxx.xxx.xxx should be the ip of a node
+# already on the cluster (usually the first one)
+# DEPRECATED
+# wsrep_cluster_address=gcomm://
+
+# Human-readable node name (non-unique). Hostname by default.
+#wsrep_node_name=###NODE-NAME###
+wsrep_node_name=galera002
+
+# INITIAL SETUP
+# Base replication <address|hostname>[:port] of the node.
+# The values supplied will be used as defaults for state transfer receiving,
+# listening ports and so on. Default: address of the first network interface.
+wsrep_node_address=###NODE-ADDRESS###
+
+# INITIAL SETUP
+# Address for incoming client connections. Autodetect by default.
+wsrep_node_incoming_address=###NODE-ADDRESS###
+
+# Number of threads that will process writesets from other nodes
+wsrep_slave_threads=1
+
+# Generate fake primary keys for non-PK tables (required for multi-master
+# and parallel applying operation)
+wsrep_certify_nonPK=1
+
+# Maximum number of rows in write set
+wsrep_max_ws_rows=131072
+
+# Maximum size of write set
+wsrep_max_ws_size=1073741824
+
+# Debug level logging (1 = enabled)
+wsrep_debug=1
+
+# Convert locking sessions into transactions
+wsrep_convert_LOCK_to_trx=0
+
+# Number of retries for deadlocked autocommits
+wsrep_retry_autocommit=1
+
+# Change auto_increment_increment and auto_increment_offset automatically
+wsrep_auto_increment_control=1
+
+# Retry autoinc insert, when the insert failed for "duplicate key error"
+wsrep_drupal_282555_workaround=0
+
+# Enable "strictly synchronous" semantics for read operations
+wsrep_causal_reads=0
+
+# Command to call when node status or cluster membership changes.
+# Will be passed all or some of the following options:
+# --status  - new status of this node
+# --uuid    - UUID of the cluster
+# --primary - whether the component is primary or not ("yes"/"no")
+# --members - comma-separated list of members
+# --index   - index of this node in the list
+wsrep_notify_cmd=
+
+##
+## WSREP State Transfer options
+##
+
+# State Snapshot Transfer method
+#wsrep_sst_method=mysqldump
+#wsrep_sst_method=xtrabackup
+wsrep_sst_method=rsync
+
+# INITIAL SETUP
+# Address which donor should send State Snapshot to.
+# Should be the address of the CURRENT node. DON'T SET IT TO DONOR ADDRESS!!!
+# (SST method dependent. Defaults to the first IP of the first interface)
+wsrep_sst_receive_address=###NODE-ADDRESS###
+
+# INITIAL SETUP
+# SST authentication string. This will be used to send SST to joining nodes.
+# Depends on SST method. For mysqldump method it is root:<root password>
+#wsrep_sst_auth=###REP-USERNAME###:###REP-PASSWORD###
+wsrep_sst_auth=repl:repl
+
+# Desired SST donor name.
+#wsrep_sst_donor=
+
+# Reject client queries when donating SST (false)
+#wsrep_sst_donor_rejects_queries=0
+
+# Protocol version to use
+# wsrep_protocol_version=

--- a/maxscale-system-test/mdbci/cnf/mysql56/galera_server4.cnf
+++ b/maxscale-system-test/mdbci/cnf/mysql56/galera_server4.cnf
@@ -1,0 +1,135 @@
+[mysqld]
+expire_logs_days=7
+user=mysql
+server_id=4
+
+# Row binary log format is required by Galera
+binlog_format=ROW
+
+log-bin
+
+# InnoDB is currently the only storage engine supported by Galera
+default-storage-engine=innodb
+innodb_file_per_table
+
+# To avoid issues with 'bulk mode inserts' using autoincrement fields
+innodb_autoinc_lock_mode=2
+
+# Required to prevent deadlocks on parallel transaction execution
+innodb_locks_unsafe_for_binlog=1
+
+# Query Cache is not supported by Galera wsrep replication
+query_cache_size=0
+query_cache_type=0
+
+# INITIAL SETUP
+# In some systems bind-address defaults to 127.0.0.1, and with mysqldump SST
+# it will have (most likely) disastrous consequences on donor node
+bind-address=###NODE-ADDRESS###
+
+##
+## WSREP options
+##
+
+# INITIAL SETUP
+# For the initial setup, wsrep should be disabled
+wsrep_provider=none
+# After initial setup, parameter should have full path to wsrep provider library
+wsrep_provider=###GALERA-LIB-PATH###
+
+# Provider specific configuration options
+wsrep_provider_options = "evs.keepalive_period = PT3S; evs.inactive_check_period = PT10S; evs.suspect_timeout = PT30S; evs.inactive_timeout = PT1M; evs.install_timeout = PT1M"
+
+# Logical cluster name. Should be the same for all nodes in the same cluster.
+wsrep_cluster_name=skycluster
+
+# INITIAL SETUP
+# Group communication system handle: for the first node to be launched, the value should be "gcomm://", indicating creation of a new cluster;
+# for the other nodes joining the cluster, the value should be "gcomm://xxx.xxx.xxx.xxx:4567", where xxx.xxx.xxx.xxx should be the ip of a node
+# already on the cluster (usually the first one)
+# DEPRECATED
+# wsrep_cluster_address=gcomm://
+
+# Human-readable node name (non-unique). Hostname by default.
+#wsrep_node_name=###NODE-NAME###
+wsrep_node_name=galera003
+
+# INITIAL SETUP
+# Base replication <address|hostname>[:port] of the node.
+# The values supplied will be used as defaults for state transfer receiving,
+# listening ports and so on. Default: address of the first network interface.
+wsrep_node_address=###NODE-ADDRESS###
+
+# INITIAL SETUP
+# Address for incoming client connections. Autodetect by default.
+wsrep_node_incoming_address=###NODE-ADDRESS###
+
+# Number of threads that will process writesets from other nodes
+wsrep_slave_threads=1
+
+# Generate fake primary keys for non-PK tables (required for multi-master
+# and parallel applying operation)
+wsrep_certify_nonPK=1
+
+# Maximum number of rows in write set
+wsrep_max_ws_rows=131072
+
+# Maximum size of write set
+wsrep_max_ws_size=1073741824
+
+# Debug level logging (1 = enabled)
+wsrep_debug=1
+
+# Convert locking sessions into transactions
+wsrep_convert_LOCK_to_trx=0
+
+# Number of retries for deadlocked autocommits
+wsrep_retry_autocommit=1
+
+# Change auto_increment_increment and auto_increment_offset automatically
+wsrep_auto_increment_control=1
+
+# Retry autoinc insert, when the insert failed for "duplicate key error"
+wsrep_drupal_282555_workaround=0
+
+# Enable "strictly synchronous" semantics for read operations
+wsrep_causal_reads=0
+
+# Command to call when node status or cluster membership changes.
+# Will be passed all or some of the following options:
+# --status  - new status of this node
+# --uuid    - UUID of the cluster
+# --primary - whether the component is primary or not ("yes"/"no")
+# --members - comma-separated list of members
+# --index   - index of this node in the list
+wsrep_notify_cmd=
+
+##
+## WSREP State Transfer options
+##
+
+# State Snapshot Transfer method
+#wsrep_sst_method=mysqldump
+#wsrep_sst_method=xtrabackup
+wsrep_sst_method=rsync
+
+# INITIAL SETUP
+# Address which donor should send State Snapshot to.
+# Should be the address of the CURRENT node. DON'T SET IT TO DONOR ADDRESS!!!
+# (SST method dependent. Defaults to the first IP of the first interface)
+wsrep_sst_receive_address=###NODE-ADDRESS###
+
+# INITIAL SETUP
+# SST authentication string. This will be used to send SST to joining nodes.
+# Depends on SST method. For mysqldump method it is root:<root password>
+#wsrep_sst_auth=###REP-USERNAME###:###REP-PASSWORD###
+wsrep_sst_auth=repl:repl
+
+# Desired SST donor name.
+#wsrep_sst_donor=
+
+# Reject client queries when donating SST (false)
+#wsrep_sst_donor_rejects_queries=0
+
+# Protocol version to use
+# wsrep_protocol_version=

--- a/maxscale-system-test/mdbci/cnf/mysql56/server1.cnf
+++ b/maxscale-system-test/mdbci/cnf/mysql56/server1.cnf
@@ -1,0 +1,39 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+#log-basename=mar
+log-bin=mar-bin
+#binlog-format=row
+binlog-format=STATEMENT
+server_id=1
+#slave_parallel_threads=2
+user=mysql
+## x001
+#max_long_data_size=1000000000
+#innodb_log_file_size=2000000000
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/mysql56/server10.cnf
+++ b/maxscale-system-test/mdbci/cnf/mysql56/server10.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+#log-basename=mar
+log-bin=mar-bin
+#binlog-format=row
+binlog-format=STATEMENT
+server_id=10
+#slave_parallel_threads=2
+user=mysql
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/mysql56/server11.cnf
+++ b/maxscale-system-test/mdbci/cnf/mysql56/server11.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+#log-basename=mar
+log-bin=mar-bin
+#binlog-format=row
+binlog-format=STATEMENT
+server_id=11
+#slave_parallel_threads=2
+user=mysql
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/mysql56/server12.cnf
+++ b/maxscale-system-test/mdbci/cnf/mysql56/server12.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+#log-basename=mar
+log-bin=mar-bin
+#binlog-format=row
+binlog-format=STATEMENT
+server_id=12
+#slave_parallel_threads=2
+user=mysql
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/mysql56/server13.cnf
+++ b/maxscale-system-test/mdbci/cnf/mysql56/server13.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+#log-basename=mar
+log-bin=mar-bin
+#binlog-format=row
+binlog-format=STATEMENT
+server_id=13
+#slave_parallel_threads=2
+user=mysql
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/mysql56/server14.cnf
+++ b/maxscale-system-test/mdbci/cnf/mysql56/server14.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+#log-basename=mar
+log-bin=mar-bin
+#binlog-format=row
+binlog-format=STATEMENT
+server_id=14
+#slave_parallel_threads=2
+user=mysql
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/mysql56/server15.cnf
+++ b/maxscale-system-test/mdbci/cnf/mysql56/server15.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+#log-basename=mar
+log-bin=mar-bin
+#binlog-format=row
+binlog-format=STATEMENT
+server_id=15
+#slave_parallel_threads=2
+user=mysql
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/mysql56/server2.cnf
+++ b/maxscale-system-test/mdbci/cnf/mysql56/server2.cnf
@@ -1,0 +1,39 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+#log-basename=mar
+log-bin=mar-bin
+#binlog-format=row
+binlog-format=STATEMENT
+server_id=2
+#slave_parallel_threads=2
+user=mysql
+## x001
+#max_long_data_size=1000000000
+#innodb_log_file_size=2000000000
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/mysql56/server3.cnf
+++ b/maxscale-system-test/mdbci/cnf/mysql56/server3.cnf
@@ -1,0 +1,39 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+#log-basename=mar
+log-bin=mar-bin
+#binlog-format=row
+binlog-format=STATEMENT
+server_id=3
+#slave_parallel_threads=2
+user=mysql
+## x001
+#max_long_data_size=1000000000
+#innodb_log_file_size=2000000000
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/mysql56/server4.cnf
+++ b/maxscale-system-test/mdbci/cnf/mysql56/server4.cnf
@@ -1,0 +1,39 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+#log-basename=mar
+log-bin=mar-bin
+#binlog-format=row
+binlog-format=STATEMENT
+server_id=4
+#slave_parallel_threads=2
+user=mysql
+## x001
+#max_long_data_size=1000000000
+#innodb_log_file_size=2000000000
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/mysql56/server5.cnf
+++ b/maxscale-system-test/mdbci/cnf/mysql56/server5.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+#log-basename=mar
+log-bin=mar-bin
+#binlog-format=row
+binlog-format=STATEMENT
+server_id=5
+#slave_parallel_threads=2
+user=mysql
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/mysql56/server6.cnf
+++ b/maxscale-system-test/mdbci/cnf/mysql56/server6.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+#log-basename=mar
+log-bin=mar-bin
+#binlog-format=row
+binlog-format=STATEMENT
+server_id=6
+#slave_parallel_threads=2
+user=mysql
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/mysql56/server7.cnf
+++ b/maxscale-system-test/mdbci/cnf/mysql56/server7.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+#log-basename=mar
+log-bin=mar-bin
+#binlog-format=row
+binlog-format=STATEMENT
+server_id=7
+#slave_parallel_threads=2
+user=mysql
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/mysql56/server8.cnf
+++ b/maxscale-system-test/mdbci/cnf/mysql56/server8.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+#log-basename=mar
+log-bin=mar-bin
+#binlog-format=row
+binlog-format=STATEMENT
+server_id=8
+#slave_parallel_threads=2
+user=mysql
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/mysql56/server9.cnf
+++ b/maxscale-system-test/mdbci/cnf/mysql56/server9.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+#log-basename=mar
+log-bin=mar-bin
+#binlog-format=row
+binlog-format=STATEMENT
+server_id=9
+#slave_parallel_threads=2
+user=mysql
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/server1.cnf
+++ b/maxscale-system-test/mdbci/cnf/server1.cnf
@@ -1,0 +1,39 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+log-slave-updates
+log-bin=mar-bin
+binlog-format=row
+binlog_row_image=full
+server_id=1
+user=mysql
+## x001
+max_long_data_size=1000000000
+innodb_log_file_size=2000000000
+slave-skip-errors=all
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/server10.cnf
+++ b/maxscale-system-test/mdbci/cnf/server10.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+log-slave-updates
+log-bin=mar-bin
+binlog-format=STATEMENT
+server_id=10
+user=mysql
+## x001
+slave-skip-errors=all
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/server11.cnf
+++ b/maxscale-system-test/mdbci/cnf/server11.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+log-slave-updates
+log-bin=mar-bin
+binlog-format=STATEMENT
+server_id=11
+user=mysql
+## x001
+slave-skip-errors=all
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/server12.cnf
+++ b/maxscale-system-test/mdbci/cnf/server12.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+log-slave-updates
+log-bin=mar-bin
+binlog-format=STATEMENT
+server_id=12
+user=mysql
+## x001
+slave-skip-errors=all
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/server13.cnf
+++ b/maxscale-system-test/mdbci/cnf/server13.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+log-slave-updates
+log-bin=mar-bin
+binlog-format=STATEMENT
+server_id=13
+user=mysql
+## x001
+slave-skip-errors=all
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/server14.cnf
+++ b/maxscale-system-test/mdbci/cnf/server14.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+log-slave-updates
+log-bin=mar-bin
+binlog-format=STATEMENT
+server_id=14
+user=mysql
+## x001
+slave-skip-errors=all
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/server15.cnf
+++ b/maxscale-system-test/mdbci/cnf/server15.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+log-slave-updates
+log-bin=mar-bin
+binlog-format=STATEMENT
+server_id=15
+user=mysql
+## x001
+slave-skip-errors=all
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/server2.cnf
+++ b/maxscale-system-test/mdbci/cnf/server2.cnf
@@ -1,0 +1,39 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+log-slave-updates
+log-bin=mar-bin
+binlog-format=row
+binlog_row_image=full
+server_id=2
+user=mysql
+## x001
+max_long_data_size=1000000000
+innodb_log_file_size=2000000000
+slave-skip-errors=all
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/server3.cnf
+++ b/maxscale-system-test/mdbci/cnf/server3.cnf
@@ -1,0 +1,39 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+log-slave-updates
+log-bin=mar-bin
+binlog-format=row
+binlog_row_image=full
+server_id=3
+user=mysql
+## x001
+max_long_data_size=1000000000
+innodb_log_file_size=2000000000
+slave-skip-errors=all
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/server4.cnf
+++ b/maxscale-system-test/mdbci/cnf/server4.cnf
@@ -1,0 +1,39 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+log-slave-updates
+log-bin=mar-bin
+binlog-format=row
+binlog_row_image=full
+server_id=4
+user=mysql
+## x001
+max_long_data_size=1000000000
+innodb_log_file_size=2000000000
+slave-skip-errors=all
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/server5.cnf
+++ b/maxscale-system-test/mdbci/cnf/server5.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+log-slave-updates
+log-bin=mar-bin
+binlog-format=STATEMENT
+server_id=5
+user=mysql
+## x001
+slave-skip-errors=all
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/server6.cnf
+++ b/maxscale-system-test/mdbci/cnf/server6.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+log-slave-updates
+log-bin=mar-bin
+binlog-format=STATEMENT
+server_id=6
+user=mysql
+## x001
+slave-skip-errors=all
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/server7.cnf
+++ b/maxscale-system-test/mdbci/cnf/server7.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+log-slave-updates
+log-bin=mar-bin
+binlog-format=STATEMENT
+server_id=7
+user=mysql
+## x001
+slave-skip-errors=all
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/server8.cnf
+++ b/maxscale-system-test/mdbci/cnf/server8.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+log-slave-updates
+log-bin=mar-bin
+binlog-format=STATEMENT
+server_id=8
+user=mysql
+## x001
+slave-skip-errors=all
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/cnf/server9.cnf
+++ b/maxscale-system-test/mdbci/cnf/server9.cnf
@@ -1,0 +1,36 @@
+
+#
+# These groups are read by MariaDB server.
+# Use it for options that only the server (but not clients) should see
+#
+# See the examples of server my.cnf files in /usr/share/mysql/
+#
+
+# this is read by the standalone daemon and embedded servers
+[server]
+
+# this is only for the mysqld standalone daemon
+[mysqld]
+log-slave-updates
+log-bin=mar-bin
+binlog-format=STATEMENT
+server_id=9
+user=mysql
+## x001
+slave-skip-errors=all
+
+# this is only for embedded server
+[embedded]
+
+# This group is only read by MariaDB-5.5 servers.
+# If you use the same .cnf file for MariaDB of different versions,
+# use this group for options that older servers don't understand
+[mysqld-5.5]
+
+# These two groups are only read by MariaDB servers, not by MySQL.
+# If you use the same .cnf file for MySQL and MariaDB,
+# you can put MariaDB-only options here
+[mariadb]
+
+[mariadb-5.5]
+

--- a/maxscale-system-test/mdbci/configure_backend.sh
+++ b/maxscale-system-test/mdbci/configure_backend.sh
@@ -1,0 +1,9 @@
+. ${script_dir}/set_env.sh $name
+
+${script_dir}/backend/setup_repl.sh
+${script_dir}/backend/galera/setup_galera.sh
+
+${script_dir}/configure_core.sh
+
+rm ~/vagrant_lock
+

--- a/maxscale-system-test/mdbci/configure_core.sh
+++ b/maxscale-system-test/mdbci/configure_core.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -x
+
+ssh -i $maxscale_sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $maxscale_access_user@$maxscale_IP '$maxscale_access_sudo service iptables stop'
+
+ssh -i $maxscale_sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $maxscale_access_user@$maxscale_IP "$maxscale_access_sudo mkdir ccore; $maxscale_access_sudo chown $maxscale_access_user ccore"
+
+scp -i $maxscale_sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ${script_dir}/add_core_cnf.sh $maxscale_access_user@$maxscale_IP:./ccore/
+ssh -i $maxscale_sshkey -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no $maxscale_access_user@$maxscale_IP "$maxscale_access_sudo /home/$maxscale_access_user/ccore/add_core_cnf.sh"
+
+set +x

--- a/maxscale-system-test/mdbci/configure_log_dir.sh
+++ b/maxscale-system-test/mdbci/configure_log_dir.sh
@@ -1,0 +1,15 @@
+set -x
+LOGS_DIR=${logs_dir:-$HOME/LOGS}
+echo $JOB_NAME | grep "/"
+if [ $? == 0 ] ; then
+        export job_name_buildID=`echo $JOB_NAME | sed "s|/|-$BUILD_NUMBER/|"`
+        export logs_publish_dir="${LOGS_DIR}/${job_name_buildID}/"
+else
+        export logs_publish_dir="${LOGS_DIR}/${JOB_NAME}-${BUILD_NUMBER}"
+fi
+
+export job_name_buildID=`echo ${JOB_NAME} | sed "s|/|-${BUILD_NUMBER}/|"`
+export logs_publish_dir="${LOGS_DIR}/${job_name_buildID}-${BUILD_NUMBER}"
+echo "Logs go to ${logs_publish_dir}"
+mkdir -p ${logs_publish_dir}
+

--- a/maxscale-system-test/mdbci/copy_logs.sh
+++ b/maxscale-system-test/mdbci/copy_logs.sh
@@ -1,0 +1,5 @@
+set -x
+rsync -a --no-o --no-g LOGS ${logs_publish_dir}
+chmod a+r ${logs_publish_dir}/*
+cp -r ${MDBCI_VM_PATH}/$name ${logs_publish_dir}
+cp  ${MDBCI_VM_PATH}/${name}.json ${logs_publish_dir}

--- a/maxscale-system-test/mdbci/create_config.sh
+++ b/maxscale-system-test/mdbci/create_config.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -x
+export dir=`pwd`
+
+# read the name of build scripts directory
+export script_dir="$(dirname $(readlink -f $0))"
+
+. ${script_dir}/set_run_test_variables.sh
+
+${mdbci_dir}/repository-config/generate_all.sh repo.d
+${mdbci_dir}/repository-config/maxscale-ci.sh $target repo.d
+
+
+export repo_dir=$dir/repo.d/
+
+export provider=`${mdbci_dir}/mdbci show provider $box --silent 2> /dev/null`
+export backend_box=${backend_box:-"centos_7_"$provider}
+
+if [ "$product" == "mysql" ] ; then
+  export cnf_path=${script_dir}/cnf/mysql56
+fi
+
+mkdir -p ${MDBCI_VM_PATH}/$name
+cd ${MDBCI_VM_PATH}/$name
+vagrant destroy -f
+cd $dir
+
+mkdir ${MDBCI_VM_PATH}/$name/cnf
+cp -r ${cnf_path}/* ${MDBCI_VM_PATH}/$name/cnf/
+export cnd_path="${MDBCI_VM_PATH}/$name/cnf/"
+
+  eval "cat <<EOF
+$(<${script_dir}/templates/${template}.json.template)
+" 2> /dev/null > ${MDBCI_VM_PATH}/${name}.json
+
+${mdbci_dir}/mdbci --override --template  ${MDBCI_VM_PATH}/${name}.json --repo-dir ${repo_dir} generate $name
+
+while [ -f ~/vagrant_lock ]
+do
+	echo "vagrant is locked, waiting ..."
+	sleep 5
+done
+touch ~/vagrant_lock
+echo ${JOB_NAME}-${BUILD_NUMBER} >> ~/vagrant_lock
+
+echo "running vagrant up $provider"
+
+${mdbci_dir}/mdbci up $name --attempts 3
+if [ $? != 0 ]; then
+	echo "Error creating configuration"
+	rm ~/vagrant_lock
+	exit 1
+fi
+
+cp ~/build-scripts/team_keys .
+${mdbci_dir}/mdbci public_keys --key ${team_keys} $name
+
+rm ~/vagrant_lock
+exit 0

--- a/maxscale-system-test/mdbci/destroy.sh
+++ b/maxscale-system-test/mdbci/destroy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+dir=`pwd`
+cd ${MDBCI_VM_PATH}/${name}
+vagrant destroy -f
+cd $dir
+
+rm -rf 	${MDBCI_VM_PATH}/${name}
+rm -rf 	${MDBCI_VM_PATH}/${name}.json
+rm -rf 	${MDBCI_VM_PATH}/${name}_network_config	

--- a/maxscale-system-test/mdbci/revert_snapshot.sh
+++ b/maxscale-system-test/mdbci/revert_snapshot.sh
@@ -1,0 +1,5 @@
+export curr_dir=`pwd`
+cd $HOME/mdbci
+$HOME/mdbci/mdbci snapshot revert --path-to-nodes $1 --snapshot-name $2
+cd $curr_dir
+

--- a/maxscale-system-test/mdbci/run_test.sh
+++ b/maxscale-system-test/mdbci/run_test.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# see set_run_test_variables.sh for default values of all variables
+
+# $box - Name of Vagrant box for Maxscale machine
+# see lists of supported boxes
+# https://github.com/mariadb-corporation/mdbci/tree/integration/BOXES
+
+# $template - name of MDBCI json template file 
+# Template file have to be in ./templates/, file name
+# have to be '$template.json.template
+# Template file can contain references to any variables -
+# all ${variable_name} will be replaced with values
+
+# $name - name of test run. It can be any string of leytters or digits
+# If it is not defined, name will be automatically genereted 
+# using $box and current date and time
+
+# $ci_url - URL to Maxscale CI repository 
+# (default "http://max-tst-01.mariadb.com/ci-repository/")
+# if build is done also locally and binaries are not uploaded to
+# max-tst-01.mariadb.com $ci_url should toint to local web server
+# e.g. http://192.168.122.1/repository (IP should be a host IP in the 
+# virtual network (not 127.0.0.1))
+
+# $product - 'mariadb' or 'mysql'
+
+# $version - version of backend DB (e.g. '10.1', '10.2')
+
+# $galera_version - version of Galera backend DB 
+# same as $version by default 
+
+# $target - name of binary repository 
+# (name of subdirectroy http://max-tst-01.mariadb.com/ci-repository/)
+
+# $team_keys - path to the file with open ssh keys to be 
+# installed on all VMs (default ${HOME}/team_keys)
+
+# $don_not_destroy_vm - if 'yes' VM won't be destored afther the test
+
+# $test_set - parameters to be send to 'ctest' (e.g. '-I 1,100',
+# '-LE UNSTABLE'
+
+export vm_memory=${vm_memory:-"2048"}
+export dir=`pwd`
+
+ulimit -n
+
+# read the name of build scripts directory
+export script_dir="$(dirname $(readlink -f $0))"
+
+. ${script_dir}/set_run_test_variables.sh
+
+rm -rf LOGS
+
+export target=`echo $target | sed "s/?//g"`
+export name=`echo $name | sed "s/?//g"`
+
+. ${script_dir}/configure_log_dir.sh
+
+cd maxscale-system-test
+
+cmake . -DBUILDNAME=$name -DCMAKE_BUILD_TYPE=Debug
+make
+
+${script_dir}/create_config.sh
+res=$?
+
+if [ $res == 0 ] ; then
+    . ${script_dir}/configure_backend.sh
+    ${mdbci_dir}/mdbci snapshot take --path-to-nodes $name --snapshot-name clean
+
+    if [ -z "${named_test}" ] ; then
+        ./${named_test}
+    else
+        ./check_backend
+        if [ $? != 0 ]; then
+            echo "Backend broken!"
+            if [ "${do_not_destroy_vm}" != "yes" ] ; then
+                ${script_dir}/destroy.sh       
+            fi
+            rm ~/vagrant_lock
+            exit 1
+        fi
+        ctest -VV -D Nightly ${test_set}
+    fi
+
+    cd $dir
+    ${script_dir}/copy_logs.sh
+else
+  echo "Failed to create VMs, exiting"
+  if [ "${do_not_destroy_vm}" != "yes" ] ; then
+	${script_dir}/destroy.sh
+  fi
+  rm ~/vagrant_lock
+  exit 1
+fi
+
+if [ "${do_not_destroy_vm}" != "yes" ] ; then
+	${script_dir}/destroy.sh
+	echo "clean up done!"
+fi
+

--- a/maxscale-system-test/mdbci/run_test_snapshot.sh
+++ b/maxscale-system-test/mdbci/run_test_snapshot.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+function checkExitStatus {
+    returnCode=$1
+    errorMessage=$2
+    lockFilePath=$3
+    if [ "$returnCode" != 0 ]; then
+        echo "$errorMesage"
+        rm $lockFilePath
+        echo "Snapshot lock file was deleted due to an error"
+        exit 1
+    fi     
+}
+
+set -x
+export dir=`pwd`
+
+# read the name of build scripts directory
+export script_dir="$(dirname $(readlink -f $0))"
+
+. ${script_dir}/set_run_test_variables.sh
+export name="$box-$product-$version-permanent"
+
+export snapshot_name=${snapshot_name:-"clean"}
+
+rm -rf LOGS
+
+export target=`echo $target | sed "s/?//g"`
+export name=`echo $name | sed "s/?//g"`
+
+. ${script_dir}/configure_log_dir.sh
+
+# Setting snapshot_lock
+export snapshot_lock_file=${MDBCI_VM_PATH}/${name}_snapshot_lock
+if [ -f ${snapshot_lock_file} ]; then
+    echo "Snapshot is locked, waiting ..."
+fi
+while [ -f ${snapshot_lock_file} ]
+do
+	sleep 5
+done
+
+touch ${snapshot_lock_file}
+echo $JOB_NAME-$BUILD_NUMBER >> ${snapshot_lock_file}
+
+export repo_dir=$dir/repo.d/
+
+${mdbci_dir}/mdbci snapshot revert --path-to-nodes $name --snapshot-name $snapshot_name
+
+if [ $? != 0 ]; then
+	${script_dir}/destroy.sh
+	${MDBCI_VM_PATH}/scripts/clean_vms.sh $name
+
+	${script_dir}/create_config.sh
+       checkExitStatus $? "Error creating configuration" $snapshot_lock_file
+       . ${script_dir}/configure_backend.sh
+    
+	echo "Creating snapshot from new config"
+	$HOME/mdbci/mdbci snapshot take --path-to-nodes $name --snapshot-name $snapshot_name
+fi
+
+. ${script_dir}/set_env.sh "$name"
+
+${mdbci_dir}/repository-config/maxscale-ci.sh $target repo.d
+
+
+${mdbci_dir}/mdbci sudo --command 'yum remove maxscale -y' $name/maxscale
+${mdbci_dir}/mdbci sudo --command 'yum clean all' $name/maxscale
+
+${mdbci_dir}/mdbci setup_repo --product maxscale $name/maxscale --repo-dir $repo_dir 
+${mdbci_dir}/mdbci install_product --product maxscale $name/maxscale --repo-dir $repo_dir
+
+checkExitStatus $? "Error installing Maxscale" $snapshot_lock_file
+
+cd ${script_dir}/..
+
+cmake . -DBUILDNAME=$JOB_NAME-$BUILD_NUMBER-$target
+make
+
+./check_backend --restart-galera
+
+checkExitStatus $? "Failed to check backends" $snapshot_lock_file
+
+ctest $test_set -VV -D Nightly
+
+cd $dir
+${script_dir}/copy_logs.sh
+
+# Removing snapshot_lock
+rm ${snapshot_lock_file}
+

--- a/maxscale-system-test/mdbci/set_env.sh
+++ b/maxscale-system-test/mdbci/set_env.sh
@@ -1,0 +1,97 @@
+set -x
+echo $*
+export MDBCI_VM_PATH=${MDBCI_VM_PATH:-$HOME/vms}
+export mdbci_dir=${mdbci_dir:-"$HOME/mdbci/"}
+export script_dir="$(dirname $(readlink -f $0))"
+
+export config_name="$1"
+if [ -z $1 ] ; then
+	config_name="test1"
+fi
+
+export curr_dir=`pwd`
+
+export maxscale_binlog_dir="/var/lib/maxscale/Binlog_Service"
+export maxdir="/usr/bin/"
+export maxdir_bin="/usr/bin/"
+export maxscale_cnf="/etc/maxscale.cnf"
+export maxscale_log_dir="/var/log/maxscale/"
+
+# Number of nodes
+export galera_N=`cat "$MDBCI_VM_PATH/$config_name"_network_config | grep galera | grep network | wc -l`
+export node_N=`cat "$MDBCI_VM_PATH/$config_name"_network_config | grep node | grep network | wc -l`
+sed "s/^/export /g" "$MDBCI_VM_PATH/$config_name"_network_config > "$curr_dir"/"$config_name"_network_config_export
+source "$curr_dir"/"$config_name"_network_config_export
+
+# IP Of MaxScale machine
+export maxscale_IP=$maxscale_network
+export maxscale_sshkey=$maxscale_keyfile
+
+# User name and Password for Master/Slave replication setup (should have all PRIVILEGES)
+export node_user="skysql"
+export node_password="skysql"
+
+# User name and Password for Galera setup (should have all PRIVILEGES)
+export galera_user="skysql"
+export galera_password="skysql"
+
+export maxscale_user="skysql"
+export maxscale_password="skysql"
+
+export maxadmin_password="mariadb"
+
+for prefix in "node" "galera"
+do
+	N_var="$prefix"_N
+	Nx=${!N_var}
+	N=`expr $Nx - 1`
+	for i in $(seq 0 $N)
+	do
+		num=`printf "%03d" $i`
+		eval 'export "$prefix"_"$num"_port=3306'
+		eval 'export "$prefix"_"$num"_access_sudo=sudo'
+
+		start_cmd_var="$prefix"_"$num"_start_db_command
+		stop_cmd_var="$prefix"_"$num"_stop_db_command
+		mysql_exe=`${mdbci_dir}/mdbci ssh --command 'ls /etc/init.d/mysql* 2> /dev/null | tr -cd "[:print:]"' $config_name/node_$num  --silent 2> /dev/null`
+		echo $mysql_exe | grep -i "mysql"
+		if [ $? != 0 ] ; then
+			service_name=`${mdbci_dir}/mdbci ssh --command 'systemctl list-unit-files | grep mysql' $config_name/node_$num  --silent`
+			echo $service_name | grep mysql
+			if [ $? == 0 ] ; then
+				echo $service_name | grep mysqld
+				if [ $? == 0 ] ; then
+		                        eval 'export $start_cmd_var="service mysqld start "'
+	        	                eval 'export $stop_cmd_var="service mysqld stop  "'
+				else
+	                        	eval 'export $start_cmd_var="service mysql start "'
+	        	                eval 'export $stop_cmd_var="service mysql stop  "'
+				fi
+			else
+				${mdbci_dir}/mdbci ssh --command 'echo \"/usr/sbin/mysqld \$* 2> stderr.log > stdout.log &\" > mysql_start.sh; echo \"sleep 20\" >> mysql_start.sh; echo \"disown\" >> mysql_start.sh; chmod a+x mysql_start.sh' $config_name/node_$num --silent
+        	                eval 'export $start_cmd_var="/home/$au/mysql_start.sh "'
+				eval 'export $start_cmd_var="killall mysqld "'
+			fi
+		else
+			eval 'export $start_cmd_var="$mysql_exe start "'
+			eval 'export $stop_cmd_var="$mysql_exe stop "'
+		fi
+
+		eval 'export "$prefix"_"$num"_start_vm_command="cd $mdbci_dir/$config_name;vagrant up node_$num --provider=$provider; cd $curr_dir"'
+		eval 'export "$prefix"_"$num"_kill_vm_command="cd $mdbci_dir/$config_name;vagrant halt node_$num --provider=$provider; cd $curr_dir"'
+	done
+done
+
+export maxscale_access_user=$maxscale_whoami
+export maxscale_access_sudo="sudo "
+
+# Sysbench directory (should be sysbench >= 0.5)
+export sysbench_dir=${sysbench_dir:-"$HOME/sysbench_deb7/sysbench/"}
+
+export ssl=true
+
+export take_snapshot_command="${script_dir}/take_snapshot.sh $config_name"
+export revert_snapshot_command="${script_dir}/revert_snapshot.sh $config_name"
+#export use_snapshots=yes
+
+set +x

--- a/maxscale-system-test/mdbci/set_run_test_variables.sh
+++ b/maxscale-system-test/mdbci/set_run_test_variables.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+
+export MDBCI_VM_PATH=${MDBCI_VM_PATH:-$HOME/vms}
+mkdir -p $MDBCI_VM_PATH
+echo "MDBCI_VM_PATH=$MDBCI_VM_PATH"
+
+export box=${box:-"centos_7_libvirt"}
+echo "box=$box"
+
+export template=${template:-"default"}
+
+export curr_date=`date '+%Y-%m-%d_%H-%M'`
+
+export name=${name:-$box-${curr_date}}
+
+export mdbci_dir=${mdbci_dir:-"$HOME/mdbci/"}
+export ci_url=${ci_url:-"http://max-tst-01.mariadb.com/ci-repository/"}
+
+export product=${product:-"mariadb"}
+export version=${version:-"10.2"}
+export target=${target:-"develop"}
+export vm_memory=${vm_memory:-"2048"}
+export cnf_path=${script_dir}/cnf
+export JOB_NAME=${JOB_NAME:-"local_test"}
+export BUILD_NUMBER=${BUILD_NUMBER:-`date '+%Y%m%d%H%M'`}
+export BUILD_TAG=${BUILD_TAG:-jenkins-${JOB_NAME}-${BUILD_NUMBER}}
+export team_keys=${team_keys:-${HOME}/team_keys}
+export galera_version=${galera_version:-$version}
+export do_not_destroy_vm=${do_not_destroy_vm:-"no"}
+#export test_set=${test_set:-"-LE UNSTABLE"}
+export test_set=${test_set:-"-I 1,5"}

--- a/maxscale-system-test/mdbci/take_snapshot.sh
+++ b/maxscale-system-test/mdbci/take_snapshot.sh
@@ -1,0 +1,5 @@
+export curr_dir=`pwd`
+cd $HOME/mdbci
+$HOME/mdbci/mdbci snapshot take --path-to-nodes $1 --snapshot-name $2
+cd $curr_dir
+

--- a/maxscale-system-test/mdbci/templates/big.json.template
+++ b/maxscale-system-test/mdbci/templates/big.json.template
@@ -1,0 +1,152 @@
+{
+  "node_000" :
+  {
+        "hostname" : "node000",
+        "box" : "centos_7_aws_large",
+	"product" : {
+      		"name": "###product###",
+		"version": "###version###",
+                "cnf_template" : "server1.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+	}
+
+  },
+
+  "node_001" :
+  {
+        "hostname" : "node001",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "###product###",
+                "version": "###version###",
+                "cnf_template" : "server2.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+
+  "node_002" :
+  {
+        "hostname" : "node002",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "###product###",
+                "version": "###version###",
+                "cnf_template" : "server3.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+
+  "node_003" :
+  {
+        "hostname" : "node003",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "###product###",
+                "version": "###version###",
+                "cnf_template" : "server4.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+  "node_004" :
+  {
+        "hostname" : "node004",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "###product###",
+                "version": "###version###",
+                "cnf_template" : "server5.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+  "node_005" :
+  {
+        "hostname" : "node005",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "###product###",
+                "version": "###version###",
+                "cnf_template" : "server6.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+  "node_006" :
+  {
+        "hostname" : "node006",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "###product###",
+                "version": "###version###",
+                "cnf_template" : "server7.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+  "node_007" :
+  {
+        "hostname" : "node007",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "###product###",
+                "version": "###version###",
+                "cnf_template" : "server8.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+
+  "galera_000" :
+  {
+        "hostname" : "galera000",
+        "box" : "centos_7_aws",
+        "product" : {
+                "name": "galera",
+                "version": "###galera_version###",
+                "cnf_template" : "galera_server1.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+
+  "galera_001" :
+  {
+        "hostname" : "galera001",
+        "box" : "centos_7_aws",
+        "product" : {
+                "name": "galera",
+                "version": "###galera_version###",
+                "cnf_template" : "galera_server2.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+
+  "galera_002" :
+  {
+        "hostname" : "galera002",
+        "box" : "centos_7_aws",
+        "product" : {
+                "name": "galera",
+                "version": "###galera_version###",
+                "cnf_template" : "galera_server3.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+
+  "galera_003" :
+  {
+        "hostname" : "galera003",
+        "box" : "centos_7_aws",
+        "product" : {
+                "name": "galera",
+                "version": "###galera_version###",
+                "cnf_template" : "galera_server4.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+
+  "maxscale" :
+  {
+        "hostname" : "maxscale",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "maxscale"
+        }
+
+  }
+}

--- a/maxscale-system-test/mdbci/templates/big15.json.template
+++ b/maxscale-system-test/mdbci/templates/big15.json.template
@@ -1,0 +1,229 @@
+{
+  "node_000" :
+  {
+        "hostname" : "node_000",
+        "box" : "centos_7_aws_large",
+	"product" : {
+      		"name": "###product###",
+		"version": "###version###",
+                "cnf_template" : "server1.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+	}
+
+  },
+
+  "node_001" :
+  {
+        "hostname" : "node_001",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "###product###",
+                "version": "###version###",
+                "cnf_template" : "server2.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+
+  "node_002" :
+  {
+        "hostname" : "node_002",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "###product###",
+                "version": "###version###",
+                "cnf_template" : "server3.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+
+  "node_003" :
+  {
+        "hostname" : "node_003",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "###product###",
+                "version": "###version###",
+                "cnf_template" : "server4.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+  "node_004" :
+  {
+        "hostname" : "node_004",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "###product###",
+                "version": "###version###",
+                "cnf_template" : "server5.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+  "node_005" :
+  {
+        "hostname" : "node_005",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "###product###",
+                "version": "###version###",
+                "cnf_template" : "server6.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+  "node_006" :
+  {
+        "hostname" : "node_006",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "###product###",
+                "version": "###version###",
+                "cnf_template" : "server7.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+  "node_007" :
+  {
+        "hostname" : "node_007",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "###product###",
+                "version": "###version###",
+                "cnf_template" : "server8.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+  "node_008" :
+  {
+        "hostname" : "node_008",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "###product###",
+                "version": "###version###",
+                "cnf_template" : "server9.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+  "node_009" :
+  {
+        "hostname" : "node_009",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "###product###",
+                "version": "###version###",
+                "cnf_template" : "server10.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+  "node_0010" :
+  {
+        "hostname" : "node_0010",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "###product###",
+                "version": "###version###",
+                "cnf_template" : "server11.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+  "node_0011" :
+  {
+        "hostname" : "node_0011",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "###product###",
+                "version": "###version###",
+                "cnf_template" : "server12.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+  "node_0012" :
+  {
+        "hostname" : "node_0012",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "###product###",
+                "version": "###version###",
+                "cnf_template" : "server13.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+  "node_0013" :
+  {
+        "hostname" : "node_0013",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "###product###",
+                "version": "###version###",
+                "cnf_template" : "server14.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+  "node_0014" :
+  {
+        "hostname" : "node_0014",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "###product###",
+                "version": "###version###",
+                "cnf_template" : "server15.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+
+  "galera_000" :
+  {
+        "hostname" : "galera_000",
+        "box" : "centos_7_aws",
+        "product" : {
+                "name": "galera",
+                "version": "###galera_version###",
+                "cnf_template" : "galera_server1.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+
+  "galera_001" :
+  {
+        "hostname" : "galera_001",
+        "box" : "centos_7_aws",
+        "product" : {
+                "name": "galera",
+                "version": "###galera_version###",
+                "cnf_template" : "galera_server2.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+
+  "galera_002" :
+  {
+        "hostname" : "galera_002",
+        "box" : "centos_7_aws",
+        "product" : {
+                "name": "galera",
+                "version": "###galera_version###",
+                "cnf_template" : "galera_server3.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+
+  "galera_003" :
+  {
+        "hostname" : "galera_003",
+        "box" : "centos_7_aws",
+        "product" : {
+                "name": "galera",
+                "version": "###galera_version###",
+                "cnf_template" : "galera_server4.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+
+  "maxscale" :
+  {
+        "hostname" : "maxscale",
+        "box" : "centos_7_aws_large",
+        "product" : {
+                "name": "maxscale"
+        }
+
+  }
+}

--- a/maxscale-system-test/mdbci/templates/default.json.template
+++ b/maxscale-system-test/mdbci/templates/default.json.template
@@ -1,0 +1,117 @@
+{
+  "node_000" :
+  {
+        "hostname" : "node000",
+        "box" : "${backend_box}",
+        "memory_size" : "${vm_memory}",
+	"product" : {
+      		"name": "${product}",
+		"version": "${version}",
+                "cnf_template" : "server1.cnf",
+                "cnf_template_path": "${cnf_path}"
+	}
+
+  },
+
+  "node_001" :
+  {
+        "hostname" : "node001",
+        "box" : "${backend_box}",
+        "memory_size" : "${vm_memory}",
+        "product" : {
+                "name": "${product}",
+                "version": "${version}",
+                "cnf_template" : "server2.cnf",
+                "cnf_template_path": "${cnf_path}"
+        }
+  },
+
+  "node_002" :
+  {
+        "hostname" : "node002",
+        "box" : "${backend_box}",
+        "memory_size" : "${vm_memory}",
+        "product" : {
+                "name": "${product}",
+                "version": "${version}",
+                "cnf_template" : "server3.cnf",
+                "cnf_template_path": "${cnf_path}"
+        }
+  },
+
+  "node_003" :
+  {
+        "hostname" : "node003",
+        "box" : "${backend_box}",
+        "memory_size" : "${vm_memory}",
+        "product" : {
+                "name": "${product}",
+                "version": "${version}",
+                "cnf_template" : "server4.cnf",
+                "cnf_template_path": "${cnf_path}"
+        }
+  },
+
+  "galera_000" :
+  {
+        "hostname" : "galera000",
+        "box" : "${backend_box}",
+        "memory_size" : "${vm_memory}",
+        "product" : {
+                "name": "galera",
+                "version": "${galera_version}",
+                "cnf_template" : "galera_server1.cnf",
+                "cnf_template_path": "${cnf_path}"
+        }
+  },
+
+  "galera_001" :
+  {
+        "hostname" : "galera001",
+        "box" : "${backend_box}",
+        "memory_size" : "${vm_memory}",
+        "product" : {
+                "name": "galera",
+                "version": "${galera_version}",
+                "cnf_template" : "galera_server2.cnf",
+                "cnf_template_path": "${cnf_path}"
+        }
+  },
+
+  "galera_002" :
+  {
+        "hostname" : "galera002",
+        "box" : "${backend_box}",
+        "memory_size" : "${vm_memory}",
+        "product" : {
+                "name": "galera",
+                "version": "${galera_version}",
+                "cnf_template" : "galera_server3.cnf",
+                "cnf_template_path": "${cnf_path}"
+        }
+  },
+
+  "galera_003" :
+  {
+        "hostname" : "galera003",
+        "box" : "${backend_box}",
+        "memory_size" : "${vm_memory}",
+        "product" : {
+                "name": "galera",
+                "version": "${galera_version}",
+                "cnf_template" : "galera_server4.cnf",
+                "cnf_template_path": "${cnf_path}"
+        }
+  },
+
+  "maxscale" :
+  {
+        "hostname" : "maxscale",
+        "box" : "${box}",
+        "memory_size" : "${vm_memory}",
+        "product" : {
+                "name": "maxscale"
+        }
+
+  }
+}

--- a/maxscale-system-test/mdbci/templates/performance.json.template
+++ b/maxscale-system-test/mdbci/templates/performance.json.template
@@ -1,0 +1,67 @@
+{
+
+###nodes###
+
+  "galera_000" :
+  {
+        "hostname" : "galera000",
+        "box" : "centos_7_libvirt",
+        "memory_size" : "2048",
+        "product" : {
+                "name": "galera",
+                "version": "###galera_version###",
+                "cnf_template" : "galera_server1.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+
+  "galera_001" :
+  {
+        "hostname" : "galera001",
+        "box" : "centos_7_libvirt",
+        "memory_size" : "2048",
+        "product" : {
+                "name": "galera",
+                "version": "###galera_version###",
+                "cnf_template" : "galera_server2.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+
+  "galera_002" :
+  {
+        "hostname" : "galera002",
+        "box" : "centos_7_libvirt",
+        "memory_size" : "2048",
+        "product" : {
+                "name": "galera",
+                "version": "###galera_version###",
+                "cnf_template" : "galera_server3.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+
+  "galera_003" :
+  {
+        "hostname" : "galera003",
+        "box" : "centos_7_libvirt",
+        "memory_size" : "2048",
+        "product" : {
+                "name": "galera",
+                "version": "###galera_version###",
+                "cnf_template" : "galera_server4.cnf",
+                "cnf_template_path": "~/build-scripts/test-setup-scripts/cnf"
+        }
+  },
+
+  "maxscale" :
+  {
+        "hostname" : "maxscale",
+        "box" : "###box###",
+        "memory_size" : "2048",
+        "product" : {
+                "name": "maxscale"
+        }
+
+  }
+}


### PR DESCRIPTION
run_test* scripts are moved to MaxScale repo (ro maxscale-system-test/mdbci directory).

run_test.sh can be executed without any parameters, in this case it will run test for default distro, 'develop' binary, template etc. 
