### PR TITLE
MXS-3238

### DIFF
--- a/include/maxscale/config.hh
+++ b/include/maxscale/config.hh
@@ -137,6 +137,7 @@ public:
     std::string   admin_pam_rw_service;         /**< PAM service for read-write users */
     std::string   admin_pam_ro_service;         /**< PAM service for read-only users */
     std::string   admin_ssl_key;                /**< Admin SSL key */
+    std::string   admin_ssl_cipher;             /**< Admin allowed SSL ciphers */
     std::string   admin_ssl_cert;               /**< Admin SSL cert */
     std::string   admin_ssl_ca_cert;            /**< Admin SSL CA cert */
     std::string   local_address;                /**< Local address to use when connecting */
@@ -218,6 +219,7 @@ private:
     static config::ParamString              s_admin_pam_rw_service;
     static config::ParamString              s_admin_pam_ro_service;
     static config::ParamString              s_admin_ssl_key;
+    static config::ParamString              s_admin_ssl_cipher;
     static config::ParamString              s_admin_ssl_cert;
     static config::ParamString              s_admin_ssl_ca_cert;
     static config::ParamString              s_local_address;

--- a/server/core/admin.cc
+++ b/server/core/admin.cc
@@ -284,19 +284,33 @@ static bool load_ssl_certificates()
 
     // Set cipher appropriately, including some shorcuts.
     if (cipher.empty())
+    {
         this_unit.ssl_cipher = "NORMAL";
+    }
     else if (cipher == "SSLv3")
+    {
         this_unit.ssl_cipher = "NONE:+VERS-SSL3.0";
+    }
     else if (cipher == "TLSv1.0")
+    {
         this_unit.ssl_cipher = "NONE:+VERS-TLS1.0";
+    }
     else if (cipher == "TLSv1.1")
+    {
         this_unit.ssl_cipher = "NONE:+VERS-TLS1.1";
+    }
     else if (cipher == "TLSv1.2")
+    {
         this_unit.ssl_cipher = "NONE:+VERS-TLS1.2";
+    }
     else if (cipher == "TLSv1.3")
+    {
         this_unit.ssl_cipher = "NONE:+VERS-TLS1.3";
+    }
     else
+    {
         this_unit.ssl_cipher = cipher;
+    }
 
     if (!key.empty() && !cert.empty())
     {

--- a/server/core/config.cc
+++ b/server/core/config.cc
@@ -88,6 +88,7 @@ constexpr char CN_ADMIN_PORT[] = "admin_port";
 constexpr char CN_ADMIN_SSL_CA_CERT[] = "admin_ssl_ca_cert";
 constexpr char CN_ADMIN_SSL_CERT[] = "admin_ssl_cert";
 constexpr char CN_ADMIN_SSL_KEY[] = "admin_ssl_key";
+constexpr char CN_ADMIN_SSL_CIPHER[] = "admin_ssl_cipher";
 constexpr char CN_AUTO[] = "auto";
 constexpr char CN_DEBUG[] = "debug";
 constexpr char CN_DUMP_LAST_STATEMENTS[] = "dump_last_statements";
@@ -461,6 +462,12 @@ config::ParamString Config::s_admin_ssl_key(
     "Admin SSL key",
     "");
 
+config::ParamString Config::s_admin_ssl_cipher(
+    &Config::s_specification,
+    CN_ADMIN_SSL_CIPHER,
+    "Admin allowed SSL ciphers",
+    "");
+
 config::ParamString Config::s_admin_ssl_cert(
     &Config::s_specification,
     CN_ADMIN_SSL_CERT,
@@ -614,6 +621,7 @@ Config::Config()
     add_native(&admin_pam_rw_service, &s_admin_pam_rw_service);
     add_native(&admin_pam_ro_service, &s_admin_pam_ro_service);
     add_native(&admin_ssl_key, &s_admin_ssl_key);
+    add_native(&admin_ssl_cipher, &s_admin_ssl_cipher);
     add_native(&admin_ssl_cert, &s_admin_ssl_cert);
     add_native(&admin_ssl_ca_cert, &s_admin_ssl_ca_cert);
     add_native(&local_address, &s_local_address);
@@ -3650,6 +3658,7 @@ bool config_is_ssl_parameter(const char* key)
         CN_SSL_CA_CERT,
         CN_SSL,
         CN_SSL_KEY,
+        CN_SSL_CIPHER,
         CN_SSL_VERSION,
         CN_SSL_CERT_VERIFY_DEPTH,
         CN_SSL_VERIFY_PEER_CERTIFICATE,


### PR DESCRIPTION
Fixes to specify accepted ciphers for the REST API as per MXS-3238
