### PR TITLE
Display full test list of test set in the run_test.sh

### DIFF
--- a/maxscale-system-test/mdbci/run_test.sh
+++ b/maxscale-system-test/mdbci/run_test.sh
@@ -103,6 +103,9 @@ fi
 if [ ! -z "${named_test}" ] ; then
     eval ${named_test}
 else
+    echo "===Full test list begin==="
+    ctest ${test_set} --show-only
+    echo "===Full test list end==="
     ctest -VV ${test_set}
 fi
 


### PR DESCRIPTION
In some cases, the ctest does not correctly output information about failed texts to the log. This fix displays a list of tests planned to run, this list is used in the script to parse logs in the buildbot.
