### PR TITLE
fixed documentation for parameter 'query_classifier_cache_size' in version 23.08

### DIFF
--- a/Documentation/Getting-Started/Configuration-Guide.md
+++ b/Documentation/Getting-Started/Configuration-Guide.md
@@ -988,7 +988,7 @@ the cache. The size of the cache can be specifed as explained [here](#sizes).
 
 ```
 # 1MB query classifier cache
-query_classifier_cache_size=1MB
+query_classifier_cache_size=1M
 ```
 
 Note that MaxScale uses a separate cache for each worker thread. To obtain the


### PR DESCRIPTION
The abbreviation of the memory size in the documentation for the 'query_classifier_cache_size' parameter was incorrect. This MR fixes this small error. The correct memory sizes can be viewed at: https://mariadb.com/kb/en/mariadb-maxscale-2308-mariadb-maxscale-configuration-guide/#sizes

I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.
