### PR TITLE
Update default.json.template

### DIFF
--- a/system-test/mdbci/templates/default.json.template
+++ b/system-test/mdbci/templates/default.json.template
@@ -184,6 +184,9 @@
       },
       {
         "name" : "docker"
+      },
+      {
+        "name": "caching_tools"
       }
     ]
   },


### PR DESCRIPTION
Add product 'caching_tools' to maxscale_000 so that memcached and redis are installed. That will also cause extra_package_management to be installed and that is needed by the cache_redis_ssl test.

I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.
