### PR TITLE
MXS-1603:Get trx status from ok packet through SESSION_TRACK_TRANSACTION_STATE mechanism

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "editor.fontSize": 16,
+    "files.associations": {
+        "typeinfo": "c"
+    },
+}

--- a/Documentation/Release-Notes/MaxScale-2.2.1-Release-Notes.md
+++ b/Documentation/Release-Notes/MaxScale-2.2.1-Release-Notes.md
@@ -1,4 +1,4 @@
-# MariaDB MaxScale 2.2.1 Release Notes
+# MariaDB MaxScale 2.2.1 Release Notes -- 2018-01-11
 
 Release 2.2.1 is a Beta release.
 

--- a/include/maxscale/buffer.h
+++ b/include/maxscale/buffer.h
@@ -59,6 +59,7 @@ typedef enum
     GWBUF_TYPE_IGNORABLE       = 0x10,
     GWBUF_TYPE_COLLECT_RESULT  = 0x20,
     GWBUF_TYPE_RESULT          = 0x40,
+    GWBUF_TYPE_REPLY_OK        = 0x80,
 } gwbuf_type_t;
 
 #define GWBUF_IS_TYPE_UNDEFINED(b)       (b->gwbuf_type == 0)
@@ -68,6 +69,7 @@ typedef enum
 #define GWBUF_IS_IGNORABLE(b)            (b->gwbuf_type & GWBUF_TYPE_IGNORABLE)
 #define GWBUF_IS_COLLECTED_RESULT(b)     (b->gwbuf_type & GWBUF_TYPE_RESULT)
 #define GWBUF_SHOULD_COLLECT_RESULT(b)   (b->gwbuf_type & GWBUF_TYPE_COLLECT_RESULT)
+#define GWBUF_IS_REPLY_OK(b)             (b->gwbuf_type & GWBUF_TYPE_REPLY_OK)
 
 typedef enum
 {

--- a/include/maxscale/config.h
+++ b/include/maxscale/config.h
@@ -54,16 +54,17 @@ MXS_BEGIN_DECLS
 #define MXS_JSON_PTR_RELATIONSHIPS_FILTERS  "/data/relationships/filters/data"
 
 /** Parameter value JSON Pointers */
-#define MXS_JSON_PTR_PARAM_PORT                  MXS_JSON_PTR_PARAMETERS "/port"
-#define MXS_JSON_PTR_PARAM_ADDRESS               MXS_JSON_PTR_PARAMETERS "/address"
-#define MXS_JSON_PTR_PARAM_PROTOCOL              MXS_JSON_PTR_PARAMETERS "/protocol"
-#define MXS_JSON_PTR_PARAM_AUTHENTICATOR         MXS_JSON_PTR_PARAMETERS "/authenticator"
-#define MXS_JSON_PTR_PARAM_AUTHENTICATOR_OPTIONS MXS_JSON_PTR_PARAMETERS "/authenticator_options"
-#define MXS_JSON_PTR_PARAM_SSL_KEY               MXS_JSON_PTR_PARAMETERS "/ssl_key"
-#define MXS_JSON_PTR_PARAM_SSL_CERT              MXS_JSON_PTR_PARAMETERS "/ssl_cert"
-#define MXS_JSON_PTR_PARAM_SSL_CA_CERT           MXS_JSON_PTR_PARAMETERS "/ssl_ca_cert"
-#define MXS_JSON_PTR_PARAM_SSL_VERSION           MXS_JSON_PTR_PARAMETERS "/ssl_version"
-#define MXS_JSON_PTR_PARAM_SSL_CERT_VERIFY_DEPTH MXS_JSON_PTR_PARAMETERS "/ssl_cert_verify_depth"
+#define MXS_JSON_PTR_PARAM_PORT                    MXS_JSON_PTR_PARAMETERS "/port"
+#define MXS_JSON_PTR_PARAM_ADDRESS                 MXS_JSON_PTR_PARAMETERS "/address"
+#define MXS_JSON_PTR_PARAM_PROTOCOL                MXS_JSON_PTR_PARAMETERS "/protocol"
+#define MXS_JSON_PTR_PARAM_AUTHENTICATOR           MXS_JSON_PTR_PARAMETERS "/authenticator"
+#define MXS_JSON_PTR_PARAM_AUTHENTICATOR_OPTIONS   MXS_JSON_PTR_PARAMETERS "/authenticator_options"
+#define MXS_JSON_PTR_PARAM_SSL_KEY                 MXS_JSON_PTR_PARAMETERS "/ssl_key"
+#define MXS_JSON_PTR_PARAM_SSL_CERT                MXS_JSON_PTR_PARAMETERS "/ssl_cert"
+#define MXS_JSON_PTR_PARAM_SSL_CA_CERT             MXS_JSON_PTR_PARAMETERS "/ssl_ca_cert"
+#define MXS_JSON_PTR_PARAM_SSL_VERSION             MXS_JSON_PTR_PARAMETERS "/ssl_version"
+#define MXS_JSON_PTR_PARAM_SSL_CERT_VERIFY_DEPTH   MXS_JSON_PTR_PARAMETERS "/ssl_cert_verify_depth"
+#define MXS_JSON_PTR_PARAM_SESSION_TRACK_TRX_STATE MXS_JSON_PTR_PARAMETERS "/session_track_trx_state"
 
 /** Non-parameter JSON pointers */
 #define MXS_JSON_PTR_MODULE   "/data/attributes/module"

--- a/include/maxscale/listener.h
+++ b/include/maxscale/listener.h
@@ -49,6 +49,7 @@ typedef struct servlistener
     SPINLOCK lock;
     int active;                /**< True if the port has not been deleted */
     struct  servlistener *next; /**< Next service protocol */
+    bool session_track_trx_state; /** Get transation state from backend */
 } SERV_LISTENER; // TODO: Rename to LISTENER
 
 typedef struct listener_iterator
@@ -79,7 +80,7 @@ json_t* listener_to_json(const SERV_LISTENER* listener);
 
 SERV_LISTENER* listener_alloc(struct service* service, const char* name, const char *protocol,
                               const char *address, unsigned short port, const char *authenticator,
-                              const char* auth_options, SSL_LISTENER *ssl);
+                              const char* auth_options, SSL_LISTENER *ssl, bool get_trx_state_from_backend);
 void listener_free(SERV_LISTENER* listener);
 int listener_set_ssl_version(SSL_LISTENER *ssl_listener, char* version);
 void listener_set_certificates(SSL_LISTENER *ssl_listener, char* cert, char* key, char* ca_cert);

--- a/include/maxscale/protocol/mysql.h
+++ b/include/maxscale/protocol/mysql.h
@@ -118,6 +118,20 @@ MXS_BEGIN_DECLS
 #define COM_QUIT_PACKET_SIZE (4+1)
 struct dcb;
 
+typedef enum  
+{
+  TX_EMPTY        =   0,  ///< "none of the below"
+  TX_EXPLICIT     =   1,  ///< an explicit transaction is active
+  TX_IMPLICIT     =   2,  ///< an implicit transaction is active
+  TX_READ_TRX     =   4,  ///<     transactional reads  were done
+  TX_READ_UNSAFE  =   8,  ///< non-transaction   reads  were done
+  TX_WRITE_TRX    =  16,  ///<     transactional writes were done
+  TX_WRITE_UNSAFE =  32,  ///< non-transactional writes were done
+  TX_STMT_UNSAFE  =  64,  ///< "unsafe" (non-deterministic like UUID()) stmts
+  TX_RESULT_SET   = 128,  ///< result-set was sent
+  TX_WITH_SNAPSHOT= 256,  ///< WITH CONSISTENT SNAPSHOT was used
+  TX_LOCKED_TABLES= 512   ///< LOCK TABLES is active
+} mysql_tx_state_t;
 
 typedef enum
 {
@@ -339,6 +353,7 @@ typedef struct
     int                    ignore_replies;               /*< How many replies should be discarded */
     GWBUF*                 stored_query;                 /*< Temporarily stored queries */
     bool                   collect_result;               /*< Collect the next result set as one buffer */
+    bool                   session_track_trx_state;      /*< Get transation state from backend */
 #if defined(SS_DEBUG)
     skygw_chk_t            protocol_chk_tail;
 #endif
@@ -478,6 +493,8 @@ char* create_auth_fail_str(char *username, char *hostaddr, bool password, char *
 void init_response_status(GWBUF* buf, uint8_t cmd, int* npackets, size_t* nbytes);
 bool read_complete_packet(DCB *dcb, GWBUF **readbuf);
 bool gw_get_shared_session_auth_info(DCB* dcb, MYSQL_session* session);
+void mxs_mysql_get_session_track_info(GWBUF *buff, uint32_t server_capabilities);
+mysql_tx_state_t parse_trx_state(char *str);
 
 /**
  * Decode server handshake

--- a/maxscale-system-test/testconnections.h
+++ b/maxscale-system-test/testconnections.h
@@ -53,6 +53,26 @@ public:
     ~TestConnections();
 
     /**
+     * @brief Is the test still ok?
+     *
+     * @return True, if no errors have occurred, false otherwise.
+     */
+    bool ok() const
+    {
+        return global_result == 0;
+    }
+
+    /**
+     * @brief Has the test failed?
+     *
+     * @return True, if errors have occurred, false otherwise.
+     */
+    bool failed() const
+    {
+        return global_result != 0;
+    }
+
+    /**
      * @brief global_result Result of test, 0 if PASSED
      */
     int global_result;

--- a/server/core/config.cc
+++ b/server/core/config.cc
@@ -147,6 +147,7 @@ const char CN_USER[]                          = "user";
 const char CN_USERS[]                         = "users";
 const char CN_VERSION_STRING[]                = "version_string";
 const char CN_WEIGHTBY[]                      = "weightby";
+const char CN_SESSION_TRACK_TRX_STATE[]    = "session_track_trx_state";
 
 typedef struct duplicate_context
 {
@@ -233,6 +234,7 @@ const char *config_listener_params[] =
     CN_SSL_VERSION,
     CN_SSL_CERT_VERIFY_DEPTH,
     CN_SSL_VERIFY_PEER_CERTIFICATE,
+    CN_SESSION_TRACK_TRX_STATE,
     NULL
 };
 
@@ -3368,8 +3370,7 @@ int create_new_listener(CONFIG_CONTEXT *obj)
     char *protocol = config_get_value(obj->parameters, CN_PROTOCOL);
     char *socket = config_get_value(obj->parameters, CN_SOCKET);
     char *authenticator = config_get_value(obj->parameters, CN_AUTHENTICATOR);
-    char *authenticator_options = config_get_value(obj->parameters, CN_AUTHENTICATOR_OPTIONS);
-
+    bool session_track_trx_state = config_get_bool(obj->parameters, CN_SESSION_TRACK_TRX_STATE);
     if (raw_service_name && protocol && (socket || port))
     {
         char service_name[strlen(raw_service_name) + 1];
@@ -3391,7 +3392,7 @@ int create_new_listener(CONFIG_CONTEXT *obj)
                 else
                 {
                     serviceCreateListener(service, obj->object, protocol, socket, 0,
-                                          authenticator, authenticator_options, ssl_info);
+                                          authenticator, authenticator_options, ssl_info, session_track_trx_state);
                 }
             }
 
@@ -3408,7 +3409,7 @@ int create_new_listener(CONFIG_CONTEXT *obj)
                 else
                 {
                     serviceCreateListener(service, obj->object, protocol, address, atoi(port),
-                                          authenticator, authenticator_options, ssl_info);
+                                          authenticator, authenticator_options, ssl_info, session_track_trx_state);
                 }
             }
 

--- a/server/core/config.cc
+++ b/server/core/config.cc
@@ -3370,6 +3370,7 @@ int create_new_listener(CONFIG_CONTEXT *obj)
     char *protocol = config_get_value(obj->parameters, CN_PROTOCOL);
     char *socket = config_get_value(obj->parameters, CN_SOCKET);
     char *authenticator = config_get_value(obj->parameters, CN_AUTHENTICATOR);
+    char *authenticator_options = config_get_value(obj->parameters, CN_AUTHENTICATOR_OPTIONS);
     bool session_track_trx_state = config_get_bool(obj->parameters, CN_SESSION_TRACK_TRX_STATE);
     if (raw_service_name && protocol && (socket || port))
     {

--- a/server/core/config_runtime.cc
+++ b/server/core/config_runtime.cc
@@ -795,7 +795,7 @@ bool runtime_create_listener(SERVICE *service, const char *name, const char *add
                              const char *port, const char *proto, const char *auth,
                              const char *auth_opt, const char *ssl_key,
                              const char *ssl_cert, const char *ssl_ca,
-                             const char *ssl_version, const char *ssl_depth)
+                             const char *ssl_version, const char *ssl_depth, bool session_track_trx_state)
 {
 
     if (addr == NULL || strcasecmp(addr, CN_DEFAULT) == 0)
@@ -842,7 +842,7 @@ bool runtime_create_listener(SERVICE *service, const char *name, const char *add
         {
             const char *print_addr = addr ? addr : "::";
             SERV_LISTENER *listener = serviceCreateListener(service, name, proto, addr,
-                                                            u_port, auth, auth_opt, ssl);
+                                                            u_port, auth, auth_opt, ssl, session_track_trx_state);
 
             if (listener && listener_serialize(listener))
             {
@@ -1961,11 +1961,12 @@ bool runtime_create_listener_from_json(SERVICE* service, json_t* json)
         const char* ssl_ca_cert = get_string_or_null(json, MXS_JSON_PTR_PARAM_SSL_CA_CERT);
         const char* ssl_version = get_string_or_null(json, MXS_JSON_PTR_PARAM_SSL_VERSION);
         const char* ssl_cert_verify_depth = get_string_or_null(json, MXS_JSON_PTR_PARAM_SSL_CERT_VERIFY_DEPTH);
+        bool session_track_trx_state = is_bool_or_null(json, MXS_JSON_PTR_PARAM_SESSION_TRACK_TRX_STATE);
 
         rval = runtime_create_listener(service, id, address, port.c_str(), protocol,
                                        authenticator, authenticator_options,
                                        ssl_key, ssl_cert, ssl_ca_cert, ssl_version,
-                                       ssl_cert_verify_depth);
+                                       ssl_cert_verify_depth, session_track_trx_state);
     }
 
     return rval;

--- a/server/core/internal/config_runtime.h
+++ b/server/core/internal/config_runtime.h
@@ -166,7 +166,8 @@ bool runtime_create_listener(SERVICE *service, const char *name, const char *add
                              const char *port, const char *proto, const char *auth,
                              const char *auth_opt, const char *ssl_key,
                              const char *ssl_cert, const char *ssl_ca,
-                             const char *ssl_version, const char *ssl_depth);
+                             const char *ssl_version, const char *ssl_depth,
+                             bool session_track_trx_state);
 
 /**
  * @brief Destroy a listener

--- a/server/core/internal/service.h
+++ b/server/core/internal/service.h
@@ -84,7 +84,7 @@ bool service_thread_init();
 SERV_LISTENER* serviceCreateListener(SERVICE *service, const char *name,
                                      const char *protocol, const char *address,
                                      unsigned short port, const char *authenticator,
-                                     const char *options, SSL_LISTENER *ssl);
+                                     const char *options, SSL_LISTENER *ssl, bool session_track_trx_state);
 
 void serviceRemoveBackend(SERVICE *service, const SERVER *server);
 

--- a/server/core/listener.cc
+++ b/server/core/listener.cc
@@ -62,7 +62,7 @@ static RSA *tmp_rsa_callback(SSL *s, int is_export, int keylength);
 SERV_LISTENER *
 listener_alloc(struct service* service, const char* name, const char *protocol,
                const char *address, unsigned short port, const char *authenticator,
-               const char* auth_options, SSL_LISTENER *ssl)
+               const char* auth_options, SSL_LISTENER *ssl, bool session_track_trx_state)
 {
     char *my_address = NULL;
     if (address)
@@ -135,6 +135,7 @@ listener_alloc(struct service* service, const char* name, const char *protocol,
     proto->users = NULL;
     proto->next = NULL;
     proto->auth_instance = auth_instance;
+    proto->session_track_trx_state = session_track_trx_state;
     spinlock_init(&proto->lock);
 
     return proto;

--- a/server/core/service.cc
+++ b/server/core/service.cc
@@ -755,10 +755,10 @@ static void service_add_listener(SERVICE* service, SERV_LISTENER* proto)
  */
 SERV_LISTENER* serviceCreateListener(SERVICE *service, const char *name, const char *protocol,
                                      const char *address, unsigned short port, const char *authenticator,
-                                     const char *options, SSL_LISTENER *ssl)
+                                     const char *options, SSL_LISTENER *ssl, bool session_track_trx_state)
 {
     SERV_LISTENER *proto = listener_alloc(service, name, protocol, address,
-                                          port, authenticator, options, ssl);
+                                          port, authenticator, options, ssl, session_track_trx_state);
 
     if (proto)
     {

--- a/server/core/test/test_service.cc
+++ b/server/core/test/test_service.cc
@@ -71,7 +71,7 @@ test1()
     ss_dfprintf(stderr, "\t..done\nAdding protocol testprotocol.");
     set_libdir(MXS_STRDUP_A("../../modules/authenticator/MySQLAuth/"));
     ss_info_dassert(serviceCreateListener(service, "TestProtocol", "testprotocol",
-                                          "localhost", 9876, "MySQLAuth", NULL, NULL),
+                                          "localhost", 9876, "MySQLAuth", NULL, NULL, false),
                     "Add Protocol should succeed");
     ss_info_dassert(0 != serviceHasListener(service, "TestProtocol", "testprotocol", "localhost", 9876),
                     "Service should have new protocol as requested");

--- a/server/modules/protocol/MySQL/mariadbbackend/mysql_backend.c
+++ b/server/modules/protocol/MySQL/mariadbbackend/mysql_backend.c
@@ -977,6 +977,8 @@ gw_read_and_write(DCB *dcb)
                 gwbuf_set_type(stmt, GWBUF_TYPE_RESULT);
             }
 
+            mxs_mysql_get_session_track_info(stmt, proto->server_capabilities);
+
             session->service->router->clientReply(session->service->router_instance,
                                                   session->router_session,
                                                   stmt, dcb);

--- a/server/modules/routing/debugcli/debugcmd.c
+++ b/server/modules/routing/debugcli/debugcmd.c
@@ -1169,7 +1169,7 @@ static void createListener(DCB *dcb, SERVICE *service, char *name, char *address
 {
     if (runtime_create_listener(service, name, address, port, protocol,
                                 authenticator, authenticator_options,
-                                key, cert, ca, version, depth))
+                                key, cert, ca, version, depth, false))
     {
         dcb_printf(dcb, "Listener '%s' created\n", name);
     }


### PR DESCRIPTION
1. parse session track info( autocommit  and transaction state) from ok packet in mysql_backend, and save it to gwbuf property;

2. when reply to client in mysql_client, mapping all the information provided by session track info to mxs_session_trx_state_t

3. add config parameter to enable/disable this behavior