### PR TITLE
Fix Galera cluster creation for system-test

### DIFF
--- a/system-test/maxtest/include/maxtest/log.hh
+++ b/system-test/maxtest/include/maxtest/log.hh
@@ -81,6 +81,7 @@ struct SharedData
     TestLogger  log;        /**< Error log container */
     Settings    settings;
     std::string test_name;      /**< Test name */
+    std::string vm_path;
 
     bool concurrent_run(const BoolFuncArray& funcs);
 

--- a/system-test/maxtest/include/maxtest/mariadb_nodes.hh
+++ b/system-test/maxtest/include/maxtest/mariadb_nodes.hh
@@ -283,6 +283,15 @@ public:
      */
     bool unblock_node(int node);
 
+    /**
+     * Setup firewall on a backend node to open port.
+     *
+     * @param node Index of node
+     * @param port Port to open
+     * @return True on success
+     */
+    bool unblock_node(int node, int port);
+
 
     /**
      * @brief Block all nodes for this cluster
@@ -505,6 +514,13 @@ protected:
      * @return The command used for unblocking a node.
      */
     virtual std::string unblock_command(int node) const;
+
+
+    /**
+     * @param port port to open.
+     * @return The command used for port opening.
+     */
+    virtual std::string unblock_port_command(int node) const;
 
     mxt::MariaDBUserDef service_user_def() const;
 

--- a/system-test/maxtest/src/galera_cluster.cc
+++ b/system-test/maxtest/src/galera_cluster.cc
@@ -48,12 +48,21 @@ bool GaleraCluster::start_replication()
     auto gcomm = ss.str();
 
     run_on_every_backend([&](int i){
+        copy_to_node(i,
+                     (m_shared.vm_path + std::string("/") + get_srv_cnf_filename(i)).c_str(),
+                     access_homedir(i));
+        ssh_node(i,
+                 (std::string("cp ") + get_srv_cnf_filename(i) + std::string(" /etc/my.cnf.d/")).c_str(),
+                  true);
         ssh_node(i, "echo [mysqld] > cluster_address.cnf", true);
         ssh_node_f(i, true, "echo wsrep_cluster_address=gcomm://%s >>  cluster_address.cnf", gcomm.c_str());
         ssh_node(i, "cp cluster_address.cnf /etc/my.cnf.d/", true);
         ssh_node(i, "cp cluster_address.cnf /etc/mysql/my.cnf.d/", true);
 
         ssh_node(i, "rm -rf /var/lib/mysql/*", true);
+        unblock_node(i, 4567);
+        unblock_node(i, 4568);
+        unblock_node(i, 4444);
         ssh_node(i, "mariadb-install-db --user=mysql", true);
 
         ssh_node_f(i,

--- a/system-test/maxtest/src/testconnections.cc
+++ b/system-test/maxtest/src/testconnections.cc
@@ -150,6 +150,7 @@ int TestConnections::prepare_for_test(int argc, char* argv[])
 
     // Read basic settings from env variables first, as cmdline may override.
     read_basic_settings();
+    m_shared.vm_path = m_vm_path;
 
     if (!read_cmdline_options(argc, argv))
     {

--- a/system-test/mdbci/templates/default.json.template
+++ b/system-test/mdbci/templates/default.json.template
@@ -86,13 +86,8 @@
         "name": "${product}",
         "version": "${version}",
         "force_version": ${force_backend_version}
-      },
-      {
-        "name": "galera_config",
-        "cnf_template" : "galera_server1.cnf"
       }
-    ],
-    "cnf_template_path": "${cnf_path}"
+    ]
   },
 
   "galera_001" :
@@ -109,13 +104,8 @@
         "name": "${product}",
         "version": "${version}",
         "force_version": ${force_backend_version}
-      },
-      {
-        "name": "galera_config",
-        "cnf_template" : "galera_server2.cnf"
       }
-    ],
-    "cnf_template_path": "${cnf_path}"
+    ]
   },
 
   "galera_002" :
@@ -132,13 +122,8 @@
         "name": "${product}",
         "version": "${version}",
         "force_version": ${force_backend_version}
-      },
-      {
-        "name": "galera_config",
-        "cnf_template" : "galera_server3.cnf"
       }
-    ],
-    "cnf_template_path": "${cnf_path}"
+    ]
   },
 
   "galera_003" :
@@ -155,13 +140,8 @@
         "name": "${product}",
         "version": "${version}",
         "force_version": ${force_backend_version}
-      },
-      {
-        "name": "galera_config",
-        "cnf_template" : "galera_server4.cnf"
       }
-    ],
-    "cnf_template_path": "${cnf_path}"
+    ]
   },
 
   "maxscale_000" :


### PR DESCRIPTION
now galera_server*.cnf files are configured by `galera_config` MDBCI product, but these files do not contain `wsrep_cluster_address`. This parameter is configured by system-test code in the separate cluster_address.cnf file. It means after MDBCI provisioning but before creation of cluster_address.cnf by system-test the server configuration is broken. The Community Server ignores it and the server can be started, but the Enterprise server fails to start.
The solution is to remove `galera_config` product and move galera_server*.cnf files coping and configuration to system-test code.