### PR TITLE
init inst->sessions for maxinfo

### DIFF
--- a/server/modules/routing/maxinfo/maxinfo.c
+++ b/server/modules/routing/maxinfo/maxinfo.c
@@ -154,6 +154,7 @@ createInstance(SERVICE *service, char **options)
         return NULL;
     }
 
+    inst->sessions = NULL;
     inst->service = service;
     spinlock_init(&inst->lock);
 
@@ -173,7 +174,6 @@ createInstance(SERVICE *service, char **options)
     spinlock_acquire(&instlock);
     inst->next = instances;
     instances = inst;
-    inst->sessions = NULL;
     spinlock_release(&instlock);
 
     return (MXS_ROUTER *)inst;

--- a/server/modules/routing/maxinfo/maxinfo.c
+++ b/server/modules/routing/maxinfo/maxinfo.c
@@ -173,6 +173,7 @@ createInstance(SERVICE *service, char **options)
     spinlock_acquire(&instlock);
     inst->next = instances;
     instances = inst;
+    inst->sessions = NULL;
     spinlock_release(&instlock);
 
     return (MXS_ROUTER *)inst;


### PR DESCRIPTION
I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.

We encounter crash at 
```
      INFO_SESSION *ptr = inst->sessions;
        **while (ptr && ptr->next != session)**
        {
            ptr = ptr->next;
        }
        if (ptr)
        {
            ptr->next = session->next;
        }
    }
```
inst->sessions not init properly