### PR TITLE
Enable galeramon to track more status's

### DIFF
--- a/server/modules/monitor/galeramon/galeramon.cc
+++ b/server/modules/monitor/galeramon/galeramon.cc
@@ -242,7 +242,7 @@ void GaleraMonitor::update_server_status(MXS_MONITORED_SERVER* monitored_server)
             /* Node is not ready - lets take it offline */
             if (strcmp(row[0], "wsrep_ready") == 0)
             {
-              if (strcasecmp(row[1],"YES") || strcasecmp(row[1],"ON") || strcasecmp(row[1],"1") || strcasecmp(row[1],"true"))
+              if (strcasecmp(row[1],"NO") || strcasecmp(row[1],"OFF") || strcasecmp(row[1],"0") || strcasecmp(row[1],"false"))
               {
                 info.joined = 0;
               }


### PR DESCRIPTION
The current `galeramon` currently only tracks the local state to check if a node is ready to serve or not.

This PR will enable `galeramon` to track the following status's too:

* `wsrep_desync` - node must not be in desync mode. See more [here](http://galeracluster.com/documentation-webpages/mysqlwsrepoptions.html#wsrep-desync).
* `wsrep_ready` - node must be ready. See more [here](http://galeracluster.com/documentation-webpages/monitoringthecluster.html).
* `wsrep_sst_donor_rejects_queries` - node must not reject queries while doing SST transfers. See more [here](http://galeracluster.com/documentation-webpages/mysqlwsrepoptions.html#wsrep_sst_donor_rejects_queries).
* `wsrep_reject_queries` - node must not reject queries. See more [here](http://galeracluster.com/documentation-webpages/mysqlwsrepoptions.html#wsrep_reject_queries).

I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.
