### PR TITLE
Fix wsrep_local_state when donor

### DIFF
--- a/server/modules/monitor/galeramon/galeramon.cc
+++ b/server/modules/monitor/galeramon/galeramon.cc
@@ -194,7 +194,7 @@ void GaleraMonitor::update_server_status(MXS_MONITORED_SERVER* monitored_server)
                     info.joined = 1;
                 }
                 /* Check if the node is a donor and is using xtrabackup, in this case it can stay alive */
-                else if (strcmp(row[1], "2") == 0 && m_availableWhenDonor == 1
+                else if (strcmp(row[1], "5") == 0 && m_availableWhenDonor == 1
                          && using_xtrabackup(monitored_server, server_string))
                 {
                     info.joined = 1;


### PR DESCRIPTION
According to the docs about node state changes at http://galeracluster.com/documentation-webpages/nodestates.html#node-state-changes the `wsrep_local_state` would be `5` when it is in donor mode and not `2`

I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.
