### PR TITLE
MXS-2042: fix multistatments hang

### DIFF
--- a/server/modules/protocol/MySQL/mariadbbackend/mysql_backend.c
+++ b/server/modules/protocol/MySQL/mariadbbackend/mysql_backend.c
@@ -823,7 +823,8 @@ gw_read_and_write(DCB *dcb)
                     if (mxs_mysql_is_result_set(read_buffer))
                     {
                         bool more = false;
-                        if (modutil_count_signal_packets(read_buffer, 0, &more, NULL) != 2)
+                        int eof_cnt = modutil_count_signal_packets(read_buffer, 0, &more, NULL);
+                        if (more || eof_cnt % 2 != 0)
                         {
                             dcb_readq_prepend(dcb, read_buffer);
                             return 0;


### PR DESCRIPTION
I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.

If enable multi statements,  and all result sets returned in one packet, then it will hang;

For example
```
select name from t1 where id = 1; select name from t1 where id = 3; select name from t1 where id = 2

```

Because function `modutil_count_signal_packets` will return more than 2;



