### PR TITLE
add -fno-omit-frame-pointer to cflags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ configure_file(${CMAKE_SOURCE_DIR}/etc/upstart/maxscale.conf.in ${CMAKE_BINARY_D
 configure_file(${CMAKE_SOURCE_DIR}/test/maxscale_test.cnf ${CMAKE_BINARY_DIR}/maxscale.cnf @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/test/maxscale_test_secondary.cnf ${CMAKE_BINARY_DIR}/maxscale_secondary.cnf @ONLY)
 
-set(FLAGS "-rdynamic -Wall -Wno-unused-variable -Wno-unused-function -Werror -fPIC" CACHE STRING "Compilation flags")
+set(FLAGS "-rdynamic -fno-omit-frame-pointer -Wall -Wno-unused-variable -Wno-unused-function -Werror -fPIC" CACHE STRING "Compilation flags")
 set(DEBUG_FLAGS "-ggdb -pthread -pipe -Wformat -fstack-protector --param=ssp-buffer-size=4" CACHE STRING "Debug compilation flags")
 
 if(CMAKE_VERSION VERSION_GREATER 2.6)


### PR DESCRIPTION
-fomit-frame-pointer is enabled at gcc compile level  -O, -O2, -O3, -Os. , it is – a compiler optimization that makes little positive difference in the real world,  the impact on performance is negligible , but it breaks stack profilers. if it enabled,  we may get incomplete stacks, make it difficult to  use perf or other profiling tools.   Because on production env, when we do trouble shooting, or performance monitoring, full stack info will be very useful, so need reverted by add option -fno-omit-frame-pointer

ref: http://www.brendangregg.com/blog/2014-06-22/perf-cpu-sample.html

I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.

