### PR TITLE
Why do a 'mysql - umaxscale - p123456 - h172.16.1.46 P3306 - e" show the databases " '  in the log will connect all the nodes (including master)

### DIFF
--- a/Documentation/Release-Notes/MaxScale-2.5.6-Release-Notes.md
+++ b/Documentation/Release-Notes/MaxScale-2.5.6-Release-Notes.md
@@ -8,6 +8,12 @@ previous release in the same series.
 For any problems you encounter, please consider submitting a bug
 report on [our Jira](https://jira.mariadb.org/projects/MXS).
 
+**NOTE** After the release of 2.5.6 it was noticed that configuring the same
+server for _both_ the persistent pool (configuration settings `persistpoolmax`
+and `persistmaxtime`) and the proxy protocol (configuration setting `proxy_protocol`)
+may in some situations lead to a crash. Using either one is ok. We will release
+2.5.7 with a fix for this as soon as possible (January 2021).
+
 ## New Features
 
 * [MXS-3129](https://jira.mariadb.org/browse/MXS-3129) Add Switchover to WebGUI


### PR DESCRIPTION
2020-12-17 14:49:55   info   : (2) Found matching user 'maxscale'@'172.16.1.0/255.255.255.0' for client 'maxscale'@'::ffff:172.16.1.42' with sufficient privileges.
2020-12-17 14:49:55   info   : (2) [readwritesplit] (Read-Write-Service) Target connection counts:
2020-12-17 14:49:55   info   : (2) [readwritesplit] (Read-Write-Service) current operations : 0 in      server1 Slave, Running
2020-12-17 14:49:55   info   : (2) [readwritesplit] (Read-Write-Service) current operations : 0 in      server2 Slave, Running
2020-12-17 14:49:55   info   : (2) [readwritesplit] (Read-Write-Service) current operations : 0 in      server3 Master, Running
**2020-12-17 14:49:55   info   : (2) [readwritesplit] (Read-Write-Service) Connected to 'server3'
2020-12-17 14:49:55   info   : (2) [readwritesplit] (Read-Write-Service) Selected Master: server3
2020-12-17 14:49:55   info   : (2) [readwritesplit] (Read-Write-Service) Connected to 'server1'
2020-12-17 14:49:55   info   : (2) [readwritesplit] (Read-Write-Service) Selected Slave: server1
2020-12-17 14:49:55   info   : (2) [readwritesplit] (Read-Write-Service) Connected to 'server2'
2020-12-17 14:49:55   info   : (2) [readwritesplit] (Read-Write-Service) Selected Slave: server2**
2020-12-17 14:49:55   info   : (2) Started Read-Write-Service client session [2] for 'maxscale' from ::ffff:172.16.1.42
2020-12-17 14:49:55   info   : (2) Connected to 'server2' with thread id 187
2020-12-17 14:49:55   info   : (2) Connected to 'server3' with thread id 203
2020-12-17 14:49:55   info   : (2) Connected to 'server1' with thread id 192
2020-12-17 14:49:55   info   : (2) (Read-Write-Service) > Autocommit: [enabled], trx is [not open], cmd: (0x03) COM_QUERY, plen: 37, type: QUERY_TYPE_READ|QUERY_TYPE_SYSVAR_READ, stmt: select @@version_comment limit 1 
2020-12-17 14:49:55   info   : (2) [readwritesplit] (Read-Write-Service) Route query to slave: server1 <
**2020-12-17 14:49:55   info   : (2) Authentication to 'server2' succeeded.
2020-12-17 14:49:55   info   : (2) Authentication to 'server3' succeeded.
2020-12-17 14:49:55   info   : (2) Authentication to 'server1' succeeded.**
2020-12-17 14:49:55   info   : (2) [readwritesplit] (Read-Write-Service) Reply complete, last reply from server1
2020-12-17 14:49:55   info   : (2) (Read-Write-Service) > Autocommit: [enabled], trx is [not open], cmd: (0x03) COM_QUERY, plen: 19, type: QUERY_TYPE_SHOW_DATABASES, stmt: show databases 
2020-12-17 14:49:55   info   : (2) [readwritesplit] (Read-Write-Service) Route query to slave: server2 <
2020-12-17 14:49:55   info   : (2) [readwritesplit] (Read-Write-Service) Reply complete, last reply from server2
2020-12-17 14:49:55   info   : (2) (Read-Write-Service) > Autocommit: [enabled], trx is [not open], cmd: (0x01) COM_QUIT, plen: 5, type: QUERY_TYPE_SESSION_WRITE, stmt:  
2020-12-17 14:49:55   info   : (2) [readwritesplit] (Read-Write-Service) Session write, routing to all servers.
2020-12-17 14:49:55   info   : (2) (Read-Write-Service) Execute sescmd 1 on 'server1': 
2020-12-17 14:49:55   info   : (2) [readwritesplit] (Read-Write-Service) Route query to slave: server1
2020-12-17 14:49:55   info   : (2) (Read-Write-Service) Execute sescmd 1 on 'server2': 
2020-12-17 14:49:55   info   : (2) [readwritesplit] (Read-Write-Service) Route query to slave: server2
2020-12-17 14:49:55   info   : (2) (Read-Write-Service) Execute sescmd 1 on 'server3': 
2020-12-17 14:49:55   info   : (2) [readwritesplit] (Read-Write-Service) Route query to master: server3
2020-12-17 14:49:55   info   : Stopped Read-Write-Service client session [2]


Session write, routing to all servers. ----->What is it?