### PR TITLE
Add the force flag for the mdbci destroy command

### DIFF
--- a/BUILD/mdbci/README.md
+++ b/BUILD/mdbci/README.md
@@ -34,7 +34,7 @@ Prerequirements:
 * $HOME/team_keys file contains public keys to be installed to VM
 
 By default VM will not stay alive after the build. Please use ```export do_not_destroy_vm=yes```
-to prevent VM from being destroyed. In this case VM have to be destroyed manually by ```mdbci destroy```
+to prevent VM from being destroyed. In this case VM have to be destroyed manually by ```mdbci destroy --force```
 command.
 
 VM will be created in ```$HOME/vms directory```, binary repository will be created the in

--- a/BUILD/mdbci/build.sh
+++ b/BUILD/mdbci/build.sh
@@ -54,7 +54,7 @@ fi
 if [ "$already_running" != "ok" ]; then
 	# destroying existing box
 	if [ -d "$MDBCI_VM_PATH/${name}" ]; then
-		${mdbci_dir}/mdbci destroy $name
+		${mdbci_dir}/mdbci destroy --force $name
 	fi
         # Just in case some old lock file left
         rm -rf ${snapshot_lock_file}
@@ -111,7 +111,7 @@ if [ "$try_already_running" == "yes" ] ; then
 fi
 if [[ "$do_not_destroy_vm" != "yes" && "$try_already_running" != "yes" ]] ; then
   echo "Destroying VM"
-  ${mdbci_dir}/mdbci destroy $name
+  ${mdbci_dir}/mdbci destroy --force $name
 fi
 cd $dir
 

--- a/BUILD/mdbci/create_full_repo.sh
+++ b/BUILD/mdbci/create_full_repo.sh
@@ -37,7 +37,7 @@ export name=`echo $name | sed "s|/|-|g"`
 
 # destroying existing box
 if [ -d "$MDBCI_VM_PATH/${name}" ]; then
-	${mdbci_dir}/mdbci destroy $name
+	${mdbci_dir}/mdbci destroy --force $name
 fi
 
   eval "cat <<EOF
@@ -95,7 +95,7 @@ echo "Removing locks and destroying VM"
 
 if [[ "$do_not_destroy_vm" != "yes" && "$try_already_running" != "yes" ]] ; then
   echo "Destroying VM"
-  ${mdbci_dir}/mdbci destroy $name
+  ${mdbci_dir}/mdbci destroy --force $name
 fi
 cd $dir
 

--- a/BUILD/mdbci/upgrade_test.sh
+++ b/BUILD/mdbci/upgrade_test.sh
@@ -23,7 +23,7 @@ $(<${script_dir}/templates/install.json.template)
 
 # destroying existing box
 if [ -d "install_$box" ]; then
-        ${mdbci_dir}/mdbci destroy $name
+        ${mdbci_dir}/mdbci destroy --force $name
 fi
 
 # starting VM for build
@@ -33,7 +33,7 @@ if [ $? != 0 ] ; then
         if [ $? != 0 ] ; then
 		echo "Error starting VM"
 		if [ "x$do_not_destroy_vm" != "xyes" ] ; then
-                        ${mdbci_dir}/mdbci destroy $name
+                        ${mdbci_dir}/mdbci destroy --force $name
 		fi
 		rm -f ~/vagrant_lock
 		exit 1
@@ -113,7 +113,7 @@ scp $scpopt $sshuser@$IP:/var/log/maxscale/* $logs_publish_dir
 chmod a+r $logs_publish_dir/*
 
 if [ "x$do_not_destroy_vm" != "xyes" ] ; then
-        ${mdbci_dir}/mdbci destroy $name
+        ${mdbci_dir}/mdbci destroy --force $name
 fi
 kill $pid_to_kill
 exit $res

--- a/system-test/mdbci/README.md
+++ b/system-test/mdbci/README.md
@@ -144,7 +144,7 @@ vagrant resume
 #### Destroying VMs
 
 ```bash
-${mdbci_dir}/mdbci destroy ${mdbci_config_name}
+${mdbci_dir}/mdbci destroy --force ${mdbci_config_name}
 ```
 
 #### Start all backend VMs

--- a/system-test/mdbci/create_config.sh
+++ b/system-test/mdbci/create_config.sh
@@ -11,7 +11,7 @@ if [ "$product" == "mysql" ] ; then
   export cnf_path=${script_dir}/cnf/mysql56
 fi
 
-mdbci destroy $name
+mdbci destroy --force $name
 mkdir -p ${MDBCI_VM_PATH}/$name
 
 export cnf_path="${MDBCI_VM_PATH}/$name/cnf/"

--- a/system-test/mdbci/run_test.sh
+++ b/system-test/mdbci/run_test.sh
@@ -54,7 +54,7 @@ export mdbci_config_name=`echo ${mdbci_config_name} | sed "s/?//g"`
 export provider=`mdbci show provider $box --silent 2> /dev/null`
 export backend_box=${backend_box:-"centos_7_"$provider}
 
-mdbci destroy ${mdbci_config_name}
+mdbci destroy --force ${mdbci_config_name}
 
 . ${script_dir}/configure_log_dir.sh
 
@@ -88,6 +88,6 @@ ${script_dir}/copy_logs.sh
 cd $dir
 
 if [ "${do_not_destroy_vm}" != "yes" ] ; then
-	mdbci destroy ${mdbci_config_name}
+	mdbci destroy --force ${mdbci_config_name}
 	echo "clean up done!"
 fi

--- a/system-test/mdbci/run_test_snapshot.sh
+++ b/system-test/mdbci/run_test_snapshot.sh
@@ -46,7 +46,7 @@ echo $JOB_NAME-$BUILD_NUMBER >> ${snapshot_lock_file}
 mdbci snapshot revert --path-to-nodes ${mdbci_config_name} --snapshot-name ${snapshot_name}
 
 if [ $? != 0 ]; then
-	mdbci destroy ${mdbci_config_name}
+	mdbci destroy --force ${mdbci_config_name}
 	${MDBCI_VM_PATH}/scripts/clean_vms.sh ${mdbci_config_name}
 
 	new_config=true	

--- a/system-test/mdbci/run_test_vm.sh
+++ b/system-test/mdbci/run_test_vm.sh
@@ -22,7 +22,7 @@ mkdir -p $HOME/${mdbci_config_name}_vms
 export provider=`mdbci show provider $box --silent 2> /dev/null`
 export backend_box=${backend_box:-"centos_7_"$provider}
 
-mdbci destroy test_vm
+mdbci destroy --force test_vm
 
 cp ${script_dir}/test_vm.json $HOME/${mdbci_config_name}_vms/
 test_vm_box="ubuntu_bionic_"$provider
@@ -103,8 +103,8 @@ cp core.* ${logs_publish_dir}
 ${script_dir}/copy_logs.sh
 
 if [ "${do_not_destroy_vm}" != "yes" ] ; then
-	mdbci destroy ${mdbci_config_name}
-        mdbci destroy test_vm
+	mdbci destroy --force ${mdbci_config_name}
+        mdbci destroy --force test_vm
         rm -rf $HOME/${mdbci_config_name}_vms
 	echo "clean up done!"
 fi


### PR DESCRIPTION
The destroy command will get interactivity, so scripts without the `force` flag will not work. The `force` flag was added for correct operation.

I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.
