### PR TITLE
Mxs 1986 repo.d

### DIFF
--- a/BUILD/mdbci/copy_repos.sh
+++ b/BUILD/mdbci/copy_repos.sh
@@ -39,4 +39,4 @@ $(<${script_dir}/templates/repository-config/deb.json.template)
 fi
 cd $dir
 
-${mdbci_dir}/mdbci generate-product-repositories --product maxscale_ci
+${mdbci_dir}/mdbci generate-product-repositories --product maxscale_ci --product-version $target

--- a/BUILD/mdbci/copy_repos.sh
+++ b/BUILD/mdbci/copy_repos.sh
@@ -38,3 +38,5 @@ $(<${script_dir}/templates/repository-config/deb.json.template)
 " 2> /dev/null > ${path_prefix}/${platform}_${platform_version}.json
 fi
 cd $dir
+
+${mdbci_dir}/mdbci generate-product-repositories --product maxscale_ci

--- a/BUILD/mdbci/templates/install.json.template
+++ b/BUILD/mdbci/templates/install.json.template
@@ -5,7 +5,8 @@
         "box" : "$box",
         "memory_size" : "4096",
         "product" : {
-                "name": "maxscale"
+                "name" : "maxscale",
+                "version" : "${old_target}"
         }
 
   }

--- a/BUILD/mdbci/upgrade_test.sh
+++ b/BUILD/mdbci/upgrade_test.sh
@@ -34,7 +34,7 @@ if [ -d "install_$box" ]; then
 fi
 
 # starting VM for build
-${mdbci_dir}/mdbci --override --template $MDBCI_VM_PATH/$name.json --repo-dir $dir/repo.d generate $name
+${mdbci_dir}/mdbci --override --template $MDBCI_VM_PATH/$name.json generate $name
 ${mdbci_dir}/mdbci up $name --attempts=1
 if [ $? != 0 ] ; then
         if [ $? != 0 ] ; then

--- a/BUILD/mdbci/upgrade_test.sh
+++ b/BUILD/mdbci/upgrade_test.sh
@@ -58,7 +58,7 @@ export sshopt="$scpopt $sshuser@$IP"
 
 old_version=`ssh $sshopt "maxscale --version" `
 
-${mdbci_dir}/mdbci setup_repo --product maxscale_ci --product-version ${new_target} $name/maxscale
+${mdbci_dir}/mdbci setup_repo --product maxscale_ci --product-version ${target} $name/maxscale
 ${mdbci_dir}/mdbci install_product --product maxscale_ci $name/maxscale
 
 res=$?

--- a/BUILD/mdbci/upgrade_test.sh
+++ b/BUILD/mdbci/upgrade_test.sh
@@ -33,9 +33,6 @@ if [ -d "install_$box" ]; then
         ${mdbci_dir}/mdbci destroy $name
 fi
 
-${mdbci_dir}/repository-config/generate_all.sh repo.d
-${mdbci_dir}/repository-config/maxscale-release.sh $old_target repo.d
-
 # starting VM for build
 ${mdbci_dir}/mdbci --override --template $MDBCI_VM_PATH/$name.json --repo-dir $dir/repo.d generate $name
 ${mdbci_dir}/mdbci up $name --attempts=1
@@ -61,12 +58,8 @@ export sshopt="$scpopt $sshuser@$IP"
 
 old_version=`ssh $sshopt "maxscale --version" `
 
-rm -rf repo.d
-${mdbci_dir}/repository-config/generate_all.sh repo.d
-${mdbci_dir}/repository-config/maxscale-ci.sh $target repo.d
-
-${mdbci_dir}/mdbci setup_repo --product maxscale --repo-dir $dir/repo.d $name/maxscale
-${mdbci_dir}/mdbci install_product --product maxscale $name/maxscale
+${mdbci_dir}/mdbci setup_repo --product maxscale_ci --product-version ${new_target} $name/maxscale
+${mdbci_dir}/mdbci install_product --product maxscale_ci $name/maxscale
 
 res=$?
 

--- a/maxscale-system-test/mdbci/create_config.sh
+++ b/maxscale-system-test/mdbci/create_config.sh
@@ -7,12 +7,6 @@ export script_dir="$(dirname $(readlink -f $0))"
 
 . ${script_dir}/set_run_test_variables.sh
 
-${mdbci_dir}/repository-config/generate_all.sh repo.d
-${mdbci_dir}/repository-config/maxscale-ci.sh $target repo.d
-
-
-export repo_dir=$dir/repo.d/
-
 export provider=`${mdbci_dir}/mdbci show provider $box --silent 2> /dev/null`
 export backend_box=${backend_box:-"centos_7_"$provider}
 
@@ -33,7 +27,7 @@ fi
 $(<${script_dir}/templates/${template}.json.template)
 " 2> /dev/null > ${MDBCI_VM_PATH}/${name}.json
 
-${mdbci_dir}/mdbci --override --template  ${MDBCI_VM_PATH}/${name}.json --repo-dir ${repo_dir} generate $name
+${mdbci_dir}/mdbci --override --template  ${MDBCI_VM_PATH}/${name}.json generate $name
 
 mkdir ${MDBCI_VM_PATH}/$name/cnf
 cp -r ${script_dir}/cnf/* ${MDBCI_VM_PATH}/$name/cnf/

--- a/maxscale-system-test/mdbci/run_test_snapshot.sh
+++ b/maxscale-system-test/mdbci/run_test_snapshot.sh
@@ -43,8 +43,6 @@ done
 touch ${snapshot_lock_file}
 echo $JOB_NAME-$BUILD_NUMBER >> ${snapshot_lock_file}
 
-export repo_dir=$dir/repo.d/
-
 ${mdbci_dir}/mdbci snapshot revert --path-to-nodes $name --snapshot-name $snapshot_name
 
 if [ $? != 0 ]; then
@@ -60,14 +58,11 @@ fi
 
 . ${script_dir}/set_env.sh "$name"
 
-${mdbci_dir}/repository-config/maxscale-ci.sh $target repo.d
-
-
 ${mdbci_dir}/mdbci sudo --command 'yum remove maxscale -y' $name/maxscale
 ${mdbci_dir}/mdbci sudo --command 'yum clean all' $name/maxscale
 
-${mdbci_dir}/mdbci setup_repo --product maxscale $name/maxscale --repo-dir $repo_dir
-${mdbci_dir}/mdbci install_product --product maxscale $name/maxscale --repo-dir $repo_dir
+${mdbci_dir}/mdbci setup_repo --product maxscale_ci --product-version ${target} $name/maxscale
+${mdbci_dir}/mdbci install_product --product maxscale_ci $name/maxscale
 
 checkExitStatus $? "Error installing Maxscale" $snapshot_lock_file
 

--- a/maxscale-system-test/mdbci/templates/big.json.template
+++ b/maxscale-system-test/mdbci/templates/big.json.template
@@ -145,7 +145,8 @@
         "hostname" : "maxscale",
         "box" : "centos_7_aws_large",
         "product" : {
-                "name": "maxscale"
+                "name" : "maxscale_ci",
+                "version" : "${target}"
         }
 
   }

--- a/maxscale-system-test/mdbci/templates/big15.json.template
+++ b/maxscale-system-test/mdbci/templates/big15.json.template
@@ -222,7 +222,8 @@
         "hostname" : "maxscale",
         "box" : "centos_7_aws_large",
         "product" : {
-                "name": "maxscale"
+                "name" : "maxscale_ci",
+                "version" : "${target}"
         }
 
   }

--- a/maxscale-system-test/mdbci/templates/default.json.template
+++ b/maxscale-system-test/mdbci/templates/default.json.template
@@ -110,7 +110,8 @@
         "box" : "${box}",
         "memory_size" : "${vm_memory}",
         "product" : {
-                "name": "maxscale"
+                "name" : "maxscale_ci",
+                "version" : "${target}"
         }
 
   }

--- a/maxscale-system-test/mdbci/templates/nogalera.json.template
+++ b/maxscale-system-test/mdbci/templates/nogalera.json.template
@@ -58,7 +58,8 @@
         "box" : "${box}",
         "memory_size" : "${vm_memory}",
         "product" : {
-                "name": "maxscale"
+                "name" : "maxscale_ci",
+                "version" : "${target}"
         }
 
   }

--- a/maxscale-system-test/mdbci/templates/performance.json.template
+++ b/maxscale-system-test/mdbci/templates/performance.json.template
@@ -60,7 +60,8 @@
         "box" : "###box###",
         "memory_size" : "2048",
         "product" : {
-                "name": "maxscale"
+                "name" : "maxscale_ci",
+                "version" : "${target}"
         }
 
   }

--- a/maxscale-system-test/mdbci/templates/twomaxscales.json.template
+++ b/maxscale-system-test/mdbci/templates/twomaxscales.json.template
@@ -58,7 +58,8 @@
         "box" : "${box}",
         "memory_size" : "${vm_memory}",
         "product" : {
-                "name": "maxscale"
+                 "name" : "maxscale_ci",
+                "version" : "${target}"
         }
 
   },
@@ -69,7 +70,8 @@
         "box" : "${box}",
         "memory_size" : "${vm_memory}",
         "product" : {
-                "name": "maxscale"
+                "name" : "maxscale_ci",
+                "version" : "${target}"
         }
 
   }


### PR DESCRIPTION
Removing all repo.d generation from Build and Run_test. Repository list have to be generated before using MDBCI with:
./mdbci generate-product-repositories