### PR TITLE
fix condition for named test

### DIFF
--- a/maxscale-system-test/mdbci/revert_snapshot.sh
+++ b/maxscale-system-test/mdbci/revert_snapshot.sh
@@ -1,5 +1,0 @@
-export curr_dir=`pwd`
-cd $HOME/mdbci
-$HOME/mdbci/mdbci snapshot revert --path-to-nodes $1 --snapshot-name $2
-cd $curr_dir
-

--- a/maxscale-system-test/mdbci/run_test.sh
+++ b/maxscale-system-test/mdbci/run_test.sh
@@ -70,7 +70,7 @@ if [ $res == 0 ] ; then
     . ${script_dir}/configure_backend.sh
     ${mdbci_dir}/mdbci snapshot take --path-to-nodes $name --snapshot-name clean
 
-    if [ -z "${named_test}" ] ; then
+    if [ ! -z "${named_test}" ] ; then
         ./${named_test}
     else
         ./check_backend

--- a/maxscale-system-test/mdbci/set_env.sh
+++ b/maxscale-system-test/mdbci/set_env.sh
@@ -90,8 +90,8 @@ export sysbench_dir=${sysbench_dir:-"$HOME/sysbench_deb7/sysbench/"}
 
 export ssl=true
 
-export take_snapshot_command="${script_dir}/take_snapshot.sh $config_name"
-export revert_snapshot_command="${script_dir}/revert_snapshot.sh $config_name"
+export take_snapshot_command="${mdbci_dir}/mdbci snapshot take --path-to-nodes $name --snapshot-name "
+export revert_snapshot_command="${mdbci_dir}/mdbci snapshot revert --path-to-nodes $name --snapshot-name "
 #export use_snapshots=yes
 
 set +x

--- a/maxscale-system-test/mdbci/take_snapshot.sh
+++ b/maxscale-system-test/mdbci/take_snapshot.sh
@@ -1,5 +1,0 @@
-export curr_dir=`pwd`
-cd $HOME/mdbci
-$HOME/mdbci/mdbci snapshot take --path-to-nodes $1 --snapshot-name $2
-cd $curr_dir
-


### PR DESCRIPTION
fixed bug in run_test.sh: condition for running namedtest was wrong 
revert_snashot.sh and take_snapshot.sh are removed (no need to do any 'cd' now take and revert commands are one line now, no need to script)