### PR TITLE
Fix issue of setting up the MariaDB configuration file during the system test

### DIFF
--- a/maxscale-system-test/mariadb_nodes.cpp
+++ b/maxscale-system-test/mariadb_nodes.cpp
@@ -1321,9 +1321,9 @@ void Mariadb_nodes::reset_server_settings(int node)
     std::string cnf = get_config_name(node);
 
     // Note: This is a CentOS specific path
-    ssh_node(node, "sudo rm -rf /etc/my.cnf.d/*", true);
+    ssh_node(node, "rm -rf /etc/my.cnf.d/*", true);
     copy_to_node(node, (cnfdir + cnf).c_str(), "~/");
-    ssh_node_f(node, false, "sudo mv ~/%s /etc/my.cnf.d/", cnf.c_str());
+    ssh_node_f(node, false, "sudo install -o root -g root -m 0644 ~/%s /etc/my.cnf.d/", cnf.c_str());
 }
 
 void Mariadb_nodes::reset_server_settings()


### PR DESCRIPTION
Explicitly state the owner, group and access parameters to the MariaDB configuration file during the server reset.

I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.
