### PR TITLE
MXS-2521:Route subseqenct COM_STMT_EXECUTE to the same server which f…

### DIFF
--- a/server/modules/routing/readwritesplit/rwsplit_internal.hh
+++ b/server/modules/routing/readwritesplit/rwsplit_internal.hh
@@ -78,7 +78,7 @@ void handle_multi_temp_and_load(RWSplitSession *rses, GWBUF *querybuf,
 SRWBackend handle_hinted_target(RWSplitSession *rses, GWBUF *querybuf,
                                 route_target_t route_target);
 SRWBackend handle_slave_is_target(RWSplit *inst, RWSplitSession *rses,
-                                  uint8_t cmd, uint32_t id);
+                                  const GWBUF *query, const RouteInfo& info);
 bool handle_master_is_target(RWSplit *inst, RWSplitSession *rses,
                              SRWBackend* dest);
 bool handle_got_target(RWSplit *inst, RWSplitSession *rses,

--- a/server/modules/routing/readwritesplit/rwsplit_route_stmt.cc
+++ b/server/modules/routing/readwritesplit/rwsplit_route_stmt.cc
@@ -1002,7 +1002,7 @@ SRWBackend handle_hinted_target(RWSplitSession *rses, GWBUF *querybuf,
 /**
  * @brief Determine whether this stmt  is subsequent COM_STMT_EXECUTE
  *
- * @param cmd     command type 
+ * @param cmd     command type
  * @param query   GWBUF including the query
  * @param info    Route info
  *
@@ -1021,9 +1021,9 @@ bool is_sub_stmt_exec(uint8_t cmd, const GWBUF *query, uint16_t n_params)
     /*need n_params to parse new_params_bound_flag(alias send type to server)*/
     int new_params_bound_flag_offset = MYSQL_HEADER_LEN + 10 + (n_params + 7) / 8;
     ss_dassert((int)gwbuf_length(query) >= new_params_bound_flag_offset);
-    uint8_t data[new_params_bound_flag_offset];
-    gwbuf_copy_data(query, 0, new_params_bound_flag_offset, data);
-    if (data[new_params_bound_flag_offset])
+    uint8_t flag;
+    gwbuf_copy_data(query, new_params_bound_flag_offset, 1, &flag);
+    if (flag)
     {
         rval = false;
     }

--- a/server/modules/routing/readwritesplit/rwsplit_route_stmt.cc
+++ b/server/modules/routing/readwritesplit/rwsplit_route_stmt.cc
@@ -1020,7 +1020,7 @@ bool is_sub_stmt_exec(uint8_t cmd, const GWBUF *query, uint16_t n_params)
     /*https://mariadb.com/kb/en/library/com_stmt_execute/*/
     /*need n_params to parse new_params_bound_flag(alias send type to server)*/
     int new_params_bound_flag_offset = MYSQL_HEADER_LEN + 10 + (n_params + 7) / 8;
-    ss_dassert(gwbuf_length(query) <= new_params_bound_flag_offset);
+    ss_dassert((int)gwbuf_length(query) >= new_params_bound_flag_offset);
     uint8_t data[new_params_bound_flag_offset];
     gwbuf_copy_data(query, 0, new_params_bound_flag_offset, data);
     if (data[new_params_bound_flag_offset])

--- a/server/modules/routing/readwritesplit/rwsplit_session_cmd.cc
+++ b/server/modules/routing/readwritesplit/rwsplit_session_cmd.cc
@@ -122,7 +122,7 @@ void process_sescmd_response(RWSplitSession* rses, SRWBackend& backend,
                     {
                         /** Map the returned response to the internal ID */
                         MXS_INFO("PS ID %u maps to internal ID %lu", resp.id, id);
-                        rses->ps_handles[resp.id] = id;
+                        rses->ps_handles[resp.id] = (id << 16) + resp.parameters;
                     }
 
                     // Discard any slave connections that did not return the same result

--- a/server/modules/routing/readwritesplit/rwsplit_session_cmd.cc
+++ b/server/modules/routing/readwritesplit/rwsplit_session_cmd.cc
@@ -122,7 +122,7 @@ void process_sescmd_response(RWSplitSession* rses, SRWBackend& backend,
                     {
                         /** Map the returned response to the internal ID */
                         MXS_INFO("PS ID %u maps to internal ID %lu", resp.id, id);
-                        rses->ps_handles[resp.id] = (id << 16) + resp.parameters;
+                        rses->ps_handles[resp.id] = (id << 32) + resp.parameters;
                     }
 
                     // Discard any slave connections that did not return the same result

--- a/server/modules/routing/readwritesplit/rwsplitsession.cc
+++ b/server/modules/routing/readwritesplit/rwsplitsession.cc
@@ -120,8 +120,8 @@ uint32_t get_internal_ps_id(RWSplitSession* rses, GWBUF* buffer, uint16_t* n_par
 
     if (it != rses->ps_handles.end())
     {
-        rval = it->second >> 16;
-        *n_params = it->second & 0xffff;
+        rval = it->second >> 32;
+        *n_params = it->second & 0xffffffff;
     }
     else
     {

--- a/server/modules/routing/readwritesplit/rwsplitsession.cc
+++ b/server/modules/routing/readwritesplit/rwsplitsession.cc
@@ -110,7 +110,7 @@ bool RWBackend::consume_fetched_rows(GWBUF* buffer)
     return m_expected_rows == 0;
 }
 
-uint32_t get_internal_ps_id(RWSplitSession* rses, GWBUF* buffer)
+uint32_t get_internal_ps_id(RWSplitSession* rses, GWBUF* buffer, uint16_t* n_params)
 {
     uint32_t rval = 0;
 
@@ -120,7 +120,8 @@ uint32_t get_internal_ps_id(RWSplitSession* rses, GWBUF* buffer)
 
     if (it != rses->ps_handles.end())
     {
-        rval = it->second;
+        rval = it->second >> 16;
+        *n_params = it->second & 0xffff;
     }
     else
     {
@@ -135,7 +136,8 @@ RouteInfo::RouteInfo(RWSplitSession* rses, GWBUF* buffer):
     target(TARGET_UNDEFINED),
     command(0xff),
     type(QUERY_TYPE_UNKNOWN),
-    stmt_id(0)
+    stmt_id(0),
+    n_params(0)
 {
     target = get_target_type(rses, buffer, &command, &type, &stmt_id);
 }

--- a/server/modules/routing/readwritesplit/rwsplitsession.hh
+++ b/server/modules/routing/readwritesplit/rwsplitsession.hh
@@ -203,7 +203,7 @@ static inline const char* rstostr(reply_state_t state)
  *
  * @param rses   Router client session
  * @param buffer Buffer containing a binary protocol statement other than COM_STMT_PREPARE
- * @param n_params statement parmas number
+ * @param n_params Statement parmas count
  *
  * @return The internal ID of the prepared statement that the buffer contents refer to
  */

--- a/server/modules/routing/readwritesplit/rwsplitsession.hh
+++ b/server/modules/routing/readwritesplit/rwsplitsession.hh
@@ -32,7 +32,7 @@ enum reply_state_t
     rstostr((a)->get_reply_state()), rstostr(b));
 
 typedef std::map<uint32_t, uint32_t> BackendHandleMap; /** Internal ID to external ID */
-typedef std::map<uint32_t, uint32_t> ClientHandleMap;  /** External ID to internal ID */
+typedef std::map<uint32_t, uint64_t> ClientHandleMap;  /** External ID to internal ID */
 
 class RWBackend: public mxs::Backend
 {
@@ -171,6 +171,7 @@ struct RouteInfo
     uint8_t        command; /**< The command byte, 0xff for unknown commands */
     uint32_t       type;    /**< The query type, QUERY_TYPE_UNKNOWN for unknown types*/
     uint32_t       stmt_id; /**< Prepared statement ID, 0 for unknown */
+    uint16_t       n_params; /**< Prepared statement params count */
 };
 
 /**
@@ -202,7 +203,8 @@ static inline const char* rstostr(reply_state_t state)
  *
  * @param rses   Router client session
  * @param buffer Buffer containing a binary protocol statement other than COM_STMT_PREPARE
+ * @param n_params statement parmas number
  *
  * @return The internal ID of the prepared statement that the buffer contents refer to
  */
-uint32_t get_internal_ps_id(RWSplitSession* rses, GWBUF* buffer);
+uint32_t get_internal_ps_id(RWSplitSession* rses, GWBUF* buffer, uint16_t* n_params);


### PR DESCRIPTION
In the scenario as below

```
 mysql_stmt_prepare
 mysql_stmt_bind_param
 mysql_stmt_execute
 mysql_stmt_execute
 mysql_stmt_execute
 ...
```

First mysql_stmt_execute will produce packet with params meta info, but the rest mysql_stmt_executes do not have the same info,  if first mysql_stmt_execute go to server1, and second go to server2, will produce different result; because server2 do not have these meta info will produce unexpected results;

![image](https://user-images.githubusercontent.com/1227070/59833368-79c7b300-9378-11e9-9b6f-7e24fe724eeb.png)


I created a simple test case to reproduce this problem, enable general_log, we can see that 'real query' execute on master and slave are different:
```
 master general_log: select c1 from test_sub_execute where c1= 8.0
 slave general_log : select c1 from test_sub_execute where c1= NULL
```


this PR will record n_params to parse flag new-params-bound-flag, 
if (new-params-bound-flag = 0 && n_params > 0) route COM_STMT_EXECUTE to the server which last COM_STMT_EXECUTE  executed on 


ps: test case https://jira.mariadb.org/secure/attachment/48236/48236_test-mxs-2521.c


I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.
