### PR TITLE
MXS-3342: Persistent connections cause signal 11 when no matching con…

### DIFF
--- a/server/core/routingworker.cc
+++ b/server/core/routingworker.cc
@@ -564,6 +564,13 @@ BackendDCB* RoutingWorker::get_backend_dcb_from_pool(SERVER* pS,
             }
         }
 
+        // If proxy protocol is in use there is a possibility that 
+        // no DCBs are suitable to use. 
+        if (!pDcb)
+        {
+            break;		
+        }
+
         // Put back the origininal handler.
         pDcb->set_handler(pDcb->protocol());
         auto ses = static_cast<Session*>(pSession);


### PR DESCRIPTION
…nection is found

There is no guarantee that the persistent pool contains a connection which matches our host
when proxy protocol is un use. We should handle this.

I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.

I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.
