### PR TITLE
copy MDBCI config to LOGS

### DIFF
--- a/system-test/mdbci/copy_logs.sh
+++ b/system-test/mdbci/copy_logs.sh
@@ -13,7 +13,8 @@
 #
 
 set -x
+cp  ${MDBCI_VM_PATH}/${mdbci_config_name}.json LOGS/
+cp -r ${MDBCI_VM_PATH}/${mdbci_config_name} LOGS/
+rm -rf LOGS/${mdbci_config_name}/*.pem
 rsync -a --no-o --no-g LOGS ${logs_publish_dir}
 chmod a+r ${logs_publish_dir}/*
-cp -r ${MDBCI_VM_PATH}/${mdbci_config_name} ${logs_publish_dir}
-cp  ${MDBCI_VM_PATH}/${mdbci_config_name}.json ${logs_publish_dir}


### PR DESCRIPTION
add storing of all MDBCI files in order to simplify MDBCI failures investigation