### PR TITLE
Fix memory leak for explain

### DIFF
--- a/query_classifier/qc_sqlite/qc_sqlite.cc
+++ b/query_classifier/qc_sqlite/qc_sqlite.cc
@@ -2400,6 +2400,8 @@ public:
                 update_names(pList->a[i].zDatabase, pList->a[i].zName, pList->a[i].zAlias, nullptr);
             }
         }
+
+        exposed_sqlite3SrcListDelete(pParse->db, pList);
     }
 
     void maxscaleExplain(Parse* pParse)


### PR DESCRIPTION
For SQL: describle table_name

The reduced srclist is not freed which will cause memory leak.

I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.
