### PR TITLE
bugfix: calculate wrong weight when add server to maxscale on rumtime

### DIFF
--- a/server/core/config_runtime.cc
+++ b/server/core/config_runtime.cc
@@ -175,6 +175,7 @@ bool runtime_link_server(Server* server, const char* target)
         {
             if (serviceAddBackend(service, server))
             {
+                service_update_weights();
                 service_serialize(service);
                 rval = true;
             }
@@ -230,6 +231,7 @@ bool runtime_unlink_server(Server* server, const char* target)
             if (!service->uses_cluster())
             {
                 serviceRemoveBackend(service, server);
+                service_update_weights();
                 service_serialize(service);
                 rval = true;
             }

--- a/server/core/service.cc
+++ b/server/core/service.cc
@@ -1312,6 +1312,11 @@ static void service_calculate_weights(SERVICE* service)
         /** Calculate total weight */
         for (SERVER_REF* server = service->dbref; server; server = server->next)
         {
+            /* If server_ref is not active, skip calculate weight */
+            if (!SERVER_REF_IS_ACTIVE(server))
+            {
+                continue;
+            }
             string buf = server->server->get_custom_parameter(weightby);
             if (!buf.empty())
             {
@@ -1335,6 +1340,11 @@ static void service_calculate_weights(SERVICE* service)
             /** Calculate the relative weight of the servers */
             for (SERVER_REF* server = service->dbref; server; server = server->next)
             {
+                /* If server_ref is not active, skip calculate weight */
+                if (!SERVER_REF_IS_ACTIVE(server))
+                {
+                    continue;
+                }
                 string buf = server->server->get_custom_parameter(weightby);
                 if (!buf.empty())
                 {

--- a/server/core/service.cc
+++ b/server/core/service.cc
@@ -1315,7 +1315,7 @@ static void service_calculate_weights(SERVICE* service)
         for (SERVER_REF* server = service->dbref; server; server = server->next)
         {
             /* If server_ref is not active, skip calculate weight */
-            if (!SERVER_REF_IS_ACTIVE(server))
+            if (!server_ref_is_active(server))
             {
                 continue;
             }
@@ -1343,7 +1343,7 @@ static void service_calculate_weights(SERVICE* service)
             for (SERVER_REF* server = service->dbref; server; server = server->next)
             {
                 /* If server_ref is not active, skip calculate weight */
-                if (!SERVER_REF_IS_ACTIVE(server))
+                if (!server_ref_is_active(server))
                 {
                     continue;
                 }

--- a/server/core/service.cc
+++ b/server/core/service.cc
@@ -166,6 +166,7 @@ void service_add_server(Monitor* pMonitor, SERVER* pServer)
             serviceAddBackend(pService, pServer);
         }
     }
+    service_update_weights();
 }
 
 void service_remove_server(Monitor* pMonitor, SERVER* pServer)
@@ -179,6 +180,7 @@ void service_remove_server(Monitor* pMonitor, SERVER* pServer)
             serviceRemoveBackend(pService, pServer);
         }
     }
+    service_update_weights();
 }
 
 Service::Service(const std::string& name,


### PR DESCRIPTION
I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.

-----

**This MR fix two issues:**
1. Each time add server to service on runtime, trigger recalculate server weight. If not so, the value of `sref->server_weight` will be the default value 1.0, which should be calculated by weight parameter.

2. When a `server_ref` object is removed, instead of really remove from the link list, MaxScale simply mark them to inactive. So in calculating weight, we should skip those inactive `server_ref`.