### PR TITLE
MXS-1892: Support deprecate eof

### DIFF
--- a/include/maxscale/buffer.h
+++ b/include/maxscale/buffer.h
@@ -60,6 +60,9 @@ typedef enum
     GWBUF_TYPE_COLLECT_RESULT  = 0x20,
     GWBUF_TYPE_RESULT          = 0x40,
     GWBUF_TYPE_REPLY_OK        = 0x80,
+    GWBUF_TYPE_REPLY_EOF       = 0x100,
+    GWBUF_TYPE_REPLY_LAST      = 0x200,
+    GWBUF_TYPE_REPLY_LINFILE   = 0x400,
 } gwbuf_type_t;
 
 #define GWBUF_IS_TYPE_UNDEFINED(b)       (b->gwbuf_type == 0)
@@ -70,6 +73,9 @@ typedef enum
 #define GWBUF_IS_COLLECTED_RESULT(b)     (b->gwbuf_type & GWBUF_TYPE_RESULT)
 #define GWBUF_SHOULD_COLLECT_RESULT(b)   (b->gwbuf_type & GWBUF_TYPE_COLLECT_RESULT)
 #define GWBUF_IS_REPLY_OK(b)             (b->gwbuf_type & GWBUF_TYPE_REPLY_OK)
+#define GWBUF_IS_REPLY_EOF(b)            (b->gwbuf_type & GWBUF_TYPE_REPLY_EOF)
+#define GWBUF_IS_REPLY_LAST(b)           (b->gwbuf_type & GWBUF_TYPE_REPLY_LAST)
+#define GWBUF_IS_REPLY_LINFILE(b)        (b->gwbuf_type & GWBUF_TYPE_REPLY_LINFILE)
 
 typedef enum
 {

--- a/include/maxscale/protocol/mysql.h
+++ b/include/maxscale/protocol/mysql.h
@@ -449,6 +449,13 @@ static inline bool MYSQL_IS_CHANGE_USER(const uint8_t* header)
     return MYSQL_GET_COMMAND(header) == MXS_COM_CHANGE_USER;
 }
 
+static inline bool expecting_resultset(MySQLProtocol *proto)
+{
+    return proto->current_command == MXS_COM_QUERY ||
+           proto->current_command == MXS_COM_STMT_EXECUTE ||
+           proto->current_command == MXS_COM_STMT_BULK_EXECUTE;
+}
+
 /* The following can be compared using memcmp to detect a null password */
 extern uint8_t null_client_sha1[MYSQL_SCRAMBLE_LEN];
 
@@ -753,6 +760,16 @@ uint16_t mxs_mysql_parse_eof_packet(GWBUF *buff);
  */
 uint16_t mxs_mysql_parse_ok_packet(GWBUF *buff);
 
+/**
+ * @brief Determine reply packet type: is the last of reply, or is eof
+ *  or ok;
+ *
+ * @param proto MySQLProtocol, privide protocol state info
+ * @param queue multi complete packets, !!!Important, every buffer should
+ *      contain a complete packet, so need called after mxs_mysql_get_complete_packets
+ *
+ */
+void mxs_mysql_mark_packet_type(MySQLProtocol *proto, GWBUF *queue);
 /* Type of the kill-command sent by client. */
 typedef enum kill_type
 {

--- a/server/core/test/test_session_track.cc
+++ b/server/core/test/test_session_track.cc
@@ -164,86 +164,8 @@ static const uint8_t resultset3[] =
     0x00, 0x07, 0xFE, 0x00, 0x00, 0x21, 0x00
 };
 
-/* functional test , test packet by packet */
-void test1()
-{
-    GWBUF   *buffer;
-    proto.server_capabilities = GW_MYSQL_CAPABILITIES_SESSION_TRACK;
-    proto.num_eof_packets = 0;
-    ss_dfprintf(stderr, "test_session_track : Functional tests.\n");
-    //BEGIN
-    buffer = gwbuf_alloc_and_load(PACKET_1_LEN, resultset1 + PACKET_1_IDX);
-    mxs_mysql_get_session_track_info(buffer, &proto);
-    ss_dassert(strncmp(gwbuf_get_property(buffer, (char *)"trx_state"), "T_______", 8) == 0);
-    gwbuf_free(buffer);
-    //COMMIT
-    buffer = gwbuf_alloc_and_load(PACKET_2_LEN, resultset1 + PACKET_2_IDX);
-    mxs_mysql_get_session_track_info(buffer, &proto);
-    ss_dassert(strncmp(gwbuf_get_property(buffer, (char *)"trx_state"), "________", 8) == 0);
-    gwbuf_free(buffer);
-    //START TRANSACTION
-    buffer = gwbuf_alloc_and_load(PACKET_3_LEN, resultset1 + PACKET_3_IDX);
-    mxs_mysql_get_session_track_info(buffer, &proto);
-    ss_dassert(strncmp(gwbuf_get_property(buffer, (char *)"trx_state"), "T_______", 8) == 0);
-    gwbuf_free(buffer);
-    //START TRANSACTION READ ONLY
-    buffer = gwbuf_alloc_and_load(PACKET_4_LEN, resultset1 + PACKET_4_IDX);
-    mxs_mysql_get_session_track_info(buffer, &proto);
-    ss_dassert(strncmp(gwbuf_get_property(buffer, (char *)"trx_characteristics"),
-                       "START TRANSACTION READ ONLY;", 28) == 0);
-    gwbuf_free(buffer);
-    //COMMIT
-    buffer = gwbuf_alloc_and_load(PACKET_5_LEN, resultset1 + PACKET_5_IDX);
-    mxs_mysql_get_session_track_info(buffer, &proto);
-    ss_dassert(gwbuf_get_property(buffer, (char *)"trx_characteristics") == NULL);
-    ss_dassert(gwbuf_get_property(buffer, (char *)"trx_state") == NULL);
-    gwbuf_free(buffer);
-    //SET AUTOCOMMIT=0;
-    buffer = gwbuf_alloc_and_load(PACKET_6_LEN, resultset1 + PACKET_6_IDX);
-    mxs_mysql_get_session_track_info(buffer, &proto);
-    ss_dassert(strncmp(gwbuf_get_property(buffer, (char *)"autocommit"), "OFF", 3) == 0);
-    gwbuf_free(buffer);
-    //INSERT INTO t1 VALUES(1);
-    buffer = gwbuf_alloc_and_load(PACKET_7_LEN, resultset1 + PACKET_7_IDX);
-    mxs_mysql_get_session_track_info(buffer, &proto);
-    ss_dassert(strncmp(gwbuf_get_property(buffer, (char *)"trx_state"), "I___W___", 8) == 0);
-    gwbuf_free(buffer);
-    //COMMIT
-    buffer = gwbuf_alloc_and_load(PACKET_8_LEN, resultset1 + PACKET_8_IDX);
-    mxs_mysql_get_session_track_info(buffer, &proto);
-    ss_dassert(strncmp(gwbuf_get_property(buffer, (char *)"trx_state"), "________", 8) == 0);
-    gwbuf_free(buffer);
-}
-
-/* multi results combine in one buffer, test for check boundary handle properly */
-void test2()
-{
-    GWBUF   *buffer;
-    ss_dfprintf(stderr, "test_session_track: multi results test\n");
-    proto.server_capabilities = GW_MYSQL_CAPABILITIES_SESSION_TRACK;
-    proto.num_eof_packets = 0;
-    buffer = gwbuf_alloc_and_load(sizeof(resultset2), resultset2);
-    mxs_mysql_get_session_track_info(buffer, &proto);
-    ss_dassert(strncmp(gwbuf_get_property(buffer, (char *)"trx_state"), "I_R_W___", 8) == 0);
-    gwbuf_free(buffer);
-}
-
-void test3()
-{
-    GWBUF   *buffer;
-    proto.server_capabilities = GW_MYSQL_CAPABILITIES_SESSION_TRACK;
-    proto.num_eof_packets = 0;
-    ss_dfprintf(stderr, "test_session_track: protocol state test\n");
-    buffer = gwbuf_alloc_and_load(sizeof(resultset2), resultset2);
-    mxs_mysql_get_session_track_info(buffer, &proto);
-    ss_dassert(strncmp(gwbuf_get_property(buffer, (char *)"trx_state"), "I_R_W___", 8) == 0);
-    gwbuf_free(buffer);
-}
-
 int main(int argc, char **argv)
 {
-    test1();
-    test2();
-    test3();
+    
     return 0;
 }

--- a/server/modules/protocol/MySQL/mariadbbackend/mysql_backend.cc
+++ b/server/modules/protocol/MySQL/mariadbbackend/mysql_backend.cc
@@ -57,7 +57,6 @@ static void gw_send_proxy_protocol_header(DCB *backend_dcb);
 static bool get_ip_string_and_port(struct sockaddr_storage *sa, char *ip, int iplen,
                                    in_port_t *port_out);
 static bool gw_connection_established(DCB* dcb);
-static inline bool expecting_resultset(MySQLProtocol *proto);
 json_t* gw_json_diagnostics(DCB* dcb);
 
 extern "C"
@@ -662,40 +661,6 @@ static inline bool session_ok_to_route(DCB *dcb)
     return rval;
 }
 
-static inline bool expecting_resultset(MySQLProtocol *proto)
-{
-    return proto->current_command == MXS_COM_QUERY ||
-           proto->current_command == MXS_COM_STMT_EXECUTE ||
-           proto->current_command == MXS_COM_STMT_BULK_EXECUTE;
-}
-
-static inline bool expecting_ok_packet(MySQLProtocol *proto)
-{
-    bool rval = false;
-    switch (proto->current_command)
-    {
-        case MXS_COM_INIT_DB:
-        case MXS_COM_CREATE_DB:
-        case MXS_COM_DROP_DB:
-        case MXS_COM_REFRESH:
-        case MXS_COM_SHUTDOWN:
-        case MXS_COM_CONNECT:
-        case MXS_COM_PROCESS_KILL:
-        case MXS_COM_PING:
-        case MXS_COM_TIME:
-        case MXS_COM_DELAYED_INSERT:
-        case MXS_COM_SET_OPTION:
-        case MXS_COM_STMT_RESET:
-            rval = true;
-            break;
-        default:
-            rval = false;
-            break; 
-    }
-
-    return rval;
-}
-
 static inline bool expecting_ps_response(MySQLProtocol *proto)
 {
     return proto->current_command == MXS_COM_STMT_PREPARE;
@@ -759,220 +724,6 @@ static bool handle_auth_change_response(GWBUF* reply, MySQLProtocol* proto, DCB*
     return rval;
 }
 
-static void mark_resultset_packets(MySQLProtocol *proto, GWBUF *buff, uint8_t reply)
-{
-    reply_info_t *rinfo = &(proto->rinfo);
-    if (rinfo->rstate == REPLY_STATE_START)
-    {
-        if (reply == MYSQL_REPLY_OK)
-        {
-            uint16_t status = mxs_mysql_parse_ok_packet(buff);
-            gwbuf_set_type(buff, GWBUF_TYPE_REPLY_OK);
-            if (!(status & SERVER_MORE_RESULTS_EXIST))
-            {
-                rinfo->rstate = REPLY_STATE_DONE;
-                gwbuf_set_type(buff, GWBUF_TYPE_REPLY_LAST);
-            }
-        }
-        else if (reply == MYSQL_REPLY_ERR)
-        {
-            rinfo->rstate = REPLY_STATE_DONE;
-            gwbuf_set_type(buff, GWBUF_TYPE_REPLY_LAST);
-        }
-        else if (reply == MYSQL_REPLY_LOCAL_INFILE)
-        {
-            gwbuf_set_type(buff, GWBUF_TYPE_REPLY_LINFILE);
-            rinfo->local_infile_requested = true;
-        }
-        else if (mxs_mysql_is_result_set(buff))
-        {
-            if (DEPRECATE_EOF_ENABLED(proto))
-            {
-                rinfo->rstate = REPLY_STATE_RSET_ROWS;
-            }
-            else
-            {
-                rinfo->rstate = REPLY_STATE_RSET_COLDEF;
-            }
-        }
-    }
-    else if (rinfo->rstate == REPLY_STATE_RSET_COLDEF)
-    {
-        if (reply == MYSQL_REPLY_EOF && GWBUF_LENGTH(buff) == MYSQL_EOF_PACKET_LEN)
-        {
-            gwbuf_set_type(buff, GWBUF_TYPE_REPLY_EOF);
-            rinfo->rstate = REPLY_STATE_RSET_ROWS;
-            rinfo->status = mxs_mysql_parse_eof_packet(buff);
-            /* COM_STMT_EXECUTE with cursor opened */
-            if (rinfo->status & SERVER_STATUS_CURSOR_EXISTS)
-            {
-                rinfo->rstate = REPLY_STATE_DONE;
-                gwbuf_set_type(buff, GWBUF_TYPE_REPLY_LAST);
-            }
-        }
-    }
-    else if (rinfo->rstate == REPLY_STATE_RSET_ROWS)
-    {
-        if (reply == MYSQL_REPLY_EOF && GWBUF_LENGTH(buff) == MYSQL_EOF_PACKET_LEN)
-        {
-            gwbuf_set_type(buff, GWBUF_TYPE_REPLY_EOF);
-            uint16_t status = mxs_mysql_parse_eof_packet(buff);
-            /**
-              * MySQL 5.6 and 5.7 have a "feature" that doesn't set
-              * the SERVER_MORE_RESULTS_EXIST flag in the last EOF packet of
-              * a result set if the SERVER_PS_OUT_PARAMS flag was set in
-              * the first eof. To handle this, we have to use last eof
-              * status
-             */
-            if (rinfo->status & SERVER_PS_OUT_PARAMS)
-            {
-                rinfo->rstate = REPLY_STATE_START;
-            }
-            else if (status & SERVER_MORE_RESULTS_EXIST)
-            {
-                rinfo->rstate = REPLY_STATE_START;
-            }
-            else
-            {
-                gwbuf_set_type(buff, GWBUF_TYPE_REPLY_LAST);
-                rinfo->rstate = REPLY_STATE_DONE;
-            }
-            rinfo->status = status;
-        }
-        else if (reply == MYSQL_REPLY_EOF && DEPRECATE_EOF_ENABLED(proto))
-        {
-            gwbuf_set_type(buff, GWBUF_TYPE_REPLY_EOF);
-            rinfo->status = mxs_mysql_parse_ok_packet(buff);
-            if (rinfo->status & SERVER_MORE_RESULTS_EXIST)
-            {
-                rinfo->rstate = REPLY_STATE_START;
-            }
-            else
-            {
-                rinfo->rstate = REPLY_STATE_DONE;
-                gwbuf_set_type(buff, GWBUF_TYPE_REPLY_LAST);
-            }
-        }
-    }
-}
-
-static inline void mark_packet_type(MySQLProtocol *proto, GWBUF *queue)
-{
-    reply_info_t *rinfo = &(proto->rinfo);
-    while (queue)
-    {
-        uint8_t header[MYSQL_HEADER_LEN + 1];
-        gwbuf_copy_data(queue, 0, MYSQL_HEADER_LEN + 1, header);
-        uint8_t reply = MYSQL_GET_COMMAND(header);
-        unsigned int packet_len = gw_mysql_get_byte3(header) + MYSQL_HEADER_LEN;
-
-        if (packet_len == GW_MYSQL_MAX_PACKET_LEN)
-        {
-            rinfo->skip_next = true;
-        }
-        else if (rinfo->skip_next)
-        {
-            rinfo->skip_next = false;
-        }
-        else if (rinfo->local_infile_requested)
-        {
-            rinfo->local_infile_requested = false;
-            gwbuf_set_type(queue, GWBUF_TYPE_REPLY_LAST);
-            if (reply == MYSQL_REPLY_OK)
-            {
-                rinfo->status = mxs_mysql_parse_ok_packet(queue);
-                gwbuf_set_type(queue, GWBUF_TYPE_REPLY_OK);
-            }
-            rinfo->rstate = REPLY_STATE_DONE;
-        }
-        else if (expecting_resultset(proto))
-        {
-            mark_resultset_packets(proto, queue, reply);
-        }
-        else if (expecting_ok_packet(proto))
-        {
-            if (reply == MYSQL_REPLY_OK)
-            {
-                rinfo->status = mxs_mysql_parse_ok_packet(queue);
-                gwbuf_set_type(queue, GWBUF_TYPE_REPLY_OK);
-            }
-            gwbuf_set_type(queue, GWBUF_TYPE_REPLY_LAST);
-        }
-        else if (proto->current_command == MXS_COM_STMT_FETCH)
-        {
-            if (reply == MYSQL_REPLY_EOF && 
-                (packet_len == MYSQL_EOF_PACKET_LEN || DEPRECATE_EOF_ENABLED(proto)))
-            {
-                gwbuf_set_type(queue, GWBUF_TYPE_REPLY_LAST | GWBUF_TYPE_REPLY_EOF);
-                rinfo->status = mxs_mysql_parse_eof_packet(queue);
-            }
-            else if (MYSQL_REPLY_ERR)
-            {
-                gwbuf_set_type(queue, GWBUF_TYPE_REPLY_LAST);
-            }
-        }
-        else if (proto->current_command == MXS_COM_STATISTICS)
-        {
-            gwbuf_set_type(queue, GWBUF_TYPE_REPLY_LAST);
-        }
-        else if (proto->current_command == MXS_COM_FIELD_LIST)
-        {
-            if (reply == MYSQL_REPLY_EOF)
-            {
-                gwbuf_set_type(queue, GWBUF_TYPE_REPLY_LAST | GWBUF_TYPE_REPLY_EOF);
-                rinfo->status = mxs_mysql_parse_eof_packet(queue);
-            }
-            else if (reply == MYSQL_REPLY_ERR)
-            {
-                gwbuf_set_type(queue, GWBUF_TYPE_REPLY_LAST);
-            }
-        }
-        else if (proto->current_command == MXS_COM_STMT_PREPARE)
-        {
-            if (reply == MYSQL_REPLY_OK)
-            {
-                MXS_PS_RESPONSE resp;
-                mxs_mysql_extract_ps_response(queue, &resp);
-                rinfo->expected_packets += resp.columns;
-                rinfo->expected_packets += resp.parameters;
-
-                if (!DEPRECATE_EOF_ENABLED(proto))
-                {
-                    /* If DEPRECATE_EOF enabled there will be no eof packet of ps response */
-                    if (resp.columns)
-                    {
-                        rinfo->expected_packets++;
-                    }
-
-                    if (resp.parameters)
-                    {
-                        rinfo->expected_packets++;
-                    }
-                }
-                
-                if (rinfo->expected_packets == 0)
-                {
-                    gwbuf_set_type(queue, GWBUF_TYPE_REPLY_LAST);
-                }
-            }
-            else if (reply == MYSQL_REPLY_ERR)
-            {
-                gwbuf_set_type(queue, GWBUF_TYPE_REPLY_LAST);
-            }
-            else
-            {
-                rinfo->expected_packets--;
-                if (rinfo->expected_packets == 0)
-                {
-                    gwbuf_set_type(queue, GWBUF_TYPE_REPLY_LAST);
-                }
-            }
-        }
-        
-        queue = queue->next;
-    }
-}
-
 /**
  * @brief With authentication completed, read new data and write to backend
  *
@@ -1034,7 +785,7 @@ gw_read_and_write(DCB *dcb)
 
         read_buffer = tmp;
         reply_info_t old_info = proto->rinfo;
-        mark_packet_type(proto, read_buffer);
+        mxs_mysql_mark_packet_type(proto, read_buffer);
 
         if (collecting_resultset(proto, capabilities))
         {

--- a/server/modules/protocol/MySQL/mariadbbackend/mysql_backend.cc
+++ b/server/modules/protocol/MySQL/mariadbbackend/mysql_backend.cc
@@ -685,6 +685,7 @@ static inline bool expecting_ok_packet(MySQLProtocol *proto)
         case MXS_COM_TIME:
         case MXS_COM_DELAYED_INSERT:
         case MXS_COM_SET_OPTION:
+        case MXS_COM_STMT_RESET:
             rval = true;
             break;
         default:
@@ -886,7 +887,7 @@ static inline void mark_packet_type(MySQLProtocol *proto, GWBUF *queue)
         }
         else if (expecting_resultset(proto))
         {
-            mark_resultset_packets(proto, queue, cmd);
+            mark_resultset_packets(proto, queue, reply);
         }
         else if (expecting_ok_packet(proto))
         {
@@ -899,8 +900,8 @@ static inline void mark_packet_type(MySQLProtocol *proto, GWBUF *queue)
         }
         else if (proto->current_command == MXS_COM_STMT_FETCH)
         {
-            if (cmd == MYSQL_REPLY_EOF && 
-                (packet_len == MYSQL_EOF_PACKET_LEN || DEPRECATE_EOF_ENABLED(proto))
+            if (reply == MYSQL_REPLY_EOF && 
+                (packet_len == MYSQL_EOF_PACKET_LEN || DEPRECATE_EOF_ENABLED(proto)))
             {
                 gwbuf_set_type(queue, GWBUF_TYPE_REPLY_LAST | GWBUF_TYPE_REPLY_EOF);
                 rinfo->status = mxs_mysql_parse_eof_packet(queue);

--- a/server/modules/routing/readwritesplit/rwbackend.cc
+++ b/server/modules/routing/readwritesplit/rwbackend.cc
@@ -1,7 +1,6 @@
 #include "rwbackend.hh"
 
 #include <maxscale/modutil.h>
-#include <maxscale/protocol/mysql.h>
 #include <maxscale/log_manager.h>
 
 namespace maxscale
@@ -12,8 +11,6 @@ RWBackend::RWBackend(SERVER_REF* ref):
     m_reply_state(REPLY_STATE_DONE),
     m_modutil_state({}),
     m_command(0),
-    m_opening_cursor(false),
-    m_expected_rows(0),
     m_local_infile_requested(false)
 {
 }
@@ -62,36 +59,16 @@ uint32_t RWBackend::get_ps_handle(uint32_t id) const
 bool RWBackend::write(GWBUF* buffer, response_type type)
 {
     uint8_t cmd = mxs_mysql_get_command(buffer);
-
     m_command = cmd;
-
     if (mxs_mysql_is_ps_command(cmd))
     {
         uint32_t id = mxs_mysql_extract_ps_id(buffer);
         BackendHandleMap::iterator it = m_ps_handles.find(id);
-
         if (it != m_ps_handles.end())
         {
             /** Replace the client handle with the real PS handle */
             uint8_t* ptr = GWBUF_DATA(buffer) + MYSQL_PS_ID_OFFSET;
             gw_mysql_set_byte4(ptr, it->second);
-
-            if (cmd == MXS_COM_STMT_EXECUTE)
-            {
-                // Extract the flag byte after the statement ID
-                uint8_t flags = 0;
-                gwbuf_copy_data(buffer, MYSQL_PS_ID_OFFSET + MYSQL_PS_ID_SIZE, 1, &flags);
-
-                // Any non-zero flag value means that we have an open cursor
-                m_opening_cursor = flags != 0;
-            }
-            else if (cmd == MXS_COM_STMT_FETCH)
-            {
-                // Number of rows to fetch is a 4 byte integer after the ID
-                uint8_t buf[4];
-                gwbuf_copy_data(buffer, MYSQL_PS_ID_OFFSET + MYSQL_PS_ID_SIZE, 4, buf);
-                m_expected_rows = gw_mysql_get_byte4(buf);
-            }
         }
     }
 
@@ -102,13 +79,6 @@ void RWBackend::close(close_type type)
 {
     m_reply_state = REPLY_STATE_DONE;
     mxs::Backend::close(type);
-}
-
-bool RWBackend::consume_fetched_rows(GWBUF* buffer)
-{
-    m_expected_rows -= modutil_count_packets(buffer);
-    ss_dassert(m_expected_rows >= 0);
-    return m_expected_rows == 0;
 }
 
 static inline bool have_next_packet(GWBUF* buffer)
@@ -127,107 +97,29 @@ static inline bool have_next_packet(GWBUF* buffer)
  */
 bool RWBackend::reply_is_complete(GWBUF *buffer)
 {
-    if (current_command() == MXS_COM_STMT_FETCH)
+    if (GWBUF_IS_COLLECTED_RESULT(buffer))
     {
-        bool more = false;
-        int n_eof = modutil_count_signal_packets(buffer, 0, &more, &m_modutil_state);
-
-        // If the server responded with an error, n_eof > 0
-        if (n_eof > 0 || consume_fetched_rows(buffer))
-        {
-
-            set_reply_state(REPLY_STATE_DONE);
-        }
-    }
-    else if (current_command() == MXS_COM_STATISTICS)
-    {
-        // COM_STATISTICS returns a single string and thus requires special handling
         set_reply_state(REPLY_STATE_DONE);
+        return true;
     }
-    else if (get_reply_state() == REPLY_STATE_START &&
-        (!mxs_mysql_is_result_set(buffer) || GWBUF_IS_COLLECTED_RESULT(buffer)))
+
+    while (buffer)
     {
-        m_local_infile_requested = false;
-
-        if (GWBUF_IS_COLLECTED_RESULT(buffer) ||
-            current_command() == MXS_COM_STMT_PREPARE ||
-            !mxs_mysql_is_ok_packet(buffer) ||
-            !mxs_mysql_more_results_after_ok(buffer))
+        if (GWBUF_IS_REPLY_LAST(buffer))
         {
-            /** Not a result set, we have the complete response */
             set_reply_state(REPLY_STATE_DONE);
-
-            if (mxs_mysql_is_local_infile(buffer))
-            {
-                m_local_infile_requested = true;
-            }
+            return true;
         }
-        else
+        else if (GWBUF_IS_REPLY_LINFILE(buffer))
         {
-            // This is an OK packet and more results will follow
-            ss_dassert(mxs_mysql_is_ok_packet(buffer) &&
-                       mxs_mysql_more_results_after_ok(buffer));
-
-            if (have_next_packet(buffer))
-            {
-                // TODO: Don't clone the buffer
-                GWBUF* tmp = gwbuf_clone(buffer);
-                tmp = gwbuf_consume(tmp, mxs_mysql_get_packet_len(tmp));
-                bool rval = reply_is_complete(tmp);
-                gwbuf_free(tmp);
-                return rval;
-            }
-        }
-    }
-    else
-    {
-        bool more = false;
-        int n_old_eof = get_reply_state() == REPLY_STATE_RSET_ROWS ? 1 : 0;
-        int n_eof = modutil_count_signal_packets(buffer, n_old_eof, &more, &m_modutil_state);
-
-        if (n_eof > 2)
-        {
-            /**
-             * We have multiple results in the buffer, we only care about
-             * the state of the last one. Skip the complete result sets and act
-             * like we're processing a single result set.
-             */
-            n_eof = n_eof % 2 ? 1 : 2;
-        }
-
-        if (n_eof == 0)
-        {
-            /** Waiting for the EOF packet after the column definitions */
-            set_reply_state(REPLY_STATE_RSET_COLDEF);
-        }
-        else if (n_eof == 1 && current_command() != MXS_COM_FIELD_LIST)
-        {
-            /** Waiting for the EOF packet after the rows */
-            set_reply_state(REPLY_STATE_RSET_ROWS);
-
-            if (is_opening_cursor())
-            {
-                set_cursor_opened();
-                MXS_INFO("Cursor successfully opened");
-                set_reply_state(REPLY_STATE_DONE);
-            }
-        }
-        else
-        {
-            /** We either have a complete result set or a response to
-             * a COM_FIELD_LIST command */
-            ss_dassert(n_eof == 2 || (n_eof == 1 && current_command() == MXS_COM_FIELD_LIST));
+            m_local_infile_requested = true;
             set_reply_state(REPLY_STATE_DONE);
-
-            if (more)
-            {
-                /** The server will send more resultsets */
-                set_reply_state(REPLY_STATE_START);
-            }
+            return true;
         }
+        buffer = buffer->next;
     }
 
-    return get_reply_state() == REPLY_STATE_DONE;
+    return false;
 }
 
 SRWBackendList RWBackend::from_servers(SERVER_REF* servers)

--- a/server/modules/routing/readwritesplit/rwbackend.hh
+++ b/server/modules/routing/readwritesplit/rwbackend.hh
@@ -19,18 +19,9 @@
 
 #include <maxscale/backend.hh>
 #include <maxscale/modutil.h>
-
+#include <maxscale/protocol/mysql.h>
 namespace maxscale
 {
-
-/** Enum for tracking client reply state */
-enum reply_state_t
-{
-    REPLY_STATE_START,          /**< Query sent to backend */
-    REPLY_STATE_DONE,           /**< Complete reply received */
-    REPLY_STATE_RSET_COLDEF,    /**< Resultset response, waiting for column definitions */
-    REPLY_STATE_RSET_ROWS       /**< Resultset response, waiting for rows */
-};
 
 typedef std::map<uint32_t, uint32_t> BackendHandleMap; /** Internal ID to external ID */
 
@@ -97,9 +88,6 @@ public:
 
     void close(close_type type = CLOSE_NORMAL);
 
-    // For COM_STMT_FETCH processing
-    bool consume_fetched_rows(GWBUF* buffer);
-
     inline uint8_t current_command() const
     {
         return m_command;
@@ -117,19 +105,8 @@ private:
     BackendHandleMap m_ps_handles; /**< Internal ID to backend PS handle mapping */
     modutil_state    m_modutil_state; /**< @see modutil_count_signal_packets */
     uint8_t          m_command;
-    bool             m_opening_cursor; /**< Whether we are opening a cursor */
-    uint32_t         m_expected_rows; /**< Number of rows a COM_STMT_FETCH is retrieving */
     bool             m_local_infile_requested; /**< Whether a LOCAL INFILE was requested */
 
-    inline bool is_opening_cursor() const
-    {
-        return m_opening_cursor;
-    }
-
-    inline void set_cursor_opened()
-    {
-        m_opening_cursor = false;
-    }
 };
 
 }


### PR DESCRIPTION
I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.

## Background
Since mxs can get many useful info from server side var session track, 
but without the feature deprecate eof, we can only get some info from ok packet;
if we can handle deprecate eof, we can get more info from server side;
For example, get latest gtid from response of COM_QUERY,  latest session variable value in the last eof packet;

## Protocol Changes
Accroding to [WL#7766](https://dev.mysql.com/worklog/task/?id=7766)

1. EOF's body changes to ok, but the identifier remain as 0xff;
2. There will be no EOF between column defs and rows;
3. The reponse of COM\_STMT\_PREPARE don't have EOF;
4. Flag SERVER\_PS\_OUT\_PARAMS move to the end eof's status;

## Implementation
Since many places need know the protocol state (is reply complete? is ok? is eof?), and we should consider both deprecate eof enabled or not, So this patch capsulate all the logic which determine protocol state in one function `mxs_mysql_mark_packet_type` by marking buffer type, make it easy to write unit testing for mysql protocol;

1. Replace `modutil_get_complete_packets` with  `mxs_mysql_get_complete_packets`
	`mxs_mysql_get_complete_packets` will produce packets the way that one buffer one packet;
	
2. `mxs_mysql_mark_packet_type` give sigal packet a type, which will be

	```
	GWBUF_TYPE_REPLY_OK        = 0x80,
    GWBUF_TYPE_REPLY_EOF       = 0x100,
    GWBUF_TYPE_REPLY_LAST      = 0x200,
    GWBUF_TYPE_REPLY_LINFILE   = 0x400,
	```
     GWBUF\_TYPE\_REPLY\_LAST indicate that reply is end

3. `RWBackend::reply_is_complete` use packet type to tell whether reply is complete

### corner cases
1. If deprecate eof enabled

	No need to check the packet length to identify whether it is a real eof;

2. Execute with cursor

	If received EOF and SERVER\_STATUS\_CURSOR\_EXISTS, reply is end.
	
2. SERVER\_PS\_OUT\_PARAMS

	If received EOF and last status have SERVER\_PS\_OUT\_PARAMS, reply not end; 
	
3. COM\_STMT\_PREPARE
	
	if DEPRECATE_EOF_ENABLED, there will be no eof, so count packets number
	
4. COM\_FILED\_LIST
	
	reply is end when received eof or error
	
5. COM\_STMT\_FETCH
	
	reply is end when received eof or error
