### PR TITLE
MXS-3282: Select query inside transactions are routed to slave with s…

### DIFF
--- a/server/core/session.cc
+++ b/server/core/session.cc
@@ -1456,7 +1456,7 @@ void Session::parse_and_set_trx_state(const mxs::Reply& reply)
 
     if (!trx_state.empty())
     {
-        if (trx_state.find_first_of("TI") == std::string::npos)
+        if (trx_state.find_first_of("TI") != std::string::npos)
         {
             set_trx_state(SESSION_TRX_ACTIVE);
         }


### PR DESCRIPTION
…ession_track_trx_state=true

if (trx_state.find_first_of("TI") == std::string::npos) is the reverse of what we want.
If neither T and I are set, we set our trx state to SESSION_TRX_ACTIVE.
This should be If either T or I is set, our trx_state is SESSION_TRX_ACTIVE

I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.
