### PR TITLE
fix api hang

### DIFF
--- a/server/core/resource.cc
+++ b/server/core/resource.cc
@@ -1177,7 +1177,10 @@ HttpResponse resource_handle_request(const HttpRequest& request)
     mxs::Semaphore sem;
     ResourceTask task(request);
 
-    worker->post(&task, &sem);
+    if (!worker->post(&task, &sem))
+    {
+        return HttpResponse(MHD_HTTP_SERVICE_UNAVAILABLE);
+    }
     sem.wait();
 
     return task.result();


### PR DESCRIPTION
When a Message failed to put into MessageQueue, just return http error 503 without wait for semaphore.
