### PR TITLE
Add MySQL 8.x replication monitoring and GTID failover

### DIFF
--- a/Documentation/Monitors/MySQL-Replication-Monitor.md
+++ b/Documentation/Monitors/MySQL-Replication-Monitor.md
@@ -1,0 +1,86 @@
+# MySQL Replication Monitor
+
+[TOC]
+
+## Overview
+
+MySQL Replication Monitor (`mysqlrepmon`) monitors a MySQL 8.x
+Primary/Replica replication cluster and can perform automatic **failover**,
+**switchover** and **rejoin** using MySQL's UUID-based GTIDs
+(`SOURCE_AUTO_POSITION = 1`).
+
+It is a MySQL-specific sibling of [MariaDB Monitor](MariaDB-Monitor.md).
+Where MariaDB Monitor speaks MariaDB's replication dialect
+(`SHOW ALL SLAVES STATUS`, `domain-server-sequence` GTIDs, `CHANGE MASTER
+TO ... MASTER_USE_GTID`), `mysqlrepmon` speaks the MySQL 8.x dialect that
+MySQL 8.4 now requires:
+
+* `SHOW REPLICA STATUS` (the legacy `SHOW SLAVE STATUS` was removed in 8.4)
+* `CHANGE REPLICATION SOURCE TO ... SOURCE_AUTO_POSITION = 1 ... FOR CHANNEL`
+* `START` / `STOP` / `RESET REPLICA ... FOR CHANNEL`
+* `SET GLOBAL super_read_only = 1` to demote a primary
+* GTID state read from `@@global.gtid_executed` / `@@global.gtid_purged`
+
+The configuration parameters, monitor commands (`switchover`, `failover`,
+`rejoin`, `reset-replication`, and their `async-` variants) and the
+failover/switchover/rejoin behaviour are identical to MariaDB Monitor; see
+that document for the full parameter reference. Use `module=mysqlrepmon`
+instead of `module=mariadbmon`.
+
+## Requirements
+
+* MySQL Server 8.0.22 or later on all backends (8.4 supported).
+* `gtid_mode = ON` and `enforce_gtid_consistency = ON` on every server, with
+  replicas configured for GTID auto-positioning
+  (`CHANGE REPLICATION SOURCE TO SOURCE_AUTO_POSITION = 1`).
+* `log_bin` and `log_replica_updates` enabled on servers that may be promoted.
+
+## Required Grants
+
+For monitoring only:
+```
+CREATE USER 'maxscale'@'maxscalehost' IDENTIFIED BY 'maxscale-password';
+GRANT REPLICATION CLIENT ON *.* TO 'maxscale'@'maxscalehost';
+```
+
+For failover / switchover / rejoin the monitor user additionally needs the
+privileges to reconfigure replication and toggle read-only, e.g.:
+```
+GRANT REPLICATION SLAVE, REPLICATION CLIENT, PROCESS, SUPER,
+      SYSTEM_VARIABLES_ADMIN, REPLICATION_SLAVE_ADMIN, CONNECTION_ADMIN
+      ON *.* TO 'maxscale'@'maxscalehost';
+```
+The `replication_user` used in the generated `CHANGE REPLICATION SOURCE`
+command must have `REPLICATION SLAVE` on all servers.
+
+When the backends use the default `caching_sha2_password` authentication over
+a non-TLS connection, the monitor issues the `CHANGE REPLICATION SOURCE`
+command with `GET_SOURCE_PUBLIC_KEY = 1` so the replica can complete the
+handshake with the promoted primary. Configure `replication_master_ssl=true`
+to use TLS instead.
+
+## Example configuration
+
+```
+[MySQL-Monitor]
+type=monitor
+module=mysqlrepmon
+servers=server1,server2,server3
+user=maxscale
+password=maxscale-password
+monitor_interval=2000ms
+auto_failover=true
+auto_rejoin=true
+enforce_read_only_slaves=true
+replication_user=maxscale
+replication_password=maxscale-password
+```
+
+## Implementation notes
+
+Internally the monitor maps each MySQL `server_uuid` to a stable synthetic
+GTID *domain* and reduces each GTID interval set to its highest transaction
+number. This lets the shared MariaDB Monitor failover engine reason about
+"which replica is furthest ahead" and "can A replicate from B" without any
+change to that logic. MySQL's `Retrieved_Gtid_Set` maps to the engine's
+relay-log GTID position and `gtid_executed` to the applied position.

--- a/server/modules/monitor/CMakeLists.txt
+++ b/server/modules/monitor/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(galeramon)
 add_subdirectory(mariadbmon)
+add_subdirectory(mysqlrepmon)
 if (BUILD_POSTGRES)
     add_subdirectory(pgmon)
 endif()

--- a/server/modules/monitor/mariadbmon/mariadbserver.cc
+++ b/server/modules/monitor/mariadbmon/mariadbserver.cc
@@ -39,6 +39,8 @@ namespace
 {
 const char not_a_db[] = "it is not a valid database.";
 const string grant_test_query = "SHOW SLAVE STATUS;";
+// MySQL 8.4 removed "SHOW SLAVE STATUS"; the equivalent permission test uses the new spelling.
+const string grant_test_query_mysql = "SHOW REPLICA STATUS;";
 }
 
 MariaDBServer::MariaDBServer(SERVER* server, int config_index,
@@ -318,10 +320,18 @@ bool MariaDBServer::do_show_slave_status(string* errmsg_out)
 {
     string query;
     bool all_slaves_status = false;
+    // MySQL 8.0.22+ uses the "REPLICA" command vocabulary and renamed the SHOW SLAVE STATUS columns
+    // (Master_* -> Source_*, Slave_*_Running -> Replica_*_Running, Seconds_Behind_Master ->
+    // Seconds_Behind_Source). MySQL 8.4 removed the legacy "SLAVE" spelling completely.
+    const bool mysql_replica = m_capabilities.mysql_replica_syntax;
     if (m_capabilities.slave_status_all)
     {
         all_slaves_status = true;
         query = "SHOW ALL SLAVES STATUS;";
+    }
+    else if (mysql_replica)
+    {
+        query = "SHOW REPLICA STATUS;";
     }
     else if (m_capabilities.basic_support)
     {
@@ -339,16 +349,25 @@ bool MariaDBServer::do_show_slave_status(string* errmsg_out)
         return false;
     }
 
+    // Column names differ between the MariaDB ("Master_*"/"Slave_*") and the MySQL 8.0.22+
+    // ("Source_*"/"Replica_*") replication dialects.
+    const char* col_master_host = mysql_replica ? "Source_Host" : "Master_Host";
+    const char* col_master_port = mysql_replica ? "Source_Port" : "Master_Port";
+    const char* col_io_running = mysql_replica ? "Replica_IO_Running" : "Slave_IO_Running";
+    const char* col_sql_running = mysql_replica ? "Replica_SQL_Running" : "Slave_SQL_Running";
+    const char* col_master_server_id = mysql_replica ? "Source_Server_Id" : "Master_Server_Id";
+    const char* col_seconds_behind = mysql_replica ? "Seconds_Behind_Source" : "Seconds_Behind_Master";
+
     // Fields common to all server versions
-    auto i_master_host = result->get_col_index("Master_Host");
-    auto i_master_port = result->get_col_index("Master_Port");
-    auto i_slave_io_running = result->get_col_index("Slave_IO_Running");
-    auto i_slave_sql_running = result->get_col_index("Slave_SQL_Running");
-    auto i_master_server_id = result->get_col_index("Master_Server_Id");
+    auto i_master_host = result->get_col_index(col_master_host);
+    auto i_master_port = result->get_col_index(col_master_port);
+    auto i_slave_io_running = result->get_col_index(col_io_running);
+    auto i_slave_sql_running = result->get_col_index(col_sql_running);
+    auto i_master_server_id = result->get_col_index(col_master_server_id);
     auto i_last_io_errno = result->get_col_index("Last_IO_Errno");
     auto i_last_io_error = result->get_col_index("Last_IO_Error");
     auto i_last_sql_error = result->get_col_index("Last_SQL_Error");
-    auto i_seconds_behind_master = result->get_col_index("Seconds_Behind_Master");
+    auto i_seconds_behind_master = result->get_col_index(col_seconds_behind);
 
     const char INVALID_DATA[] = "'%s' returned invalid data.";
     if (i_master_host < 0 || i_master_port < 0 || i_slave_io_running < 0 || i_slave_sql_running < 0
@@ -374,6 +393,12 @@ bool MariaDBServer::do_show_slave_status(string* errmsg_out)
             MXB_ERROR(INVALID_DATA, query.c_str());
             return false;
         }
+    }
+    else if (mysql_replica)
+    {
+        // MySQL "SHOW REPLICA STATUS" returns one row per replication channel. The default channel
+        // name is empty, which matches the default (unnamed) MariaDB connection.
+        i_connection_name = result->get_col_index("Channel_Name");
     }
 
     SlaveStatusArray slave_status_new;
@@ -424,6 +449,13 @@ bool MariaDBServer::do_show_slave_status(string* errmsg_out)
             {
                 new_row.gtid_io_pos = GtidList::from_string(gtid_io_pos);
             }
+        }
+        else if (mysql_replica && i_connection_name >= 0)
+        {
+            // Track the MySQL replication channel name. MySQL GTID (Auto_Position) uses a UUID-based
+            // format incompatible with MariaDB's GtidList, so gtid_mode is left as NONE: file/position
+            // replication is monitored via the master server id and the running flags above.
+            new_row.settings.name = result->get_string(i_connection_name);
         }
 
         // If parsing fails, discard all query results.
@@ -625,7 +657,12 @@ bool MariaDBServer::read_server_variables(string* errmsg_out)
 
 void MariaDBServer::check_semisync_master_status()
 {
-    const char* query =
+    // MySQL 8.0.26+ renamed the semi-sync "master" plugin variables to "source".
+    const char* query = m_capabilities.mysql_replica_syntax ?
+        "SELECT c.VARIABLE_VALUE, s.VARIABLE_VALUE FROM "
+        "INFORMATION_SCHEMA.GLOBAL_VARIABLES c JOIN INFORMATION_SCHEMA.GLOBAL_STATUS s "
+        "ON(c.VARIABLE_NAME = 'rpl_semi_sync_source_enabled' AND s.VARIABLE_NAME = 'rpl_semi_sync_source_status')"
+        :
         "SELECT c.VARIABLE_VALUE, s.VARIABLE_VALUE FROM "
         "INFORMATION_SCHEMA.GLOBAL_VARIABLES c JOIN INFORMATION_SCHEMA.GLOBAL_STATUS s "
         "ON(c.VARIABLE_NAME = 'rpl_semi_sync_master_enabled' AND s.VARIABLE_NAME = 'rpl_semi_sync_master_status')";
@@ -1016,6 +1053,13 @@ void MariaDBServer::update_server_version()
         if (total >= 50500)
         {
             m_capabilities.basic_support = true;
+            // MySQL 8.0.22 introduced the "REPLICA"/"SOURCE" command vocabulary and 8.4 removed the
+            // legacy "SLAVE"/"MASTER" spelling entirely. From 8.0.22 onwards the monitor must speak the
+            // new dialect, e.g. "SHOW REPLICA STATUS" instead of "SHOW SLAVE STATUS".
+            if (type == ServerType::MYSQL && total >= 80022)
+            {
+                m_capabilities.mysql_replica_syntax = true;
+            }
             // For more specific features, at least MariaDB 10.4 is needed.
             if ((type == ServerType::MARIADB || type == ServerType::BLR) && total >= 100400)
             {
@@ -2943,7 +2987,7 @@ const MonitorServer::EventList& MariaDBServer::new_custom_events() const
 
 const std::string& MariaDBServer::permission_test_query() const
 {
-    return grant_test_query;
+    return m_capabilities.mysql_replica_syntax ? grant_test_query_mysql : grant_test_query;
 }
 
 bool MariaDBServer::relax_connector_timeouts(std::chrono::seconds op_timeout)

--- a/server/modules/monitor/mariadbmon/mariadbserver.hh
+++ b/server/modules/monitor/mariadbmon/mariadbserver.hh
@@ -113,6 +113,8 @@ public:
         bool basic_support {false};         // Is the server version supported by the monitor at all?
         bool gtid {false};                  // Supports MariaDB gtid? Required for failover etc.
         bool slave_status_all {false};      // Supports "show all slaves status"?
+        bool mysql_replica_syntax {false};  // MySQL 8.0.22+: must use "SHOW REPLICA STATUS" etc. The
+                                            // legacy "SLAVE" spelling was removed in MySQL 8.4.
         bool max_statement_time {false};    // Supports max_statement_time?
         bool events {false};                // Supports event handling?
         bool read_only_admin {false};       // Implements read-only admin priv?

--- a/server/modules/monitor/mysqlrepmon/CMakeLists.txt
+++ b/server/modules/monitor/mysqlrepmon/CMakeLists.txt
@@ -1,0 +1,14 @@
+# libssh is already built by the mariadbmon module (the 'libssh' ExternalProject target is global).
+# Re-including cmake/BuildLibSSH.cmake here would redefine that target, so just reuse its outputs.
+set(LIBSSH_INSTALL_DIR ${CMAKE_BINARY_DIR}/libssh/install)
+set(LIBSSH_LIBRARY ${LIBSSH_INSTALL_DIR}/lib/libssh.a)
+set(LIBSSH_INCLUDE_DIR ${LIBSSH_INSTALL_DIR}/include)
+
+add_library(mysqlrepmon SHARED mariadbmon.cc cluster_manipulation.cc cluster_discovery.cc
+            monitor_commands.cc mariadbserver.cc server_utils.cc mariadbmon_common.cc ssh_utils.cc)
+target_link_libraries(mysqlrepmon maxscale-common ${LIBSSH_LIBRARY})
+target_include_directories(mysqlrepmon PRIVATE ${LIBSSH_INCLUDE_DIR})
+add_dependencies(mysqlrepmon libssh)
+
+set_target_properties(mysqlrepmon PROPERTIES VERSION "1.0.0" LINK_FLAGS -Wl,-z,defs)
+install_module(mysqlrepmon core)

--- a/server/modules/monitor/mysqlrepmon/CMakeLists.txt
+++ b/server/modules/monitor/mysqlrepmon/CMakeLists.txt
@@ -1,14 +1,7 @@
-# libssh is already built by the mariadbmon module (the 'libssh' ExternalProject target is global).
-# Re-including cmake/BuildLibSSH.cmake here would redefine that target, so just reuse its outputs.
-set(LIBSSH_INSTALL_DIR ${CMAKE_BINARY_DIR}/libssh/install)
-set(LIBSSH_LIBRARY ${LIBSSH_INSTALL_DIR}/lib/libssh.a)
-set(LIBSSH_INCLUDE_DIR ${LIBSSH_INSTALL_DIR}/include)
-
 add_library(mysqlrepmon SHARED mariadbmon.cc cluster_manipulation.cc cluster_discovery.cc
             monitor_commands.cc mariadbserver.cc server_utils.cc mariadbmon_common.cc ssh_utils.cc)
 target_link_libraries(mysqlrepmon maxscale-common ${LIBSSH_LIBRARY})
 target_include_directories(mysqlrepmon PRIVATE ${LIBSSH_INCLUDE_DIR})
-add_dependencies(mysqlrepmon libssh)
 
 set_target_properties(mysqlrepmon PROPERTIES VERSION "1.0.0" LINK_FLAGS -Wl,-z,defs)
 install_module(mysqlrepmon core)

--- a/server/modules/monitor/mysqlrepmon/cluster_discovery.cc
+++ b/server/modules/monitor/mysqlrepmon/cluster_discovery.cc
@@ -1,0 +1,1322 @@
+/*
+ * Copyright (c) 2018 MariaDB Corporation Ab
+ * Copyright (c) 2023 MariaDB plc, Finnish Branch
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file and at www.mariadb.com/bsl11.
+ *
+ * Change Date: 2027-09-09
+ *
+ * On the date above, in accordance with the Business Source License, use
+ * of this software will be governed by version 2 or later of the General
+ * Public License.
+ */
+
+#include "mariadbmon.hh"
+
+#include <algorithm>
+#include <string>
+#include <queue>
+#include <maxbase/format.hh>
+#include <maxbase/host.hh>
+
+using std::string;
+using maxbase::string_printf;
+using LockType = MariaDBServer::LockType;
+using namespace std::chrono_literals;
+
+namespace
+{
+using VisitorFunc = std::function<bool (MariaDBServer*)>;   // Used by graph search
+
+enum class SlaveMode {ACTIVE_REPL, ALL};
+/**
+ * Generic depth-first search. Iterates through the root and its child nodes (slaves) and runs
+ * 'visitor' on the nodes. 'NodeData::reset_indexes()' should be ran before this function
+ * depending on if previous node visits should be omitted or not.
+ *
+ * @param root Starting server. The server and all its slaves are visited.
+ * @param visitor Function to run on a node when visiting it. If it returns true,
+ * the search is continued to the children of the node.
+ * @param slave_mode Expand active slaves only or include broken slaves
+ */
+void topology_DFS(MariaDBServer* root, VisitorFunc& visitor, SlaveMode slave_mode)
+{
+    int next_index = NodeData::INDEX_FIRST;
+    // This lambda is recursive, so its type needs to be defined and it needs to "capture itself".
+    std::function<void(MariaDBServer*, VisitorFunc&)> topology_DFS_visit =
+        [&topology_DFS_visit, &next_index, slave_mode](MariaDBServer* node, VisitorFunc& vis) {
+        mxb_assert(node->m_node.index == NodeData::INDEX_NOT_VISITED);
+        node->m_node.index = next_index++;
+        if (vis(node))
+        {
+            for (MariaDBServer* slave : node->m_node.children)
+            {
+                if (slave->m_node.index == NodeData::INDEX_NOT_VISITED)
+                {
+                    topology_DFS_visit(slave, vis);
+                }
+            }
+
+            if (slave_mode == SlaveMode::ALL)
+            {
+                for (MariaDBServer* slave : node->m_node.children_failed)
+                {
+                    topology_DFS_visit(slave, vis);
+                }
+            }
+        }
+    };
+
+    topology_DFS_visit(root, visitor);
+}
+}
+
+/**
+ * @brief Visit a node in the graph
+ *
+ * This function is the main function used to determine whether the node is a part of a cycle. It is
+ * an implementation of the Tarjan's strongly connected component algorithm. All one node cycles are
+ * ignored since normal master-slave monitoring handles that.
+ *
+ * Tarjan's strongly connected component algorithm:
+ * https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
+ *
+ * @param node Target server/node
+ * @param stack The stack used by the algorithm, contains nodes which have not yet been assigned a cycle
+ * @param next_ind Visitation index of next node
+ * @param next_cycle Index of next found cycle
+ */
+void MariaDBMonitor::tarjan_scc_visit_node(MariaDBServer* node, ServerArray* stack, int* next_ind,
+                                           int* next_cycle)
+{
+    /** Assign an index to this node */
+    NodeData& node_info = node->m_node;
+    auto ind = *next_ind;
+    node_info.index = ind;
+    node_info.lowest_index = ind;
+    *next_ind = ind + 1;
+
+    if (node_info.parents.empty())
+    {
+        /* This node/server does not replicate from any node, it can't be a part of a cycle. Don't even
+         * bother pushing it to the stack. */
+    }
+    else
+    {
+        // Has master servers, need to investigate.
+        stack->push_back(node);
+        node_info.in_stack = true;
+
+        for (MariaDBServer* parent : node_info.parents)
+        {
+            NodeData& parent_node = parent->m_node;
+            if (parent_node.index == NodeData::INDEX_NOT_VISITED)
+            {
+                /** Node has not been visited, so recurse. */
+                tarjan_scc_visit_node(parent, stack, next_ind, next_cycle);
+                node_info.lowest_index = std::min(node_info.lowest_index, parent_node.lowest_index);
+            }
+            else if (parent_node.in_stack)
+            {
+                /* The parent node has been visited and is still on the stack. We have a cycle. */
+                node_info.lowest_index = std::min(node_info.lowest_index, parent_node.index);
+            }
+
+            /* The else-clause here can be omitted, since in that case the parent has been visited,
+             * but is not in the current stack. This means that while there is a route from this
+             * node to the parent, there is no route from the parent to this node. No cycle. */
+        }
+
+        /* At the end of a visit to node, leave this node on the stack if it has a path to a node earlier
+         * on the stack (index > lowest_index). Otherwise, start popping elements. */
+        if (node_info.index == node_info.lowest_index)
+        {
+            int cycle_size = 0;     // Keep track of cycle size since we don't mark one-node cycles.
+            auto cycle_ind = *next_cycle;
+            while (true)
+            {
+                mxb_assert(!stack->empty());
+                MariaDBServer* cycle_server = stack->back();
+                NodeData& cycle_node = cycle_server->m_node;
+                stack->pop_back();
+                cycle_node.in_stack = false;
+                cycle_size++;
+                if (cycle_node.index == node_info.index)    // Last node in cycle
+                {
+                    if (cycle_size > 1)
+                    {
+                        cycle_node.cycle = cycle_ind;
+                        ServerArray& members = m_cycles[cycle_ind];     // Creates array if didn't exist
+                        members.push_back(cycle_server);
+                        // Sort the cycle members according to monitor config order.
+                        std::sort(members.begin(), members.end(),
+                                  [](const MariaDBServer* lhs, const MariaDBServer* rhs) -> bool {
+                            return lhs->m_config_index < rhs->m_config_index;
+                        });
+                        // All cycle elements popped. Next cycle...
+                        *next_cycle = cycle_ind + 1;
+                    }
+                    break;
+                }
+                else
+                {
+                    cycle_node.cycle = cycle_ind;   // Has more nodes, mark cycle.
+                    ServerArray& members = m_cycles[cycle_ind];
+                    members.push_back(cycle_server);
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Use slave status and server id information to build the replication graph. Needs to be called whenever
+ * topology has changed, or it's suspected.
+ */
+void MariaDBMonitor::build_replication_graph()
+{
+    const bool use_hostnames = m_settings.assume_unique_hostnames;
+    // First, reset all node data.
+    for (MariaDBServer* server : m_servers)
+    {
+        server->m_node.reset_indexes();
+        server->m_node.reset_results();
+    }
+
+    for (auto slave : m_servers)
+    {
+        /* Check all slave connections of all servers. Connections are added even if one or both endpoints
+         * are down or in maintenance. */
+        for (auto& slave_conn : slave->m_slave_status)
+        {
+            slave_conn.master_server = nullptr;
+            /* IF THIS PART IS CHANGED, CHANGE THE COMPARISON IN 'sstatus_arrays_topology_equal'
+             * (in MariaDBServer) accordingly so that any possible topology changes are detected. */
+
+            /* Mark a server as "failed child" if just one of IO or SQL threads is running. This prevents
+             * such a server being emergency promoted if master goes down (MXS-4798, case 4 in
+             * master_is_valid()). Emergency promotion is still possible if both threads are shut down,
+             * i.e. STOP SLAVE */
+            bool slave_io_on = slave_conn.slave_io_running != SlaveStatus::SLAVE_IO_NO;
+            if (slave_io_on || slave_conn.slave_sql_running)
+            {
+                bool slave_threads_running = slave_io_on && slave_conn.slave_sql_running;
+                // Looks promising, check hostname or server id.
+                MariaDBServer* found_master = nullptr;
+                bool is_external = false;
+                if (use_hostnames)
+                {
+                    found_master = get_server_by_addr(slave_conn.settings.master_endpoint);
+                    if (!found_master)
+                    {
+                        // Must be an external server.
+                        is_external = true;
+                    }
+                }
+                else
+                {
+                    /* Cannot trust hostname:port since network may be complicated. Instead,
+                     * trust the "Master_Server_Id"-field of the SHOW SLAVE STATUS output if
+                     * the slave connection has been seen connected before. This means that
+                     * the graph will miss slave-master relations that have not connected
+                     * while the monitor has been running.
+                     *
+                     * TODO: This data should be saved so that monitor restarts do not lose
+                     * this information. */
+                    if (slave_conn.master_server_id >= 0 && slave_conn.seen_connected)
+                    {
+                        // Valid slave connection, find the MariaDBServer with the matching server id.
+                        found_master = get_server(slave_conn.master_server_id);
+                        if (!found_master)
+                        {
+                            /* Likely an external master. It's possible that the master is a monitored
+                             * server which has not been queried yet and the monitor does not know its
+                             * id. */
+                            is_external = true;
+                        }
+                    }
+                }
+
+                // Valid slave connection, find the MariaDBServer with this id.
+                if (found_master)
+                {
+                    if (slave_threads_running)
+                    {
+                        /* Building the parents-array is not strictly required as the same data is in
+                         * the children-array. This construction is more for convenience and faster
+                         * access later on. */
+                        slave->m_node.parents.push_back(found_master);
+                        found_master->m_node.children.push_back(slave);
+                        slave_conn.master_server = found_master;
+                    }
+                    else
+                    {
+                        slave->m_node.parents_failed.push_back(found_master);
+                        found_master->m_node.children_failed.push_back(slave);
+                    }
+                }
+                else if (is_external && slave_threads_running)
+                {
+                    // This is an external master connection. Save just the master id for now.
+                    // TODO: Save host:port instead
+                    slave->m_node.external_masters.push_back(slave_conn.master_server_id);
+                }
+            }
+        }
+    }
+}
+
+/**
+ * @brief Find the strongly connected components in the replication tree graph
+ *
+ * Each replication cluster is a directed graph made out of replication
+ * trees. If this graph has strongly connected components (more generally
+ * cycles), it is considered a multi-master cluster due to the fact that there
+ * are multiple nodes where the data can originate.
+ *
+ * Detecting the cycles in the graph allows this monitor to better understand
+ * the relationships between the nodes. All nodes that are a part of a cycle can
+ * be labeled as master nodes. This information will later be used to choose the
+ * right master where the writes should go.
+ *
+ * This function also populates the MYSQL_SERVER_INFO structures group
+ * member. Nodes in a group get a positive group ID where the nodes not in a
+ * group get a group ID of 0.
+ */
+void MariaDBMonitor::find_graph_cycles()
+{
+    m_cycles.clear();
+    // The next items need to be passed around in the recursive calls to keep track of algorithm state.
+    ServerArray stack;
+    int index = NodeData::INDEX_FIRST;      /* Node visit index */
+    int cycle = NodeData::CYCLE_FIRST;      /* If cycles are found, the nodes in the cycle are given an
+                                             * identical
+                                             * cycle index. */
+
+    for (MariaDBServer* server : m_servers)
+    {
+        /** Index is 0, this node has not yet been visited. */
+        if (server->m_node.index == NodeData::INDEX_NOT_VISITED)
+        {
+            tarjan_scc_visit_node(server, &stack, &index, &cycle);
+        }
+    }
+}
+
+/**
+ * Find the server with the best reach in the candidates-array. Running state or 'read_only' is ignored by
+ * this method.
+ *
+ * @param candidates Which servers to check. All servers in the array will have their 'reach' calculated
+ * @return The best server out of the candidates
+ */
+MariaDBServer* MariaDBMonitor::find_best_reach_server(const ServerArray& candidates)
+{
+    mxb_assert(!candidates.empty());
+    MariaDBServer* best_reach = nullptr;
+    /* Search for the server with the best reach. */
+    for (MariaDBServer* candidate : candidates)
+    {
+        calculate_node_reach(candidate);
+        // This is the first valid node or this node has better reach than the so far best found ...
+        if (best_reach == nullptr || (candidate->m_node.reach > best_reach->m_node.reach))
+        {
+            best_reach = candidate;
+        }
+    }
+
+    return best_reach;
+}
+
+/**
+ * Find the best master server in the cluster. This method should only be called when the monitor
+ * is starting, a cluster operation (e.g. failover) has occurred or the user has changed something on
+ * the current master making it unsuitable. Because of this, the method can be quite vocal and not
+ * consider the previous master.
+ *
+ * @param req_running Should non-running candidates be accepted
+ * @param msg_out Message output. Includes explanations on why potential candidates were not selected.
+ * @return The master with most slaves
+ */
+MariaDBServer* MariaDBMonitor::find_topology_master_server(RequireRunning req_running, string* msg_out)
+{
+    /* Finding the best master server may get somewhat tricky if the graph is complicated. The general
+     * criteria for the best master is that it reaches the most slaves (possibly in multiple layers and
+     * cycles). To avoid having to calculate this reachability (doable by a recursive search) to all nodes,
+     * let's use the knowledge that the best master is either a server with no masters (external ones don't
+     * count) or is part of a cycle with no out-cycle masters.
+     *
+     * Master candidates must be writable and not in maintenance to be eligible. Running candidates are
+     * preferred. A downed candidate is accepted only if no current master exists. A downed master can
+     * be failovered later. */
+
+    ServerArray master_candidates;
+
+    // Helper function for finding normal master candidates.
+    auto search_outside_cycles = [this, &master_candidates](RequireRunning require_running,
+                                                            DelimitedPrinter& topo_messages) {
+        for (MariaDBServer* server : m_servers)
+        {
+            if (server->m_node.parents.empty() && server->m_node.parents_failed.empty())
+            {
+                string why_not;
+                if (is_candidate_valid(server, require_running, &why_not))
+                {
+                    master_candidates.push_back(server);
+                }
+                else
+                {
+                    topo_messages.cat(why_not);
+                }
+            }
+        }
+    };
+
+    // Helper function for finding master candidates inside cycles.
+    auto search_inside_cycles = [this, &master_candidates](RequireRunning require_running,
+                                                           DelimitedPrinter& topo_messages) {
+        // For each cycle, it's enough to take one sample server, as all members of a cycle have the
+        // same reach. The sample server needs to be valid, though.
+        for (auto& iter : m_cycles)
+        {
+            ServerArray& cycle_members = iter.second;
+            // Check that no server in the cycle is replicating from outside the cycle. This requirement
+            // is analogous with the same requirement for non-cycle servers.
+            if (!cycle_has_master_server(cycle_members))
+            {
+                // Find a valid candidate from the cycle.
+                MariaDBServer* cycle_cand = nullptr;
+                for (MariaDBServer* elem : cycle_members)
+                {
+                    mxb_assert(elem->m_node.cycle != NodeData::CYCLE_NONE);
+                    if (is_candidate_valid(elem, require_running))
+                    {
+                        cycle_cand = elem;
+                        break;
+                    }
+                }
+                if (cycle_cand)
+                {
+                    master_candidates.push_back(cycle_cand);
+                }
+                else
+                {
+                    // No single server in the cycle was viable. Go through the cycle again and construct
+                    // a message explaining why.
+                    string server_names = monitored_servers_to_string(cycle_members);
+                    string msg_start = string_printf(
+                        "No valid primary server could be found in the cycle with servers %s:",
+                        server_names.c_str());
+
+                    DelimitedPrinter cycle_invalid_msg("\n");
+                    cycle_invalid_msg.cat(msg_start);
+                    for (MariaDBServer* elem : cycle_members)
+                    {
+                        string server_msg;
+                        is_candidate_valid(elem, require_running, &server_msg);
+                        cycle_invalid_msg.cat(server_msg);
+                    }
+                    cycle_invalid_msg.cat("");          // Adds a linebreak
+                    topo_messages.cat(cycle_invalid_msg.message());
+                }
+            }
+        }
+    };
+
+    // Normally, do not accept downed servers as master.
+    DelimitedPrinter topo_messages_reject_down("\n");
+    search_outside_cycles(RequireRunning::REQUIRED, topo_messages_reject_down);
+    search_inside_cycles(RequireRunning::REQUIRED, topo_messages_reject_down);
+
+    MariaDBServer* best_candidate = nullptr;
+    string messages;
+    if (!master_candidates.empty())
+    {
+        // Found one or more candidates. Select the best one and output the messages.
+        best_candidate = find_best_reach_server(master_candidates);
+        messages = topo_messages_reject_down.message();
+    }
+    else if (req_running == RequireRunning::OPTIONAL)
+    {
+        // If no candidate was found and the caller allows, we get desperate and allow a downed server
+        // to be selected. This is required for the case when MaxScale is started while the master is
+        // already down. Failover may be able to fix the situation if settings allow it or
+        // if activated manually.
+        DelimitedPrinter topo_messages_accept_down("\n");
+        search_outside_cycles(RequireRunning::OPTIONAL, topo_messages_accept_down);
+        search_inside_cycles(RequireRunning::OPTIONAL, topo_messages_accept_down);
+        if (!master_candidates.empty())
+        {
+            // Found one or more candidates which are down. Select the best one. Instead of the original
+            // messages, output the messages without complaints that a server is down. The caller
+            // should detect and explain that a non-running server was selected.
+            best_candidate = find_best_reach_server(master_candidates);
+            messages = topo_messages_accept_down.message();
+        }
+        else
+        {
+            // Still no luck. Output the messages from the first run since these explain if any potential
+            // candidates were down.
+            messages = topo_messages_reject_down.message();
+        }
+    }
+
+    if (msg_out)
+    {
+        *msg_out = messages;
+    }
+    return best_candidate;
+}
+
+/**
+ * Calculate the total number of reachable child (slave) nodes for the given node. A
+ * node can reach itself if it's running. Slaves are counted if they are running.
+ * The result is saved into the node data.
+ *
+ * @param search_root Start point of the search
+ */
+void MariaDBMonitor::calculate_node_reach(MariaDBServer* search_root)
+{
+    // Reset indexes since they will be reused.
+    reset_node_index_info();
+
+    int reach = 0;
+    VisitorFunc visitor = [&reach](MariaDBServer* node) -> bool {
+        bool node_running = node->is_running();
+        if (node_running)
+        {
+            reach++;
+        }
+        // The node is expanded if it's running.
+        return node_running;
+    };
+
+    topology_DFS(search_root, visitor, SlaveMode::ACTIVE_REPL);
+    search_root->m_node.reach = reach;
+}
+
+/**
+ * Calculate the total number of running slaves that the node has. The node itself can be down.
+ * Slaves are counted even if they are connected through an inactive relay. This function counts
+ * even bad slaves that are not really replicating (io or sql thread stopped, but not both). This
+ * logic is valid as the function is only used in checking master validity.
+ *
+ * @param node The node to calculate for
+ * @return The number of running slaves
+ */
+int MariaDBMonitor::running_slaves(MariaDBServer* search_root)
+{
+    // Reset indexes since they will be reused.
+    reset_node_index_info();
+
+    int n_running_slaves = 0;
+    VisitorFunc visitor = [this, &n_running_slaves](MariaDBServer* node) -> bool {
+        // Only consider the slave totally down if it has been that way long enough.
+        if (node->is_running() || node->mon_err_count < m_settings.failcount)
+        {
+            n_running_slaves++;
+        }
+        // The node is always expanded.
+        return true;
+    };
+
+    topology_DFS(search_root, visitor, SlaveMode::ALL);
+    return n_running_slaves;
+}
+
+/**
+ * Assign replication role status bits to the servers in the cluster. Starts from the cluster master server.
+ * Also updates replication lag.
+ */
+void MariaDBMonitor::assign_server_roles()
+{
+    // Remove any existing [Master], [Slave] etc flags from 'm_pending_status', they are still available in
+    // 'm_prev_status'.
+    const uint64_t remove_bits = SERVER_MASTER | SERVER_SLAVE | SERVER_RELAY | SERVER_BLR;
+    for (auto server : m_servers)
+    {
+        server->clear_status(remove_bits);
+        server->m_replication_lag = mxs::Target::RLAG_UNDEFINED;
+    }
+
+    // Check the the master node, label it as the [Master] if it meets the requirements. It must at least
+    // be running and writable.
+    if (m_master)
+    {
+        if (m_master->is_running())
+        {
+            // Master gets replication lag 0 even if it's replicating from an external server.
+            m_master->m_replication_lag = 0;
+
+            // Check that all master requirements are fulfilled.
+            bool master_conds_ok = true;
+            const auto master_conds = m_settings.shared.master_conds;
+            const bool req_connecting_slave = master_conds & MasterConds::MCOND_CONNECTING_S;
+            const bool req_connected_slave = master_conds & MasterConds::MCOND_CONNECTED_S;
+            const bool req_running_slave = master_conds & MasterConds::MCOND_RUNNING_S;
+            if (req_connecting_slave || req_connected_slave || req_running_slave)
+            {
+                // Check that at least one slave fulfills the given conditions. Only check immediate slaves,
+                // not slaves behind relays.
+                bool slave_found = false;
+                for (const auto slave : m_master->m_node.children)
+                {
+                    auto* slave_conn = slave->slave_connection_status(m_master);
+                    bool is_connected = (slave_conn->slave_io_running == SlaveStatus::SLAVE_IO_YES);
+                    bool is_running = slave->is_running();
+                    // If slave is not connected, check that the failure is not due to credentials failure.
+                    bool user_ok = is_connected
+                        || !mxs::MonitorServer::is_access_denied_error(slave_conn->last_io_errno);
+
+                    // req_connecting_slave is always met by m_node->children
+                    bool slave_is_ok = user_ok && !((req_connected_slave && !is_connected)
+                        || (req_running_slave && !is_running));
+                    if (slave_is_ok)
+                    {
+                        slave_found = true;
+                        break;
+                    }
+                }
+
+                if (!slave_found)
+                {
+                    master_conds_ok = false;
+                }
+            }
+
+            // Check other master conditions.
+            if (master_conds_ok)
+            {
+                if (((master_conds & MasterConds::MCOND_COOP_M) && is_slave_maxscale()
+                     && !m_master->marked_as_master())
+                    || ((master_conds & MasterConds::MCOND_DISK_OK) && m_master->is_low_on_disk_space()))
+                {
+                    // Master was not marked as such by primary monitor or is low on disk space.
+                    master_conds_ok = false;
+                }
+            }
+
+            // Master may never have read-only. Also, binlogrouter cannot get master-status.
+            if (master_conds_ok && !m_master->is_read_only() && m_master->is_database())
+            {
+                m_master->set_status(SERVER_MASTER);
+            }
+        }
+
+        // Run another graph search, this time assigning slaves.
+        reset_node_index_info();
+        assign_slave_and_relay_master();
+    }
+}
+
+/**
+ * Check if the servers replicating from the given node qualify for [Slave] and mark them. Continue the
+ * search to any found slaves. Also updates replication lag.
+ */
+void MariaDBMonitor::assign_slave_and_relay_master()
+{
+    mxb_assert(m_master->m_node.index == NodeData::INDEX_NOT_VISITED);
+    // Combines a node with its connection state. The state tracks whether there is a series of
+    // running slave connections all the way to the master server. If even one server is down or
+    // a connection is broken in the series, the link is considered stale.
+    struct QueueElement
+    {
+        MariaDBServer* node;
+        bool           active_link;
+    };
+
+    auto compare = [](const QueueElement& left, const QueueElement& right) {
+        return !left.active_link && right.active_link;
+    };
+    /* 'open_set' contains the nodes which the search should expand to. It's a priority queue so that nodes
+     * with a functioning chain of slave connections to the master are processed first. Only after all such
+     * nodes have been processed does the search expand to downed or disconnected nodes. */
+    std::priority_queue<QueueElement, std::vector<QueueElement>, decltype(compare)> open_set(compare);
+
+    const auto slave_conds = m_settings.shared.slave_conds;
+    const bool req_running_master = slave_conds & SlaveConds::SCOND_RUNNING_M;
+    const bool req_writable_master = slave_conds & SlaveConds::SCOND_WRITABLE_M;
+    const bool req_coop_master = slave_conds & SlaveConds::SCOND_COOP_M;
+
+    // First, check conditions that immediately prevent any [Slave]s from being tagged:
+    // 1) Require writable master yet master is not a valid master.
+    // 2) Require master set by primary monitor in a co-op situation yet none found.
+    // 3) Require running master yet master is down.
+    if ((req_writable_master && !m_master->is_master())
+        || (req_coop_master && is_slave_maxscale() && !m_master->marked_as_master())
+        || (req_running_master && m_master->is_down()))
+    {
+        return;
+    }
+
+    const bool req_disk_ok = slave_conds & SlaveConds::SCOND_DISK_OK;
+
+    // Second, check if the start node itself should be labeled [Slave]. This is the case if the master
+    // fulfills general slave requirements but is not labeled [Master]. Binlogrouter may get [Slave] for now,
+    // is removed later.
+    if (m_master->is_running() && !m_master->is_master()
+        && !(req_disk_ok && m_master->is_low_on_disk_space()))
+    {
+        m_master->set_status(SERVER_SLAVE);
+    }
+
+    // Begin by adding the starting node to the open_set. Then keep running until no more nodes can be found.
+    QueueElement start = {m_master, m_master->is_running()};
+    open_set.push(start);
+    int next_index = NodeData::INDEX_FIRST;
+    const bool allow_stale_slaves = !(slave_conds & SlaveConds::SCOND_LINKED_M);
+
+    while (!open_set.empty())
+    {
+        auto parent = open_set.top().node;
+        // If the node is not running or does not have an active link to master,
+        // it can only have "stale slaves". Such slaves are assigned if
+        // the slave connection has been observed to have worked before.
+        bool parent_has_live_link = open_set.top().active_link && !parent->is_down();
+        open_set.pop();
+
+        if (parent->m_node.index != NodeData::INDEX_NOT_VISITED)
+        {
+            // This node has already been processed and can be skipped. The same node
+            // can be in the open set multiple times if it has multiple slave connections.
+            continue;
+        }
+        else
+        {
+            parent->m_node.index = next_index++;
+        }
+
+        bool has_running_slaves = false;
+        for (MariaDBServer* slave : parent->m_node.children)
+        {
+            // If the slave has an index, it has already been visited and labelled master/slave.
+            // Even when this is the case, the node has to be checked to get correct
+            // [Relay Master] labels.
+
+            // Need to differentiate between stale and running slave connections.
+            bool found_slave_conn = false;  // slave->parent connection exists
+            bool conn_is_live = false;      // live connection chain slave->cluster_master exists
+            auto sstatus = slave->slave_connection_status(parent);
+            if (sstatus)
+            {
+                if (sstatus->slave_io_running == SlaveStatus::SLAVE_IO_YES)
+                {
+                    found_slave_conn = true;
+                    // Would it be possible to have the parent down while IO is still connected?
+                    // Perhaps, if the slave is slow to update the connection status.
+                    conn_is_live = parent_has_live_link && slave->is_running();
+                }
+                else if (sstatus->slave_io_running == SlaveStatus::SLAVE_IO_CONNECTING
+                         && !mxs::MonitorServer::is_access_denied_error(sstatus->last_io_errno))
+                {
+                    found_slave_conn = true;
+                }
+            }
+
+            // If the slave had a valid connection, label it as a slave and add it to the open set if not
+            // yet visited.
+            if (found_slave_conn && (conn_is_live || allow_stale_slaves))
+            {
+                bool slave_is_running = slave->is_running();
+                if (slave_is_running)
+                {
+                    has_running_slaves = true;
+                }
+                if (slave->m_node.index == NodeData::INDEX_NOT_VISITED)
+                {
+                    // Add the slave server to the priority queue to a position depending on the master
+                    // link status. It will be expanded later in the loop.
+                    open_set.push({slave, conn_is_live});
+
+                    // The slave only gets the slave flags if it's running.
+                    // TODO: If slaves with broken links should be given different flags, add that here.
+                    if (slave_is_running)
+                    {
+                        if (!(req_disk_ok && slave->is_low_on_disk_space()))
+                        {
+                            slave->set_status(SERVER_SLAVE);
+                        }
+
+                        // Write the replication lag for this slave. It may have multiple slave connections,
+                        // in which case take the smallest value. This only counts the slave connections
+                        // leading to the master or a relay.
+                        int64_t curr_rlag = slave->m_replication_lag;
+                        int64_t new_rlag = sstatus->seconds_behind_master;
+                        if (new_rlag != mxs::Target::RLAG_UNDEFINED
+                            && (curr_rlag == mxs::Target::RLAG_UNDEFINED || new_rlag < curr_rlag))
+                        {
+                            slave->m_replication_lag = new_rlag;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Finally, if the node itself is a running slave and has slaves of its own, label it as relay.
+        if (parent != m_master && parent_has_live_link
+            && parent->has_status(SERVER_SLAVE | SERVER_RUNNING) && has_running_slaves)
+        {
+            parent->set_status(SERVER_RELAY);
+        }
+
+        // If the node is a binlogrouter and has slave-status, remove slave and relay, and add blr-status.
+        if (parent->server_type() == ServerType::BLR && parent->has_status(SERVER_SLAVE))
+        {
+            parent->clear_status(SERVER_SLAVE | SERVER_RELAY);
+            parent->set_status(SERVER_BLR);
+        }
+    }
+}
+
+/**
+ * Is the current master server still valid or should a new one be selected?
+ *
+ * @param reason_out If master is not valid, the reason is printed here.
+ * @return True, if master is ok. False if the current master has changed in a way that
+ * a new master should be selected.
+ */
+bool MariaDBMonitor::master_is_valid(std::string* reason_out)
+{
+    bool is_valid = true;
+    string reason;
+    // The master server of the cluster needs to be re-calculated in the following cases:
+
+    // 1) There is no master. This typically only applies when MaxScale is first ran.
+    if (!m_master)
+    {
+        is_valid = false;
+    }
+    // 2) read_only has been activated on the master. If 'enforce_writable_master' is on, allow a read_only
+    // master.
+    else if (m_master->is_running() && m_master->is_read_only() && !m_settings.enforce_writable_master)
+    {
+        is_valid = false;
+        reason = "it is in read-only mode";
+    }
+    // 3) Master lock status is not properly set.
+    else if (is_slave_maxscale() && m_master->is_running() && !m_master->marked_as_master(&reason))
+    {
+        is_valid = false;
+    }
+    // 4) The master has been down for more than failcount iterations and there is no hope of any kind of
+    //    failover fixing the situation. The master is a hopeless one if it has been down for a while and
+    //    has no running slaves, not even behind relays.
+    //
+    //    This condition should account for the situation when a dba or another MaxScale performs a failover
+    //    and moves all the running slaves under another master. If even one running slave remains, the switch
+    //    will not happen.
+    else if (m_master->is_down() && m_master->mon_err_count > m_settings.failcount
+             && running_slaves(m_master) == 0)
+    {
+        is_valid = false;
+        reason = string_printf("it has been down over %ld (failcount) monitor updates and "
+                               "it does not have any running slaves",
+                               m_settings.failcount);
+    }
+
+    // Next, test topology changes which may lead to a master change. Only valid when master is running.
+    if (is_valid && m_master->is_running())
+    {
+        // 5) The master was a non-replicating master (not in a cycle) but now has a slave connection.
+        if (m_master_cycle_status.cycle_id == NodeData::CYCLE_NONE)
+        {
+            // The master should not have a master of its own.
+            if (!m_master->m_node.parents.empty())
+            {
+                is_valid = false;
+                reason = "it has started replicating from another server in the cluster";
+            }
+        }
+        // 6) The master was part of a cycle but is no longer, or one of the servers in the cycle is
+        //    replicating from a server outside the cycle.
+        else
+        {
+            /* The master was previously in a cycle. Compare the current cycle to the previous data and see
+             * if the cycle is still the best multimaster group. */
+            int current_cycle_id = m_master->m_node.cycle;
+
+            // 6a) The master is no longer in a cycle.
+            if (current_cycle_id == NodeData::CYCLE_NONE)
+            {
+                is_valid = false;
+                ServerArray& old_members = m_master_cycle_status.cycle_members;
+                string server_names_old = monitored_servers_to_string(old_members);
+                reason = "it is no longer in the multimaster group (" + server_names_old + ")";
+            }
+            // 6b) The master is still in a cycle but the cycle has gained a master outside of the cycle.
+            else
+            {
+                ServerArray& current_members = m_cycles[current_cycle_id];
+                if (cycle_has_master_server(current_members))
+                {
+                    is_valid = false;
+                    string server_names_current = monitored_servers_to_string(current_members);
+                    reason = "a server in the primary's multiprimary group (" + server_names_current
+                        + ") is replicating from a server not in the group";
+                }
+            }
+        }
+    }
+
+    *reason_out = reason;
+    return is_valid;
+}
+
+/**
+ * Check if any of the servers in the cycle is replicating from a server not in the cycle. External masters
+ * do not count.
+ *
+ * @param cycle The cycle to check
+ * @return True if a server is replicating from a master not in the same cycle
+ */
+bool MariaDBMonitor::cycle_has_master_server(ServerArray& cycle_servers)
+{
+    mxb_assert(!cycle_servers.empty());
+    bool outside_replication = false;
+    int cycle_id = cycle_servers.front()->m_node.cycle;
+
+    for (MariaDBServer* server : cycle_servers)
+    {
+        for (MariaDBServer* master : server->m_node.parents)
+        {
+            if (master->m_node.cycle != cycle_id)
+            {
+                // Cycle member is replicating from a server that is not in the current cycle. The
+                // cycle is not a valid "master" cycle.
+                outside_replication = true;
+                break;
+            }
+        }
+    }
+
+    return outside_replication;
+}
+
+void MariaDBMonitor::update_topology()
+{
+    if (m_cluster_topology_changed)
+    {
+        // Server IDs may have changed.
+        m_servers_by_id.clear();
+        for (auto server : m_servers)
+        {
+            if (server->m_server_id != Gtid::SERVER_ID_UNKNOWN)
+            {
+                m_servers_by_id[server->m_server_id] = server;
+            }
+        }
+
+        build_replication_graph();
+        find_graph_cycles();
+    }
+
+    /* Check if a failover/switchover was performed last loop and the master should change.
+     * In this case, update the master and its cycle info here. */
+    if (m_next_master)
+    {
+        assign_new_master(m_next_master);
+        m_next_master = nullptr;
+    }
+
+    if (m_cluster_topology_changed || !m_master || !m_master->is_usable()
+        || (is_slave_maxscale() && !m_master->marked_as_master()))
+    {
+        update_master();
+    }
+}
+
+void MariaDBMonitor::update_master()
+{
+    // Check if current master is still valid.
+    string reason_not_valid;
+    bool current_is_ok = master_is_valid(&reason_not_valid);
+
+    if (current_is_ok)
+    {
+        // Current master is still ok. If topology has changed, check which server looks like the best master
+        // and alert if it's not the current master. Don't change yet.
+        m_warn_current_master_invalid = true;
+        if (m_cluster_topology_changed)
+        {
+            // Update master cycle info in case it has changed.
+            update_master_cycle_info();
+            MariaDBServer* master_cand = find_topology_master_server(RequireRunning::REQUIRED);
+            // master_cand can be null if e.g. current master is down.
+            if (master_cand && (master_cand != m_master))
+            {
+                // This is unlikely to be printed continuously because of the topology-change requirement.
+                MXB_WARNING("'%s' is a better primary candidate than the current primary '%s'. "
+                            "Primary will change when '%s' is no longer a valid primary.",
+                            master_cand->name(), m_master->name(), m_master->name());
+            }
+        }
+    }
+    else if (m_master)
+    {
+        // Current master is faulty and swapping to a better, running server is allowed.
+        string topology_messages;
+        MariaDBServer* master_cand = find_topology_master_server(RequireRunning::REQUIRED,
+                                                                 &topology_messages);
+        m_warn_cannot_find_master = true;
+        if (master_cand)
+        {
+            if (master_cand != m_master)
+            {
+                // We have another master to swap to. The messages give the impression that new master
+                // selection has not yet happened, but this is just for clarity for the user.
+                mxb_assert(!reason_not_valid.empty());
+                MXB_WARNING("The current primary server '%s' is no longer valid because %s. "
+                            "Selecting new primary server.",
+                            m_master->name(), reason_not_valid.c_str());
+
+                // At this point, print messages explaining why any/other possible master servers
+                // weren't picked.
+                if (!topology_messages.empty())
+                {
+                    MXB_WARNING("%s", topology_messages.c_str());
+                }
+
+                MXB_NOTICE("Setting '%s' as primary.", master_cand->name());
+                // Change the master, even though this may break replication.
+                assign_new_master(master_cand);
+            }
+            else if (m_cluster_topology_changed)
+            {
+                // Tried to find another master but the current one is still the best. This is typically
+                // caused by a topology change. The check on 'm_cluster_topology_changed' should stop this
+                // message from printing repeatedly.
+                MXB_WARNING("Attempted to find a replacement for the current primary server '%s' because %s, "
+                            "but '%s' is still the best primary server.",
+                            m_master->name(), reason_not_valid.c_str(), m_master->name());
+
+                if (!topology_messages.empty())
+                {
+                    MXB_WARNING("%s", topology_messages.c_str());
+                }
+                // The following updates some data on the master.
+                assign_new_master(master_cand);
+            }
+        }
+        else if (m_warn_current_master_invalid)
+        {
+            // No alternative master. Keep current status and print warnings.
+            // This situation may stick so only print the messages once.
+            mxb_assert(!reason_not_valid.empty());
+            MXB_WARNING("The current primary server '%s' is no longer valid because %s, "
+                        "but there is no valid alternative to swap to.",
+                        m_master->name(), reason_not_valid.c_str());
+            if (!topology_messages.empty())
+            {
+                MXB_WARNING("%s", topology_messages.c_str());
+            }
+            m_warn_current_master_invalid = false;
+        }
+    }
+    else
+    {
+        // This happens only when starting from scratch before a master has been selected.
+        // Accept either a running or downed master, preferring running servers.
+        string topology_messages;
+        MariaDBServer* master_cand = find_topology_master_server(RequireRunning::OPTIONAL,
+                                                                 &topology_messages);
+        if (master_cand)
+        {
+            MXB_NOTICE("Selecting new primary server.");
+            if (master_cand->is_down())
+            {
+                const char msg[] = "No running primary candidates detected and no primary currently set. "
+                                   "Accepting a non-running server as primary.";
+                MXB_WARNING("%s", msg);
+            }
+
+            if (!topology_messages.empty())
+            {
+                MXB_WARNING("%s", topology_messages.c_str());
+            }
+
+            MXB_NOTICE("Setting '%s' as primary.", master_cand->name());
+            assign_new_master(master_cand);
+        }
+        else if (m_warn_cannot_find_master)
+        {
+            // No current master and could not select another. This situation may stick so only print once.
+            MXB_WARNING("Tried to find a primary but no valid primary found.");
+            if (!topology_messages.empty())
+            {
+                MXB_WARNING("%s", topology_messages.c_str());
+            }
+            m_warn_cannot_find_master = false;
+        }
+    }
+}
+
+void MariaDBMonitor::set_low_disk_slaves_maintenance()
+{
+    // Only set pure slave and standalone servers to maintenance.
+    for (MariaDBServer* server : m_servers)
+    {
+        // Don't set topology master to maintenance, as that makes the entire cluster unusable.
+        if (server->is_low_on_disk_space() && server->is_usable()
+            && server != m_master && !server->is_relay_master())
+        {
+            // TODO: Handle relays somehow, e.g. switch with a slave
+            MXB_WARNING("Setting %s to maintenance because it is low on disk space and '%s' is enabled. "
+                        "The maintenance status can be cleared manually with MaxCtrl or REST-API once the "
+                        "situation has been resolved.",
+                        server->name(), CN_MAINTENANCE_ON_LOW_DISK_SPACE);
+            server->set_status(SERVER_MAINT);
+        }
+    }
+}
+
+bool MariaDBMonitor::is_candidate_valid(MariaDBServer* cand, RequireRunning req_running, string* why_not)
+{
+    bool is_valid = true;
+    DelimitedPrinter reasons(" and ");
+    if (cand->is_in_maintenance())
+    {
+        is_valid = false;
+        reasons.cat("it's in maintenance");
+    }
+
+    if (cand->is_read_only())
+    {
+        is_valid = false;
+        reasons.cat("it's read_only");
+    }
+
+    if (req_running == RequireRunning::REQUIRED && cand->is_down())
+    {
+        is_valid = false;
+        reasons.cat("it's down");
+    }
+
+    // Check the following only if the other requirements are fulfilled.
+    if (is_valid && is_slave_maxscale())
+    {
+        // Locks are in use and this is a slave MaxScale. In this case, only a candidate clearly marked as
+        // master by the primary MaxScale is a valid candidate. Both locks must be owned by the primary
+        // MaxScale and by the same connection.
+        string reason;
+        if (!cand->marked_as_master(&reason))
+        {
+            is_valid = false;
+            reasons.cat(reason);
+        }
+    }
+
+    if (!is_valid && why_not)
+    {
+        *why_not = string_printf("'%s' is not a valid master candidate because %s.",
+                                 cand->name(), reasons.message().c_str());
+    }
+    return is_valid;
+}
+
+/**
+ * Updates the cluster level lock status. If server locks are free, try to acquire.
+ */
+void MariaDBMonitor::update_cluster_lock_status()
+{
+    if (server_locks_in_use())
+    {
+        const bool had_lock_majority = is_cluster_owner();
+
+        int server_locks_free = 0;
+        int server_locks_held = 0;
+        int server_locks_owned_other = 0;
+        int running_servers = 0;
+
+        MariaDBServer* master_lock_srv = nullptr;
+
+        for (MariaDBServer* server : m_servers)
+        {
+            auto lockstatus = server->lock_status(MariaDBServer::LockType::SERVER).status();
+            if (lockstatus == ServerLock::Status::OWNED_SELF)
+            {
+                server_locks_held++;
+            }
+            else if (lockstatus == ServerLock::Status::OWNED_OTHER)
+            {
+                server_locks_owned_other++;
+            }
+            else if (lockstatus == ServerLock::Status::FREE)
+            {
+                server_locks_free++;
+            }
+            running_servers += server->is_running();
+
+            if (server->lock_owned(MariaDBServer::LockType::MASTER))
+            {
+                master_lock_srv = server;   // Should be the master.
+            }
+        }
+
+        // Check if the monitor has a majority of locks. Either require majority of running servers or
+        // majority of all.
+        int required_for_majority = -1;
+        if (m_settings.require_server_locks == LOCKS_MAJORITY_RUNNING)
+        {
+            required_for_majority = (running_servers / 2 + 1);
+        }
+        else
+        {
+            required_for_majority = (m_servers.size() / 2 + 1);
+        }
+
+        // Check if this monitor can obtain lock majority.
+        if (server_locks_free > 0 && (server_locks_held + server_locks_free >= required_for_majority))
+        {
+            /**
+             *  This MaxScale can obtain or already has lock majority. Try to acquire free locks if
+             *  1) some time has passed since last locking attempt
+             *  2) or this is the master MaxScale, yet lacks some locks. A secondary MaxScale should not
+             *  try to repeatedly acquire locks as this could prevent the primary from getting majority.
+             */
+            if (had_lock_majority || try_acquire_locks_this_tick())
+            {
+                // Get as many locks as possible.
+                server_locks_held += get_free_locks();
+            }
+        }
+        const bool have_lock_majority = (server_locks_held >= required_for_majority);
+
+        // If situation changed, log it. Also, if monitor gained lock majority, delay automatic cluster
+        // operations for a while so that the other monitor(s) have time to detect the new situation.
+        if (have_lock_majority != had_lock_majority)
+        {
+            bool cluster_ops_on = cluster_ops_configured();
+            if (have_lock_majority)
+            {
+                if (cluster_ops_on)
+                {
+                    MXB_NOTICE("'%s' acquired the exclusive lock on a majority of its servers. "
+                               "Configured automatic cluster manipulation operations (e.g. failover) can be "
+                               "performed in %li monitor ticks.", name(), m_settings.failcount);
+                }
+                else
+                {
+                    MXB_NOTICE("'%s' acquired the exclusive lock on a majority of its servers. "
+                               "Manual cluster manipulation operations (e.g. failover) can be performed.",
+                               name());
+                }
+                // Delay automatic operations regardless of if they are configured, as the configuration
+                // could change on any tick.
+                delay_auto_cluster_ops(Log::OFF);
+            }
+            else
+            {
+                if (cluster_ops_on)
+                {
+                    MXB_WARNING("'%s' lost the exclusive lock on a majority of its servers. "
+                                "Configured automatic cluster manipulation operations (e.g. failover) "
+                                "can not be performed.", name());
+                }
+                else
+                {
+                    MXB_WARNING("'%s' lost the exclusive lock on a majority of its servers. "
+                                "Manual cluster manipulation operations (e.g. failover) "
+                                "can not be performed.", name());
+                }
+            }
+        }
+
+        // Release locks if no majority. This gives another MaxScale the chance to get them. Should be a
+        // rare occurrence.
+        int total_locks = server_locks_held + (master_lock_srv ? 1 : 0);
+        if (!have_lock_majority && total_locks > 0)
+        {
+            string msg;
+            if (server_locks_held > 0)
+            {
+                msg.append(mxb::string_printf(
+                    "'%s' holds %i exclusive server lock(s) out of %i required for lock majority, "
+                    "and will release them.",
+                    name(), server_locks_held, required_for_majority));
+
+                if (m_settings.require_server_locks == LOCKS_MAJORITY_ALL
+                    && running_servers < (int)m_servers.size())
+                {
+                    int servers_down = m_servers.size() - running_servers;
+                    msg.append(mxb::string_printf(" %i lock(s) could not be acquired because server is down.",
+                                                  servers_down));
+                }
+                if (server_locks_owned_other > 0)
+                {
+                    msg.append(mxb::string_printf(" %i lock(s) were held by another MaxScale.",
+                                                  server_locks_owned_other));
+                }
+                msg.append(" Will try to reacquire locks later if majority is possible.");
+                if (master_lock_srv)
+                {
+                    msg.append(mxb::string_printf(" The monitor will also release its master lock on %s.",
+                                                  master_lock_srv->name()));
+                }
+            }
+            else
+            {
+                // This is a highly unlikely situation.
+                msg.append(mxb::string_printf(
+                    "'%s' lost all exclusive server locks, releasing master lock on %s.",
+                    name(), master_lock_srv->name()));
+            }
+            MXB_WARNING("%s", msg.c_str());
+
+            for (MariaDBServer* server : m_servers)
+            {
+                server->release_all_locks();
+            }
+        }
+        m_locks_info.have_lock_majority.store(have_lock_majority, std::memory_order_relaxed);
+    }
+}
+
+int MariaDBMonitor::get_free_locks()
+{
+    ServerArray targets;
+    for (auto server : m_servers)
+    {
+        if (server->serverlock_status().is_free())
+        {
+            targets.push_back(server);
+        }
+    }
+
+    std::atomic_int locks_acquired {0};
+    auto get_lock_task = [&locks_acquired](MariaDBServer* server) {
+        locks_acquired += server->get_lock(LockType::SERVER);
+    };
+    execute_task_on_servers(get_lock_task, targets);
+    return locks_acquired;
+}
+
+MariaDBMonitor::DNSResolver::StringSet MariaDBMonitor::DNSResolver::resolve_server(const string& host)
+{
+    auto now = mxb::Clock::now();
+    const auto MAX_AGE = 5min;      // Refresh interval for cache entries.
+    auto recent_time = now - MAX_AGE;
+    DNSResolver::StringSet rval;
+
+    auto iter = m_mapping.find(host);
+    if (iter == m_mapping.end() || iter->second.timestamp < recent_time)
+    {
+        // Map did not have a record, or it was too old. In either case, generate a new one.
+        DNSResolver::StringSet addresses;
+        string error_msg;
+        bool dns_success = mxb::name_lookup(host, &addresses, &error_msg);
+        if (!dns_success)
+        {
+            MXB_ERROR("Could not resolve host '%s'. %s", host.c_str(), error_msg.c_str());
+        }
+        // If dns failed, the array will be empty. Add/replace the element anyway to prevent repeated lookups.
+        m_mapping[host] = {addresses, now};
+        rval = std::move(addresses);
+    }
+    else
+    {
+        // Return recent value.
+        rval = iter->second.addresses;
+    }
+    return rval;
+}

--- a/server/modules/monitor/mysqlrepmon/cluster_manipulation.cc
+++ b/server/modules/monitor/mysqlrepmon/cluster_manipulation.cc
@@ -1,0 +1,2254 @@
+/*
+ * Copyright (c) 2018 MariaDB Corporation Ab
+ * Copyright (c) 2023 MariaDB plc, Finnish Branch
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file and at www.mariadb.com/bsl11.
+ *
+ * Change Date: 2027-09-09
+ *
+ * On the date above, in accordance with the Business Source License, use
+ * of this software will be governed by version 2 or later of the General
+ * Public License.
+ */
+
+#include "mariadbmon.hh"
+#include <memory>
+#include <set>
+#include <cinttypes>
+#include <mysql.h>
+#include <maxbase/stopwatch.hh>
+#include <maxbase/format.hh>
+#include <maxscale/clock.hh>
+#include <maxscale/protocol/mariadb/maxscale.hh>
+
+using std::string;
+using std::move;
+using std::unique_ptr;
+using maxbase::string_printf;
+using maxbase::StopWatch;
+using maxbase::Duration;
+using GtidMode = SlaveStatus::Settings::GtidMode;
+using ReplicationOp = MariaDBServer::ReplicationOp;
+using LockType = MariaDBServer::LockType;
+using namespace std::chrono_literals;
+
+namespace
+{
+void print_no_locks_error(mxb::Json& error_out)
+{
+    const char locks_taken[] =
+        "Cannot perform cluster operation because this MaxScale does not have exclusive locks "
+        "on a majority of servers. Run \"SELECT IS_USED_LOCK('%s');\" on the servers to find out "
+        "which connection id has a lock.";
+    auto err_msg = string_printf(locks_taken, SERVER_LOCK_NAME);
+    PRINT_JSON_ERROR(error_out, "%s", err_msg.c_str());
+}
+
+const char NO_SERVER[] = "Server '%s' is not monitored by '%s'.";
+const char FAILOVER_OK[] = "Failover '%s' -> '%s' performed.";
+const char FAILOVER_FAIL[] = "Failover '%s' -> '%s' failed.";
+const char SWITCHOVER_OK[] = "Switchover '%s' -> '%s' performed.";
+const char SWITCHOVER_FAIL[] = "Switchover %s -> %s failed.";
+}
+
+
+/**
+ * Run a manual switchover, promoting a new master server and demoting the existing master.
+ *
+ * @param new_master The server which should be promoted. If null, monitor will autoselect.
+ * @param current_master The server which should be demoted. Can be null for autoselect, in which case
+ * monitor will select the cluster master server. Otherwise must be a valid master server or a relay.
+ * @return Result structure
+ */
+mon_op::Result MariaDBMonitor::manual_switchover(SwitchoverType type, AfterDemotion after_demotion,
+                                                 SERVER* new_master, SERVER* current_master)
+{
+    // Manual commands should only run in the main monitor thread.
+    mxb_assert(mxb::Worker::get_current()->id() == m_worker->id());
+    mxb_assert(m_op_info.exec_state == mon_op::ExecState::RUNNING);
+
+    mon_op::Result rval;
+    auto& output = rval.output;
+    if (!lock_status_is_ok())
+    {
+        print_no_locks_error(output);
+        return rval;
+    }
+
+    bool switchover_done = false;
+    auto op = switchover_prepare(type, after_demotion, new_master, current_master, Log::ON, OpStart::MANUAL,
+                                 output);
+    if (op)
+    {
+        switchover_done = switchover_perform(*op);
+        if (switchover_done)
+        {
+            MXB_NOTICE(SWITCHOVER_OK, op->demotion.target->name(), op->promotion.target->name());
+        }
+        else
+        {
+            string msg = string_printf(SWITCHOVER_FAIL,
+                                       op->demotion.target->name(), op->promotion.target->name());
+            PRINT_JSON_ERROR(output, "%s", msg.c_str());
+            delay_auto_cluster_ops();
+        }
+    }
+    else
+    {
+        PRINT_JSON_ERROR(output, "Switchover cancelled.");
+    }
+    rval.success = switchover_done;
+    return rval;
+}
+
+mon_op::Result MariaDBMonitor::manual_failover(FailoverType fo_type)
+{
+    // Manual commands should only run in the main monitor thread.
+    mxb_assert(mxb::Worker::get_current()->id() == m_worker->id());
+    mxb_assert(m_op_info.exec_state == mon_op::ExecState::RUNNING);
+
+    mon_op::Result rval;
+    auto& output = rval.output;
+    if (!lock_status_is_ok())
+    {
+        print_no_locks_error(output);
+        return rval;
+    }
+
+    bool failover_done = false;
+    auto op = failover_prepare(fo_type, Log::ON, OpStart::MANUAL, output);
+    if (op)
+    {
+        failover_done = failover_perform(*op);
+        if (failover_done)
+        {
+            MXB_NOTICE(FAILOVER_OK, op->demotion_target->name(), op->promotion.target->name());
+        }
+        else
+        {
+            PRINT_JSON_ERROR(output, FAILOVER_FAIL, op->demotion_target->name(),
+                             op->promotion.target->name());
+        }
+    }
+    else
+    {
+        PRINT_JSON_ERROR(output, "Failover cancelled.");
+    }
+    rval.success = failover_done;
+    return rval;
+}
+
+mon_op::Result MariaDBMonitor::manual_rejoin(SERVER* rejoin_cand_srv)
+{
+    // Manual commands should only run in the main monitor thread.
+    mxb_assert(mxb::Worker::get_current()->id() == m_worker->id());
+    mxb_assert(m_op_info.exec_state == mon_op::ExecState::RUNNING);
+
+    mon_op::Result rval;
+    auto& output = rval.output;
+    if (!lock_status_is_ok())
+    {
+        print_no_locks_error(output);
+        return rval;
+    }
+
+    maxbase::Duration time_limit(m_settings.shared.switchover_timeout);
+    GeneralOpData op(OpStart::MANUAL, output, time_limit);
+
+    bool rejoin_done = false;
+    if (cluster_can_be_joined())
+    {
+        MariaDBServer* rejoin_cand = get_server(rejoin_cand_srv);
+        if (rejoin_cand)
+        {
+            if (server_is_rejoin_suspect(op, rejoin_cand))
+            {
+                string gtid_update_error;
+                if (m_master->update_gtids(&gtid_update_error))
+                {
+                    // The manual version of rejoin does not need to be as careful as the automatic one.
+                    // The rules are mostly the same, the only difference is that a server with empty gtid:s
+                    // can be rejoined manually.
+                    // TODO: Add the warning to JSON output.
+                    string no_rejoin_reason;
+                    bool safe_rejoin = rejoin_cand->can_replicate_from(m_master, &no_rejoin_reason);
+                    bool empty_gtid = rejoin_cand->m_gtid_current_pos.empty();
+                    bool rejoin_allowed = false;
+                    if (safe_rejoin)
+                    {
+                        rejoin_allowed = true;
+                    }
+                    else
+                    {
+                        if (empty_gtid)
+                        {
+                            rejoin_allowed = true;
+                            MXB_WARNING("gtid_curren_pos of '%s' is empty. Manual rejoin is unsafe "
+                                        "but allowed.", rejoin_cand->name());
+                        }
+                        else
+                        {
+                            PRINT_JSON_ERROR(output, "'%s' cannot replicate from primary server '%s': %s",
+                                             rejoin_cand->name(), m_master->name(),
+                                             no_rejoin_reason.c_str());
+                        }
+                    }
+
+                    if (rejoin_allowed)
+                    {
+                        ServerArray joinable_server = {rejoin_cand};
+                        if (do_rejoin(op, joinable_server) == 1)
+                        {
+                            rejoin_done = true;
+                            MXB_NOTICE("Rejoin performed.");
+                        }
+                        else
+                        {
+                            PRINT_JSON_ERROR(output, "Rejoin attempted but failed.");
+                        }
+                    }
+                }
+                else
+                {
+                    PRINT_JSON_ERROR(output, "The GTIDs of primary server '%s' could not be updated: %s",
+                                     m_master->name(), gtid_update_error.c_str());
+                }
+            }   // server_is_rejoin_suspect has added any error messages to the output, no need to print here
+        }
+        else
+        {
+            PRINT_JSON_ERROR(output, "%s is not monitored by %s, cannot rejoin.",
+                             rejoin_cand_srv->name(), name());
+        }
+    }
+    else
+    {
+        const char BAD_CLUSTER[] = "The server cluster of monitor %s is not in a valid state for joining. "
+                                   "Either it has no primary or its gtid domain is unknown.";
+        PRINT_JSON_ERROR(output, BAD_CLUSTER, name());
+    }
+    rval.success = rejoin_done;
+    return rval;
+}
+
+/**
+ * Reset replication of the cluster. Removes all slave connections and deletes binlogs. Then resets the
+ * gtid sequence of the cluster to 0 and directs all servers to replicate from the given master.
+ *
+ * @param master_server Server to promote to master. If null, autoselect.
+ * @return Result structure
+ */
+mon_op::Result MariaDBMonitor::manual_reset_replication(SERVER* master_server)
+{
+    // This command is a last-resort type, so no need to be that careful. Users are only supposed to run this
+    // when replication is broken and they know the cluster is in sync.
+
+    // Manual commands should only run in the main monitor thread.
+    mxb_assert(mxb::Worker::get_current()->id() == m_worker->id());
+    mxb_assert(m_op_info.exec_state == mon_op::ExecState::RUNNING);
+
+    mon_op::Result rval;
+    auto& error_out = rval.output;
+    if (!lock_status_is_ok())
+    {
+        print_no_locks_error(error_out);
+        return rval;
+    }
+
+    MariaDBServer* new_master = nullptr;
+    if (master_server)
+    {
+        MariaDBServer* new_master_cand = get_server(master_server);
+        if (new_master_cand == nullptr)
+        {
+            PRINT_JSON_ERROR(error_out, NO_SERVER, master_server->name(), name());
+        }
+        else if (!new_master_cand->is_usable())
+        {
+            PRINT_JSON_ERROR(error_out, "Server '%s' is down or in maintenance and cannot be used as primary.",
+                             new_master_cand->name());
+        }
+        else
+        {
+            new_master = new_master_cand;
+        }
+    }
+    else
+    {
+        const char BAD_MASTER[] = "Could not autoselect new master for replication reset because %s";
+        if (m_master == nullptr)
+        {
+            PRINT_JSON_ERROR(error_out, BAD_MASTER, "the cluster has no primary.");
+        }
+        else if (!m_master->is_usable())
+        {
+            PRINT_JSON_ERROR(error_out, BAD_MASTER, "the primary is down or in maintenance.");
+        }
+        else
+        {
+            new_master = m_master;
+        }
+    }
+
+    m_state = State::RESET_REPLICATION;
+    // Also record the previous master, needed for scheduled events.
+    MariaDBServer* old_master = (m_master && m_master->is_master()) ? m_master : nullptr;
+
+    bool success = false;
+    if (new_master)
+    {
+        bool error = false;
+        // Step 1: Gather the list of affected servers. If any operation on the servers fails,
+        // the reset fails as well.
+        ServerArray targets;
+        for (MariaDBServer* server : m_servers)
+        {
+            if (server->is_usable())
+            {
+                targets.push_back(server);
+            }
+        }
+
+        // reset-replication has no specific timeout setting as it's a manual operation. Base the guess
+        // on switchover_timeout.
+        maybe_set_wait_timeout_all_servers(targets.size() * m_settings.shared.switchover_timeout);
+
+        // The 'targets'-array cannot be empty, at least 'new_master' is there.
+        MXB_NOTICE("Reseting replication on the following servers: %s. '%s' will be the new primary.",
+                   monitored_servers_to_string(targets).c_str(), new_master->name());
+
+        // Helper function for running a command on all servers in the list.
+        auto exec_cmd_on_array = [&error](const ServerArray& tgts, const string& query,
+                                          mxb::Json& err_out) {
+            if (!error)
+            {
+                for (MariaDBServer* server : tgts)
+                {
+                    string error_msg;
+                    if (!server->execute_cmd(query, &error_msg))
+                    {
+                        error = true;
+                        PRINT_JSON_ERROR(err_out, "%s", error_msg.c_str());
+                        break;
+                    }
+                }
+            }
+        };
+
+        // Step 2: Stop and reset all slave connections, even external ones.
+        for (MariaDBServer* server : targets)
+        {
+            if (!server->reset_all_slave_conns(error_out))
+            {
+                error = true;
+                break;
+            }
+        }
+
+        // In theory, this is wrong if there are no slaves. Cluster is modified soon anyway.
+        m_cluster_modified = true;
+
+        // Step 3: Set read_only and disable events.
+        exec_cmd_on_array(targets, "SET GLOBAL read_only=1;", error_out);
+        if (!error)
+        {
+            MXB_NOTICE("read_only set on affected servers.");
+            if (m_settings.shared.handle_event_scheduler)
+            {
+                for (MariaDBServer* server : targets)
+                {
+                    if (!server->disable_events(MariaDBServer::BinlogMode::BINLOG_OFF, error_out))
+                    {
+                        error = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Step 4: delete binary logs and reset the GTID state. MySQL 8.4 replaced "RESET MASTER" with
+        // "RESET BINARY LOGS AND GTIDS", which also clears gtid_executed/gtid_purged on every target.
+        exec_cmd_on_array(targets, "RESET BINARY LOGS AND GTIDS;", error_out);
+        if (!error)
+        {
+            MXB_NOTICE("Binary logs and GTID state reset on affected servers.");
+        }
+
+        // Step 5 (MariaDB's "SET GLOBAL gtid_slave_pos") is not needed for MySQL: after the GTID reset
+        // every replica reconnects with SOURCE_AUTO_POSITION=1 and resynchronises from the new primary.
+
+        if (!error)
+        {
+            // Step 6: Enable writing and events on new master, add gtid event.
+            string error_msg;
+            if (new_master->execute_cmd("SET GLOBAL read_only=0;", &error_msg))
+            {
+                // Point of no return, perform later steps even if an error occurs.
+                m_next_master = new_master;
+
+                if (m_settings.shared.handle_event_scheduler)
+                {
+                    if (old_master)
+                    {
+                        if (!new_master->enable_events(MariaDBServer::BinlogMode::BINLOG_ON,
+                                                       old_master->m_enabled_events, error_out))
+                        {
+                            error = true;
+                            PRINT_JSON_ERROR(error_out, "Could not enable events on '%s': %s",
+                                             new_master->name(), error_msg.c_str());
+                        }
+                    }
+                    else
+                    {
+                        MXB_WARNING("No scheduled events were enabled on '%s' because previous primary is "
+                                    "unknown. Check events manually.", new_master->name());
+                    }
+                }
+
+                // Add an event to the new master so that it has a non-empty gtid_current_pos.
+                if (!new_master->execute_cmd("FLUSH TABLES;", &error_msg))
+                {
+                    error = true;
+                    PRINT_JSON_ERROR(error_out, "Could not add event to '%s': %s",
+                                     new_master->name(), error_msg.c_str());
+                }
+
+                // Step 7: Set all slaves to replicate from the master.
+                // The following commands are only sent to slaves.
+                ServerArray slaves;
+                for (auto target : targets)
+                {
+                    if (target != new_master)
+                    {
+                        slaves.push_back(target);
+                    }
+                }
+
+                if (!slaves.empty())
+                {
+                    SERVER* new_master_srv = new_master->server;
+                    // Using Slave_Pos here since gtid_slave_pos was set earlier.
+                    SlaveStatus::Settings new_conn("", new_master_srv, GtidMode::SLAVE);
+                    // Expect this to complete quickly.
+                    GeneralOpData general(OpStart::MANUAL, rval.output, 0s);
+                    size_t slave_conns_started = 0;
+                    for (auto slave : slaves)
+                    {
+                        if (slave->create_start_slave(general, new_conn, ReplicationOp::CONN_SETT))
+                        {
+                            slave_conns_started++;
+                        }
+                    }
+
+                    if (slave_conns_started == slaves.size())
+                    {
+                        // TODO: Properly check slave IO/SQL threads.
+                        MXB_NOTICE("All replicas redirected successfully.");
+                    }
+                    else
+                    {
+                        error = true;
+                        PRINT_JSON_ERROR(error_out, "Some servers were not redirected to '%s'.",
+                                         new_master->name());
+                    }
+                }
+            }
+            else
+            {
+                error = true;
+                PRINT_JSON_ERROR(error_out, "Could not enable writes on '%s': %s",
+                                 new_master->name(), error_msg.c_str());
+            }
+        }
+
+        if (error)
+        {
+            PRINT_JSON_ERROR(error_out, "Replication reset failed or succeeded only partially. "
+                                        "Server cluster may be in an invalid state for replication.");
+        }
+        success = !error;
+
+        reset_wait_timeout_all_servers();
+    }
+    m_state = State::IDLE;
+    rval.success = success;
+    return rval;
+}
+
+/**
+ * Redirect slave connections from the promotion target to replicate from the demotion target and vice versa.
+ *
+ * @param op Operation descriptor
+ * @param redirected_to_promo Output for slaves successfully redirected to promotion target
+ * @param redirected_to_demo Output for slaves successfully redirected to demotion target
+ * @return The number of slaves successfully redirected
+ */
+int MariaDBMonitor::redirect_slaves_ex(GeneralOpData& general, OperationType type,
+                                       const MariaDBServer* promotion_target,
+                                       const MariaDBServer* demotion_target,
+                                       ServerArray* redirected_to_promo, ServerArray* redirected_to_demo)
+{
+    const bool is_switchover = (type == OperationType::SWITCHOVER || type == OperationType::SWITCHOVER_FORCE);
+    mxb_assert(is_switchover || type == OperationType::FAILOVER || type == OperationType::FAILOVER_SAFE);
+
+    // Slaves of demotion target are redirected to promotion target.
+    // Try to redirect even disconnected slaves.
+    ServerArray redirect_to_promo_target = get_redirectables(demotion_target, promotion_target);
+    // Slaves of promotion target are redirected to demotion target in case of switchover.
+    // This list contains elements only when promoting a relay in switchover.
+    ServerArray redirect_to_demo_target;
+    if (is_switchover)
+    {
+        redirect_to_demo_target = get_redirectables(promotion_target, demotion_target);
+    }
+    if (redirect_to_promo_target.empty() && redirect_to_demo_target.empty())
+    {
+        // This is ok, nothing to do.
+        return 0;
+    }
+
+    /* In complicated topologies, this redirection can get tricky. It's possible that a slave is
+     * replicating from both promotion and demotion targets and with different settings. This leads
+     * to a somewhat similar situation as in promotion (connection copy/merge).
+     *
+     * Neither slave connection can be redirected since they would be conflicting. As a temporary
+     * solution, such duplicate slave connections are for now avoided by not redirecting them. If this
+     * becomes an issue (e.g. connection settings need to be properly preserved), add code which:
+     * 1) In switchover, swaps the connections by first deleting or redirecting the other to a nonsensial
+     * host to avoid host:port conflict.
+     * 2) In failover, deletes the connection to promotion target and redirects the one to demotion target,
+     * or does the same as in 1.
+     */
+
+    const char redir_fmt[] = "Redirecting %s to replicate from '%s' instead of '%s'.";
+    string slave_names_to_promo = monitored_servers_to_string(redirect_to_promo_target);
+    string slave_names_to_demo = monitored_servers_to_string(redirect_to_demo_target);
+    mxb_assert(slave_names_to_demo.empty() || is_switchover);
+
+    // Print both name lists if both have items, otherwise just the one with items.
+    if (!slave_names_to_promo.empty() && !slave_names_to_demo.empty())
+    {
+        MXB_NOTICE("Redirecting %s to replicate from '%s' instead of '%s', and %s to replicate from "
+                   "'%s' instead of '%s'.",
+                   slave_names_to_promo.c_str(), promotion_target->name(), demotion_target->name(),
+                   slave_names_to_demo.c_str(), demotion_target->name(), promotion_target->name());
+    }
+    else if (!slave_names_to_promo.empty())
+    {
+        MXB_NOTICE(redir_fmt,
+                   slave_names_to_promo.c_str(), promotion_target->name(), demotion_target->name());
+    }
+    else if (!slave_names_to_demo.empty())
+    {
+        MXB_NOTICE(redir_fmt,
+                   slave_names_to_demo.c_str(), demotion_target->name(), promotion_target->name());
+    }
+
+    int successes = 0;
+    int fails = 0;
+    int conflicts = 0;
+    auto redirection_helper =
+        [&general, &conflicts, &successes, &fails](ServerArray& redirect_these, const MariaDBServer* from,
+                                                   const MariaDBServer* to, ServerArray* redirected) {
+        for (MariaDBServer* redirectable : redirect_these)
+        {
+            mxb_assert(redirected);
+            /* If the connection exists, even if disconnected, don't redirect.
+             * Compare host:port, since that is how server detects duplicate connections.
+             * Ignore for now the possibility of different host:ports having same server id:s
+             * etc as such setups shouldn't try failover/switchover anyway. */
+            auto existing_conn = redirectable->slave_connection_status_host_port(to);
+            if (existing_conn)
+            {
+                // Already has a connection to redirect target.
+                conflicts++;
+                MXB_WARNING("'%s' already has a replica connection to '%s', connection to '%s' was "
+                            "not redirected.",
+                            redirectable->name(), to->name(), from->name());
+            }
+            else
+            {
+                // No conflict, redirect as normal.
+                auto old_conn = redirectable->slave_connection_status(from);
+                auto old_settings = old_conn->settings;
+                if (redirectable->redirect_existing_slave_conn(general, old_settings, to))
+                {
+                    successes++;
+                    redirected->push_back(redirectable);
+                }
+                else
+                {
+                    fails++;
+                }
+            }
+        }
+    };
+
+    redirection_helper(redirect_to_promo_target, demotion_target, promotion_target, redirected_to_promo);
+    redirection_helper(redirect_to_demo_target, promotion_target, demotion_target, redirected_to_demo);
+
+    // Redirection may have caused errors. Since redirect_slaves_ex is only ran when failover/switchover
+    // is considered a success, remove any errors from the output. The errors have already been written to
+    // log.
+    auto& error_out = general.error_out;
+    if (error_out.object_size() > 0)
+    {
+        error_out = mxb::Json(mxb::Json::Type::OBJECT);
+    }
+
+    if (fails == 0 && conflicts == 0)
+    {
+        MXB_NOTICE("All redirects successful.");
+    }
+    else if (fails == 0)
+    {
+        MXB_NOTICE("%i slave connections were redirected while %i connections were ignored.",
+                   successes, conflicts);
+    }
+    else
+    {
+        int total = fails + conflicts + successes;
+        MXB_WARNING("%i redirects failed, %i slave connections ignored and %i redirects successful "
+                    "out of %i.", fails, conflicts, successes, total);
+    }
+    return successes;
+}
+
+/**
+ * (Re)join given servers to the cluster. The servers in the array are assumed to be joinable.
+ * Usually the list is created by get_joinable_servers().
+ *
+ * @param joinable_servers Which servers to rejoin
+ * @return The number of servers successfully rejoined
+ */
+uint32_t MariaDBMonitor::do_rejoin(GeneralOpData& op, const ServerArray& joinable_servers)
+{
+    SERVER* master_server = m_master->server;
+    const char* master_name = master_server->name();
+    uint32_t servers_joined = 0;
+    bool rejoin_error = false;
+    m_state = State::REJOIN;
+    if (!joinable_servers.empty())
+    {
+        // Usually rejoin should be fast, just a "change master to ...", so changing wait_timeouts would not
+        // be required. However, old master demotion may contain custom commands that take some time, so
+        // be on the safe side here.
+        maybe_set_wait_timeout_all_servers(joinable_servers.size() * m_settings.shared.switchover_timeout);
+
+        for (MariaDBServer* joinable : joinable_servers)
+        {
+            const char* name = joinable->name();
+            bool op_success = false;
+
+            if (joinable->m_slave_status.empty())
+            {
+                // Assume that server is an old master which was failed over. Even if this is not really
+                // the case, the following is unlikely to do damage.
+                ServerOperation demotion(joinable, ServerOperation::TargetType::MASTER);
+                if (joinable->demote(op, demotion, OperationType::REJOIN))
+                {
+                    MXB_NOTICE("Directing standalone server '%s' to replicate from '%s'.", name, master_name);
+                    // A slave connection description is required. As this is the only connection, no name
+                    // is required.
+                    SlaveStatus::Settings new_conn("", master_server, GtidMode::NONE);
+                    op_success = joinable->create_start_slave(op, new_conn, ReplicationOp::DEMOTE);
+                }
+                else
+                {
+                    PRINT_JSON_ERROR(op.error_out, "Failed to prepare (demote) standalone "
+                                                   "server '%s' for rejoin.", name);
+                }
+            }
+            else
+            {
+                MXB_NOTICE("Server '%s' is replicating from a server other than '%s', "
+                           "redirecting it to '%s'.",
+                           name, master_name, master_name);
+                // Multisource replication does not get to this point unless enforce_simple_topology is
+                // enabled. If multisource replication is used, we must remove the excess connections.
+                mxb_assert(joinable->m_slave_status.size() == 1 || m_settings.enforce_simple_topology);
+
+                if (joinable->m_slave_status.size() > 1)
+                {
+                    SlaveStatusArray extra_conns(std::next(joinable->m_slave_status.begin()),
+                                                 joinable->m_slave_status.end());
+
+                    MXB_NOTICE("Erasing %lu replication connections(s) from server '%s'.",
+                               extra_conns.size(), name);
+                    joinable->remove_slave_conns(op, extra_conns);
+                }
+
+                auto slave_settings = joinable->m_slave_status[0].settings;
+                op_success = joinable->redirect_existing_slave_conn(op, slave_settings, m_master);
+            }
+
+            if (op_success)
+            {
+                servers_joined++;
+                m_cluster_modified = true;
+            }
+            else
+            {
+                rejoin_error = true;
+            }
+        }
+
+        reset_wait_timeout_all_servers();
+    }
+
+    m_state = State::IDLE;
+    if (rejoin_error)
+    {
+        delay_auto_cluster_ops();
+    }
+    return servers_joined;
+}
+
+/**
+ * Check if the cluster is a valid rejoin target.
+ *
+ * @return True if master and gtid domain are known
+ */
+bool MariaDBMonitor::cluster_can_be_joined()
+{
+    return m_master && m_master->is_master() && m_master_gtid_domain != GTID_DOMAIN_UNKNOWN;
+}
+
+/**
+ * Scan the servers in the cluster and add (re)joinable servers to an array.
+ *
+ * @param output Array to save results to. Each element is a valid (re)joinable server according
+ * to latest data.
+ * @return False, if there were possible rejoinable servers but communications error to master server
+ * prevented final checks.
+ */
+bool MariaDBMonitor::get_joinable_servers(GeneralOpData& op, ServerArray* output)
+{
+    mxb_assert(output);
+
+    // Whether a join operation should be attempted or not depends on several criteria. Start with the ones
+    // easiest to test. Go though all slaves and construct a preliminary list.
+    ServerArray suspects;
+    for (MariaDBServer* server : m_servers)
+    {
+        if (server_is_rejoin_suspect(op, server))
+        {
+            suspects.push_back(server);
+        }
+    }
+
+    // Update Gtid of master for better info.
+    bool comm_ok = true;
+    if (!suspects.empty())
+    {
+        string gtid_update_error;
+        if (m_master->update_gtids(&gtid_update_error))
+        {
+            for (auto* suspect : suspects)
+            {
+                string rejoin_err_msg;
+                if (suspect->can_replicate_from(m_master, &rejoin_err_msg))
+                {
+                    output->push_back(suspect);
+                }
+                else if (m_warn_cannot_rejoin)
+                {
+                    // Print a message explaining why an auto-rejoin is not done. Suppress printing.
+                    MXB_WARNING("Automatic rejoin was not attempted on server '%s' even though it is a "
+                                "valid candidate. Will keep retrying with this message suppressed for all "
+                                "servers. Errors: \n%s", suspect->name(), rejoin_err_msg.c_str());
+                    m_warn_cannot_rejoin = false;
+                }
+            }
+        }
+        else
+        {
+            MXB_ERROR("The GTIDs of primary server '%s' could not be updated while attempting an automatic "
+                      "rejoin: %s", m_master->name(), gtid_update_error.c_str());
+            comm_ok = false;
+        }
+    }
+    else
+    {
+        m_warn_cannot_rejoin = true;
+    }
+    return comm_ok;
+}
+
+/**
+ * Checks if a server is a possible rejoin candidate. A true result from this function is not yet sufficient
+ * criteria and another call to can_replicate_from() should be made.
+ *
+ * @param rejoin_cand Server to check
+ * @param output Error output. If NULL, no error is printed to log.
+ * @return True, if server is a rejoin suspect.
+ */
+bool MariaDBMonitor::server_is_rejoin_suspect(GeneralOpData& op, MariaDBServer* rejoin_cand)
+{
+    bool is_suspect = false;
+    auto output = op.error_out;
+    if (rejoin_cand->is_usable() && !rejoin_cand->is_master())
+    {
+        // Has no slave connection, yet is not a master.
+        if (rejoin_cand->m_slave_status.empty())
+        {
+            is_suspect = true;
+        }
+        // Or has existing slave connection ...
+        else if (rejoin_cand->m_slave_status.size() == 1)
+        {
+            SlaveStatus* slave_status = &rejoin_cand->m_slave_status[0];
+
+            // which is connected to master but it's the wrong one
+            if (slave_status->slave_io_running == SlaveStatus::SLAVE_IO_YES
+                && slave_status->master_server_id != m_master->m_server_id)
+            {
+                is_suspect = true;
+            }
+            // or is disconnected but master host or port is wrong.
+            else if (slave_status->slave_io_running == SlaveStatus::SLAVE_IO_CONNECTING
+                     && slave_status->slave_sql_running)
+            {
+                if (!slave_status->settings.master_endpoint.points_to_server(*m_master->server))
+                {
+                    is_suspect = true;
+                }
+            }
+        }
+        else if (m_settings.enforce_simple_topology)
+        {
+            // If enforce_simple_topology is enabled, the presence of multiple slave connections always
+            // triggers a rejoin as only one must be configured.
+            is_suspect = true;
+        }
+
+        if (op.start == OpStart::MANUAL && !is_suspect)
+        {
+            /* User has requested a manual rejoin but with a server which has multiple slave connections or
+             * is already connected or trying to connect to the correct master. TODO: Slave IO stopped is
+             * not yet handled perfectly. */
+            if (rejoin_cand->m_slave_status.size() > 1)
+            {
+                const char MULTI_SLAVE[] = "Server '%s' has multiple slave connections, cannot rejoin.";
+                PRINT_JSON_ERROR(output, MULTI_SLAVE, rejoin_cand->name());
+            }
+            else
+            {
+                const char CONNECTED[] = "Server '%s' is already connected or trying to connect to the "
+                                         "correct primary server.";
+                PRINT_JSON_ERROR(output, CONNECTED, rejoin_cand->name());
+            }
+        }
+    }
+    else if (op.start == OpStart::MANUAL)
+    {
+        PRINT_JSON_ERROR(output, "Server '%s' is primary or not running.", rejoin_cand->name());
+    }
+    return is_suspect;
+}
+
+/**
+ * Performs switchover for a simple topology (1 master, N slaves, no intermediate masters). If an
+ * intermediate step fails, the cluster may be left without a master and manual intervention is
+ * required to fix things.
+ *
+ * @param op Operation descriptor
+ * @return True if successful. If false, replication may be broken.
+ */
+bool MariaDBMonitor::switchover_perform(SwitchoverParams& op)
+{
+    using std::chrono::seconds;
+    using std::chrono::duration_cast;
+    mxb_assert(op.demotion.target && op.promotion.target);
+    maybe_set_wait_timeout_all_servers(m_settings.shared.switchover_timeout);
+
+    const OperationType type = (op.type == SwitchoverType::NORMAL || op.type == SwitchoverType::AUTO) ?
+        OperationType::SWITCHOVER : OperationType::SWITCHOVER_FORCE;
+    MariaDBServer* const promotion_target = op.promotion.target;
+    MariaDBServer* const demotion_target = op.demotion.target;
+
+    bool rval = false;
+    m_state = State::DEMOTE;
+
+    // Step 0: Prepare connection to old master
+    // Some of the following commands (e.g. set read_only=1) can take a while. The basic monitor timeouts
+    // may be too small, so reconnect with larger. To retain any exclusive locks held by the monitor,
+    // backup the old connection.
+    bool ok_to_demote = false;
+    StopWatch timer;
+    auto new_conn_timeout = round_to_seconds(op.general.time_remaining) * 1s;
+    if (demotion_target->relax_connector_timeouts(new_conn_timeout))
+    {
+        ok_to_demote = true;
+    }
+    op.general.time_remaining -= timer.lap();
+
+    // Step 1: Set read-only to on, flush logs, update gtid:s.
+    if (ok_to_demote && demotion_target->demote(op.general, op.demotion, type))
+    {
+        m_cluster_modified = true;
+        bool catchup_and_promote_success = false;
+        timer.restart();
+        // Step 2: Wait for the promotion target to catch up with the demotion target. Disregard the other
+        // slaves of the promotion target to avoid needless waiting.
+        // The gtid:s of the demotion target were updated at the end of demotion.
+        // If forcing a switch, do not require the catchup to succeed as old master may not be frozen and
+        // could send events continuously.
+        m_state = State::WAIT_FOR_TARGET_CATCHUP;
+        if (promotion_target->catchup_to_master(op.general, demotion_target->m_gtid_binlog_pos)
+            || type == OperationType::SWITCHOVER_FORCE)
+        {
+            MXB_INFO("Switchover: Catchup took %.1f seconds.", mxb::to_secs(timer.lap()));
+            // Step 3: On new master: remove slave connections, set read-only to OFF etc. This needs to
+            // succeed even in switchover-force, as otherwise the operation makes no sense.
+            m_state = State::PROMOTE_TARGET;
+            if (promotion_target->promote(op.general, op.promotion, type, demotion_target))
+            {
+                // Point of no return. Even if following steps fail, do not try to undo.
+                // Switchover considered at least partially successful.
+                catchup_and_promote_success = true;
+                rval = true;
+                if (op.promotion.target_type == ServerOperation::TargetType::MASTER)
+                {
+                    // Force a master swap on next tick.
+                    m_next_master = promotion_target;
+                }
+
+                // Step 4: Start replication on old master and redirect slaves. Using Current_Pos since
+                // Slave_Pos is likely obsolete or empty.
+                m_state = State::REJOIN;
+                ServerArray redirected_to_promo_target;
+
+                switch (op.after_demotion)
+                {
+                case AfterDemotion::REDIRECT:
+                    if (demotion_target->copy_slave_conns(op.general, op.demotion.conns_to_copy,
+                                                          promotion_target, ReplicationOp::DEMOTE))
+                    {
+                        redirected_to_promo_target.push_back(demotion_target);
+                    }
+                    else
+                    {
+                        MXB_WARNING("Could not copy slave connections from '%s' to '%s'.",
+                                    promotion_target->name(), demotion_target->name());
+                    }
+                    break;
+
+                case AfterDemotion::MAINTENANCE:
+                    demotion_target->server->set_status(SERVER_MAINT);
+                    MXB_NOTICE("Old primary %s set to maintenance.", demotion_target->name());
+                    break;
+                }
+
+                ServerArray redirected_to_demo_target;
+                redirect_slaves_ex(op.general, type, promotion_target, demotion_target,
+                                   &redirected_to_promo_target, &redirected_to_demo_target);
+
+                if (!redirected_to_promo_target.empty() || !redirected_to_demo_target.empty())
+                {
+                    timer.restart();
+                    // Step 5: Finally, check that slaves are replicating.
+                    m_state = State::CONFIRM_REPLICATION;
+                    wait_cluster_stabilization(op.general, redirected_to_promo_target, promotion_target);
+                    wait_cluster_stabilization(op.general, redirected_to_demo_target, demotion_target);
+                    auto step6_duration = timer.lap();
+                    MXB_INFO("Switchover: slave replication confirmation took %.1f seconds with "
+                             "%.1f seconds to spare.",
+                             mxb::to_secs(step6_duration), mxb::to_secs(op.general.time_remaining));
+                }
+            }
+        }
+
+        if (!catchup_and_promote_success)
+        {
+            // Step 2 or 3 failed, try to undo step 1 by promoting the demotion target back to master.
+            // Reset the time limit since the last part may have used it all.
+            MXB_NOTICE("Attempting to undo changes to '%s'.", demotion_target->name());
+            const mxb::Duration demotion_undo_time_limit(m_settings.shared.switchover_timeout);
+            GeneralOpData general_undo(op.general.start, op.general.error_out, demotion_undo_time_limit);
+            if (demotion_target->promote(general_undo, op.promotion, OperationType::UNDO_DEMOTION, nullptr))
+            {
+                MXB_NOTICE("'%s' restored to original status.", demotion_target->name());
+            }
+            else
+            {
+                PRINT_JSON_ERROR(op.general.error_out,
+                                 "Restoring of '%s' failed, cluster may be in an invalid state.",
+                                 demotion_target->name());
+            }
+        }
+    }
+
+    demotion_target->restore_connector_timeouts();
+    m_state = State::IDLE;
+    reset_wait_timeout_all_servers();
+    return rval;
+}
+
+/**
+ * Performs failover for a simple topology (1 master, N slaves, no intermediate masters).
+ *
+ * @param op Operation descriptor
+ * @return True if successful
+ */
+bool MariaDBMonitor::failover_perform(FailoverParams& op)
+{
+    mxb_assert(op.promotion.target && op.demotion_target);
+    maybe_set_wait_timeout_all_servers(m_settings.failover_timeout);
+
+    const OperationType type = OperationType::FAILOVER;
+    MariaDBServer* const promotion_target = op.promotion.target;
+    auto const demotion_target = op.demotion_target;
+
+    bool rval = false;
+    // Step 1: Stop and reset slave, set read-only to OFF.
+    m_state = State::PROMOTE_TARGET;
+    if (promotion_target->promote(op.general, op.promotion, type, demotion_target))
+    {
+        // Point of no return. Even if following steps fail, do not try to undo. Failover considered
+        // at least partially successful.
+        rval = true;
+        m_cluster_modified = true;
+        if (op.promotion.target_type == ServerOperation::TargetType::MASTER)
+        {
+            // Force a master swap on next tick.
+            m_next_master = promotion_target;
+        }
+
+        // Step 2: Redirect slaves.
+        m_state = State::REJOIN;
+        ServerArray redirected_slaves;
+        redirect_slaves_ex(op.general, type, promotion_target, demotion_target, &redirected_slaves, nullptr);
+        if (!redirected_slaves.empty())
+        {
+            StopWatch timer;
+            /* Step 3: Finally, check that slaves are connected to the new master. Even if
+             * time is out at this point, wait_cluster_stabilization() will check the slaves
+             * once so that latest status is printed. */
+            m_state = State::CONFIRM_REPLICATION;
+            wait_cluster_stabilization(op.general, redirected_slaves, promotion_target);
+            MXB_INFO("Failover: slave replication confirmation took %.1f seconds with "
+                     "%.1f seconds to spare.",
+                     mxb::to_secs(timer.lap()), mxb::to_secs(op.general.time_remaining));
+        }
+    }
+    m_state = State::IDLE;
+    reset_wait_timeout_all_servers();
+    return rval;
+}
+
+/**
+ * Check that the given slaves are connected and replicating from the new master. Only checks
+ * the SLAVE STATUS of the slaves.
+ *
+ * @param op Operation descriptor
+ * @param redirected_slaves Slaves to check
+ * @param new_master The target server of the slave connections
+ */
+void MariaDBMonitor::wait_cluster_stabilization(GeneralOpData& op, const ServerArray& redirected_slaves,
+                                                const MariaDBServer* new_master)
+{
+    if (redirected_slaves.empty())
+    {
+        // No need to check anything or print messages.
+        return;
+    }
+
+    maxbase::Duration& time_remaining = op.time_remaining;
+    StopWatch timer;
+    // Check all the servers in the list. Using a set because erasing from container.
+    std::set<MariaDBServer*> unconfirmed(redirected_slaves.begin(), redirected_slaves.end());
+    ServerArray successes;
+    ServerArray repl_fails;
+    ServerArray query_fails;
+    bool time_is_up = false;    // Try at least once, even if time is up.
+
+    while (!unconfirmed.empty() && !time_is_up)
+    {
+        auto iter = unconfirmed.begin();
+        while (iter != unconfirmed.end())
+        {
+            MariaDBServer* slave = *iter;
+            if (slave->do_show_slave_status())
+            {
+                auto slave_conn = slave->slave_connection_status_host_port(new_master);
+                if (slave_conn == nullptr)
+                {
+                    // Highly unlikely. Maybe someone just removed the slave connection after it was created.
+                    MXB_WARNING("'%s' does not have a slave connection to '%s' although one should have "
+                                "been created.",
+                                slave->name(), new_master->name());
+                    repl_fails.push_back(*iter);
+                    iter = unconfirmed.erase(iter);
+                }
+                else if (slave_conn->slave_io_running == SlaveStatus::SLAVE_IO_YES
+                         && slave_conn->slave_sql_running == true)
+                {
+                    // This slave has connected to master and replication seems to be ok.
+                    successes.push_back(*iter);
+                    iter = unconfirmed.erase(iter);
+                }
+                else if (slave_conn->slave_io_running == SlaveStatus::SLAVE_IO_NO)
+                {
+                    // IO error on slave
+                    MXB_WARNING("%s cannot start replication because of IO thread error: '%s'.",
+                                slave_conn->settings.to_string().c_str(), slave_conn->last_io_error.c_str());
+                    repl_fails.push_back(*iter);
+                    iter = unconfirmed.erase(iter);
+                }
+                else if (slave_conn->slave_sql_running == false)
+                {
+                    // SQL error on slave
+                    MXB_WARNING("%s cannot start replication because of SQL thread error: '%s'.",
+                                slave_conn->settings.to_string().c_str(), slave_conn->last_sql_error.c_str());
+                    repl_fails.push_back(*iter);
+                    iter = unconfirmed.erase(iter);
+                }
+                else
+                {
+                    // Slave IO is still connecting, must wait.
+                    ++iter;
+                }
+            }
+            else
+            {
+                query_fails.push_back(*iter);
+                iter = unconfirmed.erase(iter);
+            }
+        }
+
+        time_remaining -= timer.lap();
+        if (!unconfirmed.empty())
+        {
+            if (time_remaining.count() > 0)
+            {
+                maxbase::Duration standard_sleep = 500ms;
+                // If we have unconfirmed slaves and have time remaining, sleep a bit and try again.
+                /* TODO: This sleep is kinda pointless, because whether or not replication begins,
+                 * all operations for failover/switchover are complete. The sleep is only required to
+                 * get correct messages to the user. Think about removing it, or shortening the maximum
+                 * time of this function. */
+                auto sleep_time = std::min(time_remaining, standard_sleep);
+                std::this_thread::sleep_for(sleep_time);
+            }
+            else
+            {
+                // Have undecided slaves and is out of time.
+                time_is_up = true;
+            }
+        }
+    }
+
+    if (successes.size() == redirected_slaves.size())
+    {
+        // Complete success.
+        MXB_NOTICE("All redirected slaves successfully started replication from '%s'.", new_master->name());
+    }
+    else
+    {
+        if (!successes.empty())
+        {
+            MXB_NOTICE("%s successfully started replication from '%s'.",
+                       monitored_servers_to_string(successes).c_str(), new_master->name());
+        }
+        // Something went wrong.
+        auto fails = query_fails.size() + repl_fails.size() + unconfirmed.size();
+        const char MSG[] = "%lu slaves did not start replicating from '%s'. "
+                           "%lu encountered an I/O or SQL error, %lu failed to reply and %lu did not "
+                           "connect to '%s' within the time limit.";
+        MXB_WARNING(MSG, fails, new_master->name(), repl_fails.size(), query_fails.size(),
+                    unconfirmed.size(), new_master->name());
+
+        // If any of the unconfirmed slaves have error messages in their slave status, print them. They
+        // may explain what went wrong.
+        for (auto failed_slave : unconfirmed)
+        {
+            auto slave_conn = failed_slave->slave_connection_status_host_port(new_master);
+            if (slave_conn && !slave_conn->last_io_error.empty())
+            {
+                MXB_WARNING("%s did not connect because of error: '%s'",
+                            slave_conn->settings.to_string().c_str(), slave_conn->last_io_error.c_str());
+            }
+        }
+    }
+    time_remaining -= timer.lap();
+}
+
+/**
+ * Select a promotion target for failover/switchover. Looks at the slaves of 'demotion_target' and selects
+ * the server with the most up-do-date event or, if events are equal, the one with the best settings and
+ * status. When comparing, also selects the domain id used for comparing gtids.
+ *
+ * @param demotion_target The former master server/relay
+ * @param op Switchover or failover
+ * @param log_mode Print log or operate silently
+ * @param gtid_domain_out Output for selected gtid domain id guess
+ * @param error_out Error output
+ * @return The selected promotion target or NULL if no valid candidates
+ */
+MariaDBServer*
+MariaDBMonitor::select_promotion_target(MariaDBServer* demotion_target, OperationType op, Log log_mode,
+                                        int64_t* gtid_domain_out, mxb::Json& error_out)
+{
+    /* Select a new master candidate. Selects the one with the latest event in relay log.
+     * If multiple slaves have same number of events, select the one with most processed events. */
+
+    if (!demotion_target->m_node.children.empty())
+    {
+        if (log_mode == Log::ON)
+        {
+            MXB_NOTICE("Selecting a server to promote and replace '%s'. Candidates are: %s.",
+                       demotion_target->name(),
+                       monitored_servers_to_string(demotion_target->m_node.children).c_str());
+        }
+    }
+    else
+    {
+        PRINT_ERROR_IF(log_mode, error_out, "'%s' does not have any slaves to promote.",
+                       demotion_target->name());
+        return nullptr;
+    }
+
+    // Servers that cannot be selected because of exclusion, but seem otherwise ok.
+    ServerArray valid_but_excluded;
+
+    string all_reasons;
+    DelimitedPrinter printer("\n");
+    // The valid promotion candidates are the slaves replicating directly from the demotion target.
+    ServerArray candidates;
+    for (MariaDBServer* cand : demotion_target->m_node.children)
+    {
+        string reason;
+        if (!cand->can_be_promoted(op, demotion_target, &reason))
+        {
+            string msg = string_printf("'%s' cannot be selected because %s", cand->name(), reason.c_str());
+            printer.cat(all_reasons, msg);
+        }
+        else if (server_is_excluded(cand))
+        {
+            valid_but_excluded.push_back(cand);
+            string msg = string_printf("'%s' cannot be selected because it is excluded.", cand->name());
+            printer.cat(all_reasons, msg);
+        }
+        else
+        {
+            candidates.push_back(cand);
+            // Print some warnings about the candidate server.
+            if (log_mode == Log::ON)
+            {
+                cand->warn_replication_settings();
+            }
+        }
+    }
+
+    MariaDBServer* current_best = nullptr;
+    string current_best_reason;
+    int64_t gtid_domain = m_master_gtid_domain;
+    if (candidates.empty())
+    {
+        PRINT_ERROR_IF(log_mode, error_out, "No suitable promotion candidate found:\n%s",
+                       all_reasons.c_str());
+    }
+    else
+    {
+        if (gtid_domain == GTID_DOMAIN_UNKNOWN && m_settings.enforce_simple_topology)
+        {
+            // Need to guess the domain id. This only happens when failovering without having seen
+            // the master running.
+            int id_missing_count = 0;
+            // Guaranteed to give a value if candidates are ok.
+            gtid_domain = guess_gtid_domain(demotion_target, candidates, &id_missing_count);
+            mxb_assert(gtid_domain != GTID_DOMAIN_UNKNOWN);
+            if (log_mode == Log::ON)
+            {
+                MXB_WARNING("Gtid-domain id of '%s' is unknown, attempting to guess it by looking at "
+                            "gtid:s of candidates.", m_master->name());
+                if (id_missing_count > 0)
+                {
+                    MXB_WARNING("Guessed domain id %li, which is missing on %i candidates. This may cause "
+                                "faulty promotion target selection.", gtid_domain, id_missing_count);
+                }
+                else
+                {
+                    MXB_WARNING("Guessed domain id %li, which is on all candidates.", gtid_domain);
+                }
+            }
+        }
+
+        // Check which candidate is best. Default select the first.
+        current_best = candidates.front();
+        candidates.erase(candidates.begin());
+        if (!all_reasons.empty() && log_mode == Log::ON)
+        {
+            MXB_WARNING("Some servers were disqualified for promotion:\n%s", all_reasons.c_str());
+        }
+        for (MariaDBServer* cand : candidates)
+        {
+            if (is_candidate_better(cand, current_best, demotion_target, gtid_domain, &current_best_reason))
+            {
+                // Select the server for promotion, for now.
+                current_best = cand;
+            }
+        }
+    }
+
+    // Check if any of the excluded servers would be better than the best candidate. Only print one item.
+    if (log_mode == Log::ON)
+    {
+        for (MariaDBServer* excluded : valid_but_excluded)
+        {
+            const char* excluded_name = excluded->name();
+            if (current_best == nullptr)
+            {
+                const char EXCLUDED_ONLY_CAND[] = "Server '%s' is a viable choice for new primary, "
+                                                  "but cannot be selected as it's excluded.";
+                MXB_WARNING(EXCLUDED_ONLY_CAND, excluded_name);
+                break;
+            }
+            else if (is_candidate_better(excluded, current_best, demotion_target, gtid_domain))
+            {
+                // Print a warning if this server is actually a better candidate than the previous best.
+                const char EXCLUDED_CAND[] = "Server '%s' is superior to current best candidate '%s', "
+                                             "but cannot be selected as it's excluded. This may lead to "
+                                             "loss of data if '%s' is ahead of other servers.";
+                MXB_WARNING(EXCLUDED_CAND, excluded_name, current_best->name(), excluded_name);
+                break;
+            }
+        }
+    }
+
+    if (current_best)
+    {
+        if (gtid_domain_out)
+        {
+            *gtid_domain_out = gtid_domain;
+        }
+
+        if (log_mode == Log::ON)
+        {
+            // If there was a specific reason this server was selected, print it now.
+            // If the first candidate was chosen (likely all servers were equally good), do not print.
+            string msg = string_printf("Selected '%s'", current_best->name());
+            msg += current_best_reason.empty() ? "." : (" because " + current_best_reason);
+            MXB_NOTICE("%s", msg.c_str());
+        }
+    }
+    return current_best;
+}
+
+/**
+ * Is the server in the excluded list
+ *
+ * @param server Server to test
+ * @return True if server is in the excluded-list of the monitor.
+ */
+bool MariaDBMonitor::server_is_excluded(const MariaDBServer* server)
+{
+    for (MariaDBServer* excluded : m_excluded_servers)
+    {
+        if (excluded == server)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Is the candidate a better choice for master than the previous best?
+ *
+ * @param candidate_info Server info of new candidate
+ * @param current_best_info Server info of current best choice
+ * @param demotion_target Server which will be demoted
+ * @param gtid_domain Which domain to compare
+ * @param reason_out Why is the candidate better than current_best
+ * @return True if candidate is better
+ */
+bool MariaDBMonitor::is_candidate_better(const MariaDBServer* candidate, const MariaDBServer* current_best,
+                                         const MariaDBServer* demotion_target, uint32_t gtid_domain,
+                                         std::string* reason_out)
+{
+    const SlaveStatus* cand_slave_conn = candidate->slave_connection_status(demotion_target);
+    const SlaveStatus* curr_best_slave_conn = current_best->slave_connection_status(demotion_target);
+    mxb_assert(cand_slave_conn && curr_best_slave_conn);
+
+    uint64_t cand_io = cand_slave_conn->gtid_io_pos.get_gtid(gtid_domain).m_sequence;
+    uint64_t curr_io = curr_best_slave_conn->gtid_io_pos.get_gtid(gtid_domain).m_sequence;
+    string reason;
+    bool is_better = false;
+    // A slave with a later event in relay log is always preferred.
+    if (cand_io > curr_io)
+    {
+        is_better = true;
+        reason = "it has received more events.";
+    }
+    // If io sequences are identical ...
+    else if (cand_io == curr_io)
+    {
+        uint64_t cand_processed = candidate->m_gtid_current_pos.get_gtid(gtid_domain).m_sequence;
+        uint64_t curr_processed = current_best->m_gtid_current_pos.get_gtid(gtid_domain).m_sequence;
+        // ... the slave with more events processed wins.
+        if (cand_processed > curr_processed)
+        {
+            is_better = true;
+            reason = "it has processed more events.";
+        }
+        // If gtid positions are identical ...
+        else if (cand_processed == curr_processed)
+        {
+            bool cand_updates = candidate->m_rpl_settings.log_slave_updates;
+            bool curr_updates = current_best->m_rpl_settings.log_slave_updates;
+            // ... prefer a slave with log_slave_updates.
+            if (cand_updates && !curr_updates)
+            {
+                is_better = true;
+                reason = "it has 'log_slave_updates' on.";
+            }
+            // If both have log_slave_updates on ...
+            else if (cand_updates && curr_updates)
+            {
+                bool cand_disk_ok = !candidate->server->is_low_on_disk_space();
+                bool curr_disk_ok = !current_best->server->is_low_on_disk_space();
+                // ... prefer a slave without disk space issues.
+                if (cand_disk_ok && !curr_disk_ok)
+                {
+                    is_better = true;
+                    reason = "it is not low on disk space.";
+                }
+            }
+        }
+    }
+
+    if (reason_out && is_better)
+    {
+        *reason_out = reason;
+    }
+    return is_better;
+}
+
+/**
+ * Check cluster and parameters for suitability to failover. Also writes found servers to output pointers.
+ *
+ * @param log_mode Logging mode
+ * @param error_out Error output
+ * @return Operation object if cluster is suitable and failover may proceed, or NULL on error
+ */
+unique_ptr<MariaDBMonitor::FailoverParams>
+MariaDBMonitor::failover_prepare(FailoverType fo_type, Log log_mode, OpStart start, mxb::Json& error_out)
+{
+    // This function resembles 'switchover_prepare', but does not yet support manual selection.
+
+    // Check that the cluster has a non-functional master server and that one of the slaves of
+    // that master can be promoted. TODO: add support for demoting a relay server.
+    MariaDBServer* demotion_target = nullptr;
+    auto binlog_policy = MariaDBServer::FOBinlogPosPolicy::FAIL_UNKNOWN;
+    if ((start == OpStart::AUTO && m_settings.enforce_simple_topology)
+        || (start == OpStart::MANUAL && fo_type == FailoverType::ALLOW_TRX_LOSS))
+    {
+        binlog_policy = MariaDBServer::FOBinlogPosPolicy::ALLOW_UNKNOWN;
+    }
+
+    // Autoselect current master as demotion target.
+    string demotion_msg;
+    if (m_master == nullptr)
+    {
+        const char msg[] = "Can not select a demotion target for failover: cluster does not have a primary.";
+        PRINT_ERROR_IF(log_mode, error_out, msg);
+    }
+    // If replacing a hung master, ignore demotion checks as they do not apply.
+    else if (fo_type != FailoverType::WRITE_TEST_FAIL
+             && !m_master->can_be_demoted_failover(binlog_policy, &demotion_msg))
+    {
+        const char msg[] = "Can not select '%s' as a demotion target for failover because %s";
+        PRINT_ERROR_IF(log_mode, error_out, msg, m_master->name(), demotion_msg.c_str());
+    }
+    else
+    {
+        demotion_target = m_master;
+    }
+
+    MariaDBServer* promotion_target = nullptr;
+    int64_t gtid_domain_id = GTID_DOMAIN_UNKNOWN;
+    if (demotion_target)
+    {
+        // Autoselect best server for promotion.
+        auto op = OperationType::FAILOVER_SAFE;
+        if (fo_type == FailoverType::ALLOW_TRX_LOSS || fo_type == FailoverType::WRITE_TEST_FAIL)
+        {
+            op = OperationType::FAILOVER;
+        }
+
+        MariaDBServer* promotion_candidate = select_promotion_target(
+            demotion_target, op, log_mode, &gtid_domain_id, error_out);
+        if (promotion_candidate)
+        {
+            promotion_target = promotion_candidate;
+        }
+        else
+        {
+            PRINT_ERROR_IF(log_mode, error_out, "Could not autoselect promotion target for failover.");
+        }
+    }
+
+    bool gtid_ok = false;
+    if (demotion_target)
+    {
+        gtid_ok = check_gtid_replication(log_mode, demotion_target, gtid_domain_id, error_out);
+    }
+
+    unique_ptr<FailoverParams> rval;
+    if (promotion_target && demotion_target && gtid_ok)
+    {
+        const SlaveStatus* slave_conn = promotion_target->slave_connection_status(demotion_target);
+        mxb_assert(slave_conn);
+        uint64_t events = promotion_target->relay_log_events(*slave_conn);
+        if (events > 0)
+        {
+            // The relay log of the promotion target is not yet clear. This is not really an error,
+            // but should be communicated to the user in the case of manual failover. For automatic
+            // failover, it's best to just try again during the next monitor iteration. The difference
+            // to a typical prepare-fail is that the relay log status should be logged
+            // repeatedly since it is likely to change continuously.
+            if (start == OpStart::MANUAL || log_mode == Log::ON)
+            {
+                const char unproc_fmt[] = "The relay log of '%s' has %lu unprocessed events "
+                                          "(Gtid_IO_Pos: %s, Gtid_Current_Pos: %s).";
+                string unproc_events = string_printf(
+                    unproc_fmt, promotion_target->name(), events, slave_conn->gtid_io_pos.to_string().c_str(),
+                    promotion_target->m_gtid_current_pos.to_string().c_str());
+
+                if (start == OpStart::MANUAL)
+                {
+                    /* Print a bit more helpful error for the user, goes to log too.
+                     * This should be a very rare occurrence: either the dba managed to start failover
+                     * really fast, or the relay log is massive. In the latter case it's ok
+                     * that the monitor does not do the waiting since there  is no telling how long
+                     * the wait will be. */
+                    const char wait_relay_log[] = "%s To avoid data loss, failover should be postponed until "
+                                                  "the log has been processed. Please try again later.";
+                    string error_msg = string_printf(wait_relay_log, unproc_events.c_str());
+                    PRINT_JSON_ERROR(error_out, "%s", error_msg.c_str());
+                }
+                else if (log_mode == Log::ON)
+                {
+                    // For automatic failover the message is more typical. TODO: Think if this message should
+                    // be logged more often.
+                    MXB_WARNING("%s To avoid data loss, failover is postponed until the log "
+                                "has been processed.", unproc_events.c_str());
+                }
+            }
+        }
+        else
+        {
+            // The Duration ctor taking a double interprets the value as seconds.
+            auto time_limit = std::chrono::seconds(m_settings.failover_timeout);
+            auto target_type = (demotion_target == m_master) ? ServerOperation::TargetType::MASTER :
+                ServerOperation::TargetType::RELAY;
+            ServerOperation promotion(promotion_target, target_type,
+                                      demotion_target->m_slave_status, demotion_target->m_enabled_events);
+            GeneralOpData general(start, error_out, time_limit);
+            rval = std::make_unique<FailoverParams>(promotion, demotion_target, general);
+        }
+    }
+    return rval;
+}
+
+/**
+ * Check if failover is required and perform it if so.
+ */
+void MariaDBMonitor::handle_auto_failover()
+{
+    if (!m_master || m_master->is_running())
+    {
+        // No need for failover. This also applies if master is in maintenance, because that is a user
+        // problem.
+        m_warn_master_down = true;
+        m_warn_failover_precond = true;
+        return;
+    }
+
+    const int failcount = m_settings.failcount;
+    const int master_down_count = m_master->mon_err_count;
+
+    if (m_warn_master_down)
+    {
+        if (failcount > 1 && master_down_count < failcount)
+        {
+            // Failover is not happening yet but likely soon will.
+            int ticks_until = failcount - master_down_count;
+            MXB_WARNING("Primary has failed. If primary does not return in %i monitor tick(s), failover "
+                        "begins.", ticks_until);
+        }
+        m_warn_master_down = false;
+    }
+
+    if (master_down_count >= failcount)
+    {
+        // Master has been down long enough.
+        bool slave_verify_ok = true;
+        if (m_settings.verify_master_failure)
+        {
+            Duration event_age;
+            Duration delay_time;
+            auto connected_slave = slave_receiving_events(m_master, &event_age, &delay_time);
+            if (connected_slave)
+            {
+                slave_verify_ok = false;
+                MXB_NOTICE("Slave '%s' is still connected to '%s' and received a new gtid or heartbeat "
+                           "event %.1f seconds ago. Delaying failover for at least %.1f seconds.",
+                           connected_slave->name(), m_master->name(),
+                           mxb::to_secs(event_age), mxb::to_secs(delay_time));
+            }
+        }
+
+        if (slave_verify_ok)
+        {
+            // Failover is required, but first we should check if preconditions are met.
+            Log log_mode = m_warn_failover_precond ? Log::ON : Log::OFF;
+            mxb::Json dummy(mxb::Json::Type::UNDEFINED);
+            auto fo_type = (m_settings.auto_failover == AutoFailover::SAFE) ? FailoverType::SAFE :
+                FailoverType::ALLOW_TRX_LOSS;
+            auto op = failover_prepare(fo_type, log_mode, OpStart::AUTO, dummy);
+            if (op)
+            {
+                m_warn_failover_precond = true;
+                MXB_NOTICE("Performing automatic failover to replace failed primary '%s'.",
+                           m_master->name());
+                if (failover_perform(*op))
+                {
+                    MXB_NOTICE(FAILOVER_OK, op->demotion_target->name(), op->promotion.target->name());
+                }
+                else
+                {
+                    MXB_ERROR(FAILOVER_FAIL, op->demotion_target->name(), op->promotion.target->name());
+                    delay_auto_cluster_ops();
+                }
+            }
+            else
+            {
+                // Failover was not attempted because of errors, however these errors are not permanent.
+                // Servers were not modified, so it's ok to try this again.
+                if (m_warn_failover_precond)
+                {
+                    MXB_WARNING("Not performing automatic failover. Will keep retrying with most "
+                                "error messages suppressed.");
+                    m_warn_failover_precond = false;
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Is the topology such that failover and switchover are supported, even if not required just yet?
+ * Print errors and disable the settings if this is not the case.
+ */
+void MariaDBMonitor::check_cluster_operations_support()
+{
+    bool supported = true;
+    DelimitedPrinter printer("\n");
+    string all_reasons;
+    // Currently, only simple topologies are supported. No Relay Masters or multiple slave connections.
+    // Gtid-replication is required, and a server version which supports it.
+    for (MariaDBServer* server : m_servers)
+    {
+        // Check capabilities of running servers.
+        if (server->is_usable())
+        {
+            auto& info = server->server->info();
+            auto type = info.type();
+            if ((type != ServerType::MARIADB && type != ServerType::MYSQL && type != ServerType::BLR) || !server->m_capabilities.gtid)
+            {
+                supported = false;
+                auto reason = string_printf("The version of '%s' (%s) is not supported. Failover/switchover "
+                                            "requires MariaDB Server 10.4 or later, or MySQL 8.0.22+ with GTID.",
+                                            server->name(), info.version_string());
+                printer.cat(all_reasons, reason);
+            }
+
+            for (const auto& slave_conn : server->m_slave_status)
+            {
+                if (slave_conn.slave_io_running == SlaveStatus::SLAVE_IO_YES
+                    && slave_conn.slave_sql_running && slave_conn.gtid_io_pos.empty())
+                {
+                    supported = false;
+                    auto reason = string_printf("%s is not using gtid-replication.",
+                                                slave_conn.settings.to_string().c_str());
+                    printer.cat(all_reasons, reason);
+                }
+            }
+        }
+    }
+
+    if (!supported)
+    {
+        const char PROBLEMS[] =
+            "The backend cluster does not support failover/switchover due to the following reason(s):\n"
+            "%s\n";
+        string msg = string_printf(PROBLEMS, all_reasons.c_str());
+        MXB_ERROR("%s", msg.c_str());
+        delay_auto_cluster_ops();
+    }
+}
+
+/**
+ * Check if a slave is receiving events from master. Returns the first slave that is both
+ * connected (or not realized the disconnect yet) and has an event more recent than
+ * master_failure_timeout. The age of the event is written in 'event_age_out'.
+ *
+ * @param demotion_target The server whose slaves should be checked
+ * @param event_age_out Output for event age
+ * @return The first connected slave or NULL if none found
+ */
+const MariaDBServer*
+MariaDBMonitor::slave_receiving_events(const MariaDBServer* demotion_target, Duration* event_age_out,
+                                       Duration* delay_out) const
+{
+    auto event_timeout(std::chrono::seconds(m_settings.master_failure_timeout));
+    auto current_time = maxbase::Clock::now();
+    maxbase::TimePoint recent_event_time = current_time - event_timeout;
+
+    const MariaDBServer* connected_slave = nullptr;
+    for (MariaDBServer* slave : demotion_target->m_node.children)
+    {
+        const SlaveStatus* slave_conn = nullptr;
+        if (slave->is_running()
+            && (slave_conn = slave->slave_connection_status(demotion_target)) != nullptr
+            && slave_conn->slave_io_running == SlaveStatus::SLAVE_IO_YES
+            && slave_conn->last_data_time >= recent_event_time)
+        {
+            // The slave is still connected to the correct master and has received events. This means that
+            // while MaxScale can't connect to the master, it's probably still alive.
+            connected_slave = slave;
+            auto latest_event_age = current_time - slave_conn->last_data_time;
+            *event_age_out = latest_event_age;
+            *delay_out = event_timeout - latest_event_age;
+            break;
+        }
+    }
+    return connected_slave;
+}
+
+/**
+ * Check cluster and parameters for suitability to switchover. Also writes found servers to output pointers.
+ *
+ * @param promotion_server The server which should be promoted. If null, monitor will autoselect.
+ * @param demotion_server The server which should be demoted. Can be null for autoselect.
+ * @param log_mode Logging mode
+ * @param error_out Error output
+ * @return Operation object if cluster is suitable and switchover may proceed, or NULL on error
+ */
+unique_ptr<MariaDBMonitor::SwitchoverParams>
+MariaDBMonitor::switchover_prepare(SwitchoverType type, AfterDemotion after_demotion,
+                                   SERVER* promotion_server, SERVER* demotion_server,
+                                   Log log_mode, OpStart start, mxb::Json& error_out)
+{
+    // Check that both servers are ok if specified, or autoselect them. Demotion target must be checked
+    // first since the promotion target depends on it.
+    MariaDBServer* demotion_target = nullptr;
+    string demotion_msg;
+    if (demotion_server)
+    {
+        // Manual select.
+        MariaDBServer* demotion_candidate = get_server(demotion_server);
+        if (demotion_candidate == nullptr)
+        {
+            PRINT_ERROR_IF(log_mode, error_out, NO_SERVER, demotion_server->name(), name());
+        }
+        else if (!demotion_candidate->can_be_demoted_switchover(type, &demotion_msg))
+        {
+            PRINT_ERROR_IF(log_mode, error_out,
+                           "'%s' is not a valid demotion target for switchover: %s",
+                           demotion_candidate->name(), demotion_msg.c_str());
+        }
+        else
+        {
+            demotion_target = demotion_candidate;
+        }
+    }
+    else
+    {
+        // Autoselect current master as demotion target.
+        mxb_assert(type != SwitchoverType::AUTO);
+        if (m_master == nullptr || (type == SwitchoverType::NORMAL && !m_master->is_master()))
+        {
+            const char msg[] = "Can not autoselect a demotion target for switchover: cluster does "
+                               "not have a primary.";
+            PRINT_ERROR_IF(log_mode, error_out, msg);
+        }
+        else if (!m_master->can_be_demoted_switchover(type, &demotion_msg))
+        {
+            const char msg[] = "Can not autoselect '%s' as a demotion target for switchover because %s";
+            PRINT_ERROR_IF(log_mode, error_out, msg, m_master->name(), demotion_msg.c_str());
+        }
+        else
+        {
+            demotion_target = m_master;
+        }
+    }
+
+    const auto op_type = (type == SwitchoverType::NORMAL || type == SwitchoverType::AUTO) ?
+        OperationType::SWITCHOVER : OperationType::SWITCHOVER_FORCE;
+    MariaDBServer* promotion_target = nullptr;
+    if (demotion_target)
+    {
+        string promotion_msg;
+        if (promotion_server)
+        {
+            // Manual select.
+            MariaDBServer* promotion_candidate = get_server(promotion_server);
+            if (promotion_candidate == nullptr)
+            {
+                PRINT_ERROR_IF(log_mode, error_out, NO_SERVER, promotion_server->name(), name());
+            }
+            else if (!promotion_candidate->can_be_promoted(op_type, demotion_target, &promotion_msg))
+            {
+                const char msg[] = "'%s' is not a valid promotion target for switchover because %s";
+                PRINT_ERROR_IF(log_mode, error_out, msg, promotion_candidate->name(), promotion_msg.c_str());
+            }
+            else
+            {
+                promotion_target = promotion_candidate;
+            }
+        }
+        else
+        {
+            // Autoselect. More involved than the autoselecting the demotion target.
+            MariaDBServer* promotion_candidate = select_promotion_target(demotion_target, op_type,
+                                                                         log_mode, nullptr, error_out);
+            if (promotion_candidate)
+            {
+                promotion_target = promotion_candidate;
+            }
+            else
+            {
+                PRINT_ERROR_IF(log_mode, error_out, "Could not autoselect promotion target for switchover.");
+            }
+        }
+    }
+
+    bool gtid_ok = false;
+    if (demotion_target)
+    {
+        gtid_ok = check_gtid_replication(log_mode, demotion_target, m_master_gtid_domain, error_out);
+    }
+
+    unique_ptr<SwitchoverParams> rval;
+    if (promotion_target && demotion_target && gtid_ok)
+    {
+        maxbase::Duration time_limit(std::chrono::seconds(m_settings.shared.switchover_timeout));
+        auto target_type = (demotion_target == m_master) ? ServerOperation::TargetType::MASTER :
+            ServerOperation::TargetType::RELAY;
+        ServerOperation promotion(promotion_target, target_type,
+                                  demotion_target->m_slave_status, demotion_target->m_enabled_events);
+        ServerOperation demotion(demotion_target, target_type, promotion_target->m_slave_status,
+                                 EventNameSet());
+        GeneralOpData general(start, error_out, time_limit);
+        rval = std::make_unique<SwitchoverParams>(promotion, demotion, general, type, after_demotion);
+    }
+    return rval;
+}
+
+void MariaDBMonitor::enforce_read_only()
+{
+    if (!m_master || (!m_settings.enforce_read_only_slaves && !m_settings.enforce_read_only_servers))
+    {
+        // If primary is not known, do nothing. Don't want to set read_only on a server that may be selected
+        // primary next tick.
+        return;
+    }
+
+    const char QUERY[] = "SET GLOBAL super_read_only=1;";
+    bool error = false;
+    for (MariaDBServer* server : m_servers)
+    {
+        if (server != m_master && !server->is_read_only() && (server->server_type() == ServerType::MYSQL))
+        {
+            bool is_slave = server->is_slave();
+            if (is_slave || (m_settings.enforce_read_only_servers && server->is_usable()))
+            {
+                MYSQL* conn = server->con;
+                if (mxs_mysql_query(conn, QUERY) == 0)
+                {
+                    const char* type = is_slave ? "replica" : "server";
+                    MXB_NOTICE("read_only set to ON on %s %s.", type, server->name());
+                }
+                else
+                {
+                    MXB_ERROR("Setting read_only on server %s failed. Error %i: '%s'.",
+                              server->name(), mysql_errno(conn), mysql_error(conn));
+                    error = true;
+                }
+            }
+        }
+    }
+
+    if (error)
+    {
+        delay_auto_cluster_ops();
+    }
+}
+
+
+void MariaDBMonitor::enforce_writable_on_master()
+{
+    bool error = false;
+    if (m_master && m_master->is_read_only() && !m_master->is_in_maintenance())
+    {
+        auto type = m_master->server_type();
+        if (type == ServerType::MARIADB || type == ServerType::MYSQL)
+        {
+            const char QUERY[] = "SET GLOBAL read_only=0;";
+            MYSQL* conn = m_master->con;
+            if (mxs_mysql_query(conn, QUERY) == 0)
+            {
+                MXB_NOTICE("read_only set to OFF on '%s'.", m_master->name());
+            }
+            else
+            {
+                MXB_ERROR("Disabling read_only on '%s' failed: '%s'.", m_master->name(), mysql_error(conn));
+                error = true;
+            }
+        }
+    }
+
+    if (error)
+    {
+        delay_auto_cluster_ops();
+    }
+}
+
+void MariaDBMonitor::handle_low_disk_space_master()
+{
+    // If master is really out of disk space, it has lost [Master] (if using default settings).
+    // This needs to be taken into account in the following checks.
+    if (m_master && m_master->is_low_on_disk_space())
+    {
+        if (m_warn_switchover_precond)
+        {
+            MXB_WARNING("Primary server '%s' is low on disk space. Attempting to switch it with a slave.",
+                        m_master->name());
+        }
+
+        // Looks like the master should be swapped out. Before trying it, check if there is even
+        // a likely valid slave to swap to.
+        Log log_mode = m_warn_switchover_precond ? Log::ON : Log::OFF;
+        mxb::Json dummy(mxb::Json::Type::UNDEFINED);
+        auto op = switchover_prepare(SwitchoverType::AUTO, AfterDemotion::REDIRECT, nullptr,
+                                     m_master->server, log_mode, OpStart::AUTO, dummy);
+        if (op)
+        {
+            m_warn_switchover_precond = true;
+            bool switched = switchover_perform(*op);
+            if (switched)
+            {
+                MXB_NOTICE(SWITCHOVER_OK, op->demotion.target->name(), op->promotion.target->name());
+            }
+            else
+            {
+                MXB_ERROR(SWITCHOVER_FAIL, op->demotion.target->name(), op->promotion.target->name());
+                delay_auto_cluster_ops();
+            }
+        }
+        else
+        {
+            // Switchover was not attempted because of errors, however these errors are not permanent.
+            // Servers were not modified, so it's ok to try this again.
+            if (m_warn_switchover_precond)
+            {
+                MXB_WARNING("Not performing automatic switchover. Will keep retrying with this message "
+                            "suppressed.");
+                m_warn_switchover_precond = false;
+            }
+        }
+    }
+    else
+    {
+        m_warn_switchover_precond = true;
+    }
+}
+
+void MariaDBMonitor::handle_auto_rejoin()
+{
+    mxb::Json dummy(mxb::Json::Type::UNDEFINED);
+    // Rejoin doesn't have its own time limit setting. Use switchover time limit for now since
+    // the first phase of standalone rejoin is similar to switchover.
+    maxbase::Duration time_limit(m_settings.shared.switchover_timeout);
+    GeneralOpData op(OpStart::AUTO, dummy, time_limit);
+
+    ServerArray joinable_servers;
+    if (get_joinable_servers(op, &joinable_servers))
+    {
+        uint32_t joins = do_rejoin(op, joinable_servers);
+        if (joins > 0)
+        {
+            MXB_NOTICE("%d server(s) redirected or rejoined the cluster.", joins);
+        }
+    }
+    // get_joinable_servers prints an error if master is unresponsive
+}
+
+void MariaDBMonitor::handle_master_write_test()
+{
+    using WriteTestTblStatus = MariaDBServer::WriteTestTblStatus;
+    if (m_master && m_master->is_master())
+    {
+        const string& target_tbl = m_settings.master_write_test_table;
+        if (m_write_test_tbl_status == WriteTestTblStatus::UNKNOWN)
+        {
+            m_write_test_tbl_status = m_master->check_write_test_table(target_tbl);
+        }
+
+        if (m_write_test_tbl_status == WriteTestTblStatus::CREATED)
+        {
+            auto now = m_worker->epoll_tick_now();
+            auto no_change_dur = now - m_last_master_gtid_change;
+            if (no_change_dur > m_settings.master_write_test_interval)
+            {
+                MXB_INFO("gtid_binlog_pos of primary %s has not changed in %.0f seconds. "
+                         "Performing write test to table '%s'.",
+                         m_master->name(), mxb::to_secs(no_change_dur), target_tbl.c_str());
+                if (m_master->test_writability(target_tbl))
+                {
+                    m_write_test_fails = 0;
+                    m_warn_write_test_fail = true;
+                    m_last_master_gtid_change = now;
+
+                    if (m_random_gen.zero_to_one_co() > 0.9)
+                    {
+                        m_master->truncate_write_test_table(target_tbl);
+                    }
+                }
+                else
+                {
+                    m_write_test_fails++;
+                    if (m_settings.write_test_fail_action == WriteTestFailAction::FAILOVER)
+                    {
+                        if (m_write_test_fails >= m_settings.failcount)
+                        {
+                            Log log_mode = m_warn_write_fail_fo_precond ? Log::ON : Log::OFF;
+                            mxb::Json dummy(mxb::Json::Type::UNDEFINED);
+                            auto op = failover_prepare(FailoverType::WRITE_TEST_FAIL, log_mode, OpStart::AUTO,
+                                                       dummy);
+                            if (op)
+                            {
+                                m_warn_write_fail_fo_precond = true;
+                                MXB_NOTICE("Performing automatic failover to replace write-blocked primary "
+                                           "%s.", m_master->name());
+                                if (failover_perform(*op))
+                                {
+                                    MXB_NOTICE(FAILOVER_OK, op->demotion_target->name(),
+                                               op->promotion.target->name());
+                                    auto* demo_target = op->demotion_target->server;
+                                    MXB_WARNING("Setting %s to maintenance. The maintenance status can be "
+                                                "cleared manually with MaxCtrl or REST-API once the "
+                                                "situation has been resolved.",
+                                                demo_target->name());
+                                    demo_target->set_status(SERVER_MAINT);
+                                }
+                                else
+                                {
+                                    MXB_ERROR(FAILOVER_FAIL, op->demotion_target->name(),
+                                              op->promotion.target->name());
+                                    delay_auto_cluster_ops();
+                                }
+                            }
+                            else
+                            {
+                                // Failover was not attempted because of errors, however these errors
+                                // may get resolved. Servers were not modified, so it's ok to try this again.
+                                if (m_warn_write_fail_fo_precond)
+                                {
+                                    MXB_WARNING("Not performing failover. Will keep retrying with "
+                                                "most error messages suppressed.");
+                                    m_warn_write_fail_fo_precond = false;
+                                }
+                            }
+                        }
+                        else if (m_warn_write_test_fail)
+                        {
+                            MXB_WARNING("%s failed write test. If situation persists for %li monitor "
+                                        "interval(s), failover begins.",
+                                        m_master->name(), m_settings.failcount - m_write_test_fails);
+                            m_warn_write_test_fail = false;
+                        }
+                    }
+                    else
+                    {
+                        MXB_ERROR("Primary server %s failed write test. MariaDB Server storage engine may "
+                                  "be locked or filesystem cannot be written to.", m_master->name());
+                        m_last_master_gtid_change = now;    // Prevents printing the message every tick.
+                    }
+                }
+            }
+            else
+            {
+                m_write_test_fails = 0;
+                m_warn_write_test_fail = true;
+                m_warn_write_fail_fo_precond = true;
+            }
+        }
+    }
+}
+
+/**
+ * Check that the slaves to demotion target are using gtid replication and that the gtid domain of the
+ * cluster is defined. Only the slave connections to the demotion target are checked.
+ *
+ * @param log_mode Logging mode
+ * @param demotion_target The server whose slaves should be checked
+ * @param cluster_gtid_domain Cluster gtid domain
+ * @param error_out Error output
+ * @return True if gtid is used
+ */
+bool MariaDBMonitor::check_gtid_replication(Log log_mode, const MariaDBServer* demotion_target,
+                                            int64_t cluster_gtid_domain, mxb::Json& error_out)
+{
+    bool gtid_domain_ok = false;
+    if (cluster_gtid_domain == GTID_DOMAIN_UNKNOWN)
+    {
+        PRINT_ERROR_IF(log_mode, error_out,
+                       "Cluster gtid domain is unknown. This is usually caused by the cluster never "
+                       "having a primary server while MaxScale was running.");
+    }
+    else
+    {
+        gtid_domain_ok = true;
+    }
+
+    // Check that all slaves are using gtid-replication.
+    bool gtid_ok = true;
+    for (MariaDBServer* server : demotion_target->m_node.children)
+    {
+        auto sstatus = server->slave_connection_status(demotion_target);
+        if (sstatus && sstatus->gtid_io_pos.empty())
+        {
+            PRINT_ERROR_IF(log_mode, error_out,
+                           "The slave connection '%s' -> '%s' is not using gtid replication.",
+                           server->name(), demotion_target->name());
+            gtid_ok = false;
+        }
+    }
+
+    return gtid_domain_ok && gtid_ok;
+}
+
+bool MariaDBMonitor::lock_status_is_ok() const
+{
+    return !(server_locks_in_use() && !is_cluster_owner());
+}
+
+/**
+ * List slaves which should be redirected to the new master.
+ *
+ * @param old_master The server whose slaves are listed
+ * @param ignored_slave A slave which should not be listed even if otherwise valid
+ * @return A list of slaves to redirect
+ */
+ServerArray MariaDBMonitor::get_redirectables(const MariaDBServer* old_master,
+                                              const MariaDBServer* ignored_slave)
+{
+    ServerArray redirectable_slaves;
+    for (MariaDBServer* slave : old_master->m_node.children)
+    {
+        if (slave->is_usable() && slave != ignored_slave)
+        {
+            auto sstatus = slave->slave_connection_status(old_master);
+            if (sstatus && !sstatus->gtid_io_pos.empty())
+            {
+                redirectable_slaves.push_back(slave);
+            }
+        }
+    }
+    return redirectable_slaves;
+}
+
+void MariaDBMonitor::delay_auto_cluster_ops(Log log)
+{
+    if (log == Log::ON && cluster_ops_configured())
+    {
+        const char DISABLING_AUTO_OPS[] = "Disabling automatic cluster operations for %li monitor ticks.";
+        MXB_NOTICE(DISABLING_AUTO_OPS, m_settings.failcount);
+    }
+    // + 1 because the start of next tick subtracts 1.
+    cluster_operation_disable_timer = m_settings.failcount + 1;
+}
+
+bool MariaDBMonitor::can_perform_cluster_ops()
+{
+    return !mxs::Config::get().passive.get() && cluster_operation_disable_timer <= 0
+           && !m_cluster_modified && lock_status_is_ok();
+}
+
+/**
+ * Guess the best gtid id by looking at promotion candidates.
+ *
+ * @param demotion_target Server being demoted
+ * @param candidates List of candidates
+ * @param id_missing_out If the selected domain id is not on all slaves, the number of missing slaves is
+ * written here.
+ * @return The guessed id. -1 if no candidates.
+ */
+int64_t MariaDBMonitor::guess_gtid_domain(MariaDBServer* demotion_target, const ServerArray& candidates,
+                                          int* id_missing_out) const
+{
+    // Because gtid:s can be complicated, this guess is not an exact science. In most cases, however, the
+    // correct answer is obvious. As a general rule, select the domain id which is in most candidates.
+    using IdToCount = std::map<int64_t, int>;
+    IdToCount id_to_count;      // How many of each domain id was found.
+    for (const auto& cand : candidates)
+    {
+        auto& gtid_io_pos = cand->slave_connection_status(demotion_target)->gtid_io_pos;    // Must exist.
+        GtidList::DomainList domains = gtid_io_pos.domains();
+        for (auto domain : domains)
+        {
+            if (id_to_count.count(domain) == 0)
+            {
+                id_to_count[domain] = 1;
+            }
+            else
+            {
+                id_to_count[domain]++;
+            }
+        }
+    }
+
+    int64_t best_domain = GTID_DOMAIN_UNKNOWN;
+    int best_count = 0;
+    for (auto elem : id_to_count)
+    {
+        // In a tie, prefer the smaller domain id.
+        if (elem.second > best_count || (elem.second == best_count && elem.first < best_domain))
+        {
+            best_domain = elem.first;
+            best_count = elem.second;
+        }
+    }
+
+    if (best_domain != GTID_DOMAIN_UNKNOWN && best_count < (int)candidates.size())
+    {
+        *id_missing_out = candidates.size() - best_count;
+    }
+    return best_domain;
+}
+
+MariaDBMonitor::SwitchoverParams::SwitchoverParams(ServerOperation promotion, ServerOperation demotion,
+                                                   const GeneralOpData& general, SwitchoverType type,
+                                                   AfterDemotion after_demotion)
+    : promotion(move(promotion))
+    , demotion(move(demotion))
+    , general(general)
+    , type(type)
+    , after_demotion(after_demotion)
+{
+}
+
+MariaDBMonitor::FailoverParams::FailoverParams(ServerOperation promotion,
+                                               const MariaDBServer* demotion_target,
+                                               const GeneralOpData& general)
+    : promotion(move(promotion))
+    , demotion_target(demotion_target)
+    , general(general)
+{
+}

--- a/server/modules/monitor/mysqlrepmon/mariadbmon.cc
+++ b/server/modules/monitor/mysqlrepmon/mariadbmon.cc
@@ -1,0 +1,1464 @@
+/*
+ * Copyright (c) 2016 MariaDB Corporation Ab
+ * Copyright (c) 2023 MariaDB plc, Finnish Branch
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file and at www.mariadb.com/bsl11.
+ *
+ * Change Date: 2027-09-09
+ *
+ * On the date above, in accordance with the Business Source License, use
+ * of this software will be governed by version 2 or later of the General
+ * Public License.
+ */
+
+/**
+ * @file A MariaDB replication cluster monitor
+ */
+#include "mariadbmon.hh"
+
+#include <future>
+#include <cinttypes>
+#include <mysql.h>
+#include <maxbase/assert.hh>
+#include <maxbase/format.hh>
+#include <maxscale/mainworker.hh>
+#include <maxscale/modulecmd.hh>
+#include <maxscale/secrets.hh>
+#include <maxscale/utils.hh>
+
+using std::string;
+using maxbase::string_printf;
+using maxscale::Monitor;
+using maxscale::MonitorServer;
+
+// Config parameter names
+const char* const CN_AUTO_FAILOVER = "auto_failover";
+const char* const CN_SWITCHOVER_ON_LOW_DISK_SPACE = "switchover_on_low_disk_space";
+const char* const CN_MAINTENANCE_ON_LOW_DISK_SPACE = "maintenance_on_low_disk_space";
+const char* const CN_PROMOTION_SQL_FILE = "promotion_sql_file";
+const char* const CN_DEMOTION_SQL_FILE = "demotion_sql_file";
+const char* const CN_HANDLE_EVENTS = "handle_events";
+
+static const char CN_AUTO_REJOIN[] = "auto_rejoin";
+static const char CN_FAILCOUNT[] = "failcount";
+static const char CN_ENFORCE_READONLY[] = "enforce_read_only_slaves";
+static const char CN_ENFORCE_READONLY_SRVRS[] = "enforce_read_only_servers";
+static const char CN_NO_PROMOTE_SERVERS[] = "servers_no_promotion";
+static const char CN_FAILOVER_TIMEOUT[] = "failover_timeout";
+static const char CN_SWITCHOVER_TIMEOUT[] = "switchover_timeout";
+static const char CN_ASSUME_UNIQUE_HOSTNAMES[] = "assume_unique_hostnames";
+
+
+// Parameters for master failure verification and timeout
+static const char CN_VERIFY_MASTER_FAILURE[] = "verify_master_failure";
+static const char CN_MASTER_FAILURE_TIMEOUT[] = "master_failure_timeout";
+// Replication credentials parameters for failover/switchover/join
+static const char CN_REPLICATION_USER[] = "replication_user";
+static const char CN_REPLICATION_PASSWORD[] = "replication_password";
+static const char CN_REPLICATION_MASTER_SSL[] = "replication_master_ssl";
+
+namespace
+{
+const char ENFORCE_WRITABLE_MASTER[] = "enforce_writable_master";
+const char CLUSTER_OP_REQUIRE_LOCKS[] = "cooperative_monitoring_locks";
+const char MASTER_CONDITIONS[] = "master_conditions";
+const char SLAVE_CONDITIONS[] = "slave_conditions";
+const char SCRIPT_MAX_RLAG[] = "script_max_replication_lag";
+
+using namespace std::chrono_literals;
+namespace cfg = mxs::config;
+
+class Spec : public cfg::Specification
+{
+public:
+    using cfg::Specification::Specification;
+
+protected:
+    template<class Params>
+    bool do_post_validate(Params& params) const;
+
+    bool post_validate(const cfg::Configuration* config,
+                       const mxs::ConfigParameters& params,
+                       const std::map<std::string, mxs::ConfigParameters>& nested_params) const override
+    {
+        return do_post_validate(params);
+    }
+
+    bool post_validate(const cfg::Configuration* config,
+                       json_t* json,
+                       const std::map<std::string, json_t*>& nested_params) const override
+    {
+        return do_post_validate(json);
+    }
+};
+
+cfg::Specification s_spec(MXB_MODULE_NAME, cfg::Specification::MONITOR);
+
+cfg::ParamCount s_failcount(
+    &s_spec, CN_FAILCOUNT,
+    "Number of failures to tolerate before failover occurs",
+    5, cfg::Param::AT_RUNTIME);
+
+cfg::ParamEnum<MariaDBMonitor::AutoFailover> s_auto_failover(
+    &s_spec, CN_AUTO_FAILOVER,
+    "Enable automatic primary server failover",
+    {
+        GEN_BOOL_ENUMERATION(MariaDBMonitor::AutoFailover::NONE, MariaDBMonitor::AutoFailover::ALLOW_TRX_LOSS)
+        {MariaDBMonitor::AutoFailover::SAFE, "safe"},
+    }, MariaDBMonitor::AutoFailover::NONE, cfg::Param::AT_RUNTIME);
+
+cfg::ParamSeconds s_failover_timeout(
+    &s_spec, CN_FAILOVER_TIMEOUT,
+    "Timeout for failover",
+    90s, cfg::Param::AT_RUNTIME);
+
+cfg::ParamSeconds s_switchover_timeout(
+    &s_spec, CN_SWITCHOVER_TIMEOUT,
+    "Timeout for switchover",
+    90s, cfg::Param::AT_RUNTIME);
+
+cfg::ParamString s_replication_user(
+    &s_spec, CN_REPLICATION_USER,
+    "User used for replication",
+    "", cfg::Param::AT_RUNTIME);
+
+cfg::ParamPassword s_replication_password(
+    &s_spec, CN_REPLICATION_PASSWORD,
+    "Password for the user that is used for replication",
+    "", cfg::Param::AT_RUNTIME);
+
+cfg::ParamBool s_replication_master_ssl(
+    &s_spec, CN_REPLICATION_MASTER_SSL,
+    "Enable SSL when configuring replication",
+    false, cfg::Param::AT_RUNTIME);
+
+cfg::ParamReplOpts s_replication_custom_opts(
+    &s_spec, "replication_custom_options",
+    "Custom CHANGE MASTER TO options", cfg::Param::AT_RUNTIME);
+
+cfg::ParamBool s_verify_master_failure(
+    &s_spec, CN_VERIFY_MASTER_FAILURE,
+    "Verify master failure",
+    true, cfg::Param::AT_RUNTIME);
+
+cfg::ParamSeconds s_master_failure_timeout(
+    &s_spec, CN_MASTER_FAILURE_TIMEOUT,
+    "Master failure timeout",
+    10s, cfg::Param::AT_RUNTIME);
+
+cfg::ParamBool s_auto_rejoin(
+    &s_spec, CN_AUTO_REJOIN,
+    "Enable automatic server rejoin",
+    false, cfg::Param::AT_RUNTIME);
+
+cfg::ParamBool s_enforce_read_only_slaves(
+    &s_spec, CN_ENFORCE_READONLY,
+    "Enable read_only on all slave servers",
+    false, cfg::Param::AT_RUNTIME);
+
+cfg::ParamBool s_enforce_read_only_servers(
+    &s_spec, CN_ENFORCE_READONLY_SRVRS,
+    "Enable read_only on all non-primary servers",
+    false, cfg::Param::AT_RUNTIME);
+
+cfg::ParamBool s_enforce_writable_master(
+    &s_spec, ENFORCE_WRITABLE_MASTER,
+    "Disable read_only on the current master server",
+    false, cfg::Param::AT_RUNTIME);
+
+cfg::ParamServerList s_server_no_promotion(
+    &s_spec, CN_NO_PROMOTE_SERVERS,
+    "List of servers that are never promoted",
+    cfg::Param::OPTIONAL, cfg::Param::AT_RUNTIME);
+
+cfg::ParamPath s_promotion_sql_file(
+    &s_spec, CN_PROMOTION_SQL_FILE,
+    "Path to SQL file that is executed during node promotion",
+    cfg::ParamPath::R, "", cfg::Param::AT_RUNTIME);
+
+cfg::ParamPath s_demotion_sql_file(
+    &s_spec, CN_DEMOTION_SQL_FILE,
+    "Path to SQL file that is executed during node demotion",
+    cfg::ParamPath::R, "", cfg::Param::AT_RUNTIME);
+
+cfg::ParamBool s_switchover_on_low_disk_space(
+    &s_spec, CN_SWITCHOVER_ON_LOW_DISK_SPACE,
+    "Perform a switchover when a server runs out of disk space",
+    false, cfg::Param::AT_RUNTIME);
+
+cfg::ParamBool s_maintenance_on_low_disk_space(
+    &s_spec, CN_MAINTENANCE_ON_LOW_DISK_SPACE,
+    "Put the server into maintenance mode when it runs out of disk space",
+    true, cfg::Param::AT_RUNTIME);
+
+cfg::ParamBool s_handle_events(
+    &s_spec, CN_HANDLE_EVENTS,
+    "Manage server-side events",
+    true, cfg::Param::AT_RUNTIME);
+
+cfg::ParamBool s_assume_unique_hostnames(
+    &s_spec, CN_ASSUME_UNIQUE_HOSTNAMES,
+    "Assume that hostnames are unique",
+    true, cfg::Param::AT_RUNTIME);
+
+cfg::ParamBool s_enforce_simple_topology(
+    &s_spec, CN_ENFORCE_SIMPLE_TOPOLOGY,
+    "Enforce a simple topology",
+    false, cfg::Param::AT_RUNTIME);
+
+cfg::ParamEnum<MariaDBMonitor::RequireLocks> s_cooperative_monitoring_locks(
+    &s_spec, CLUSTER_OP_REQUIRE_LOCKS,
+    "Cooperative monitoring type",
+    {
+        {MariaDBMonitor::LOCKS_NONE, "none"},
+        {MariaDBMonitor::LOCKS_MAJORITY_RUNNING, "majority_of_running"},
+        {MariaDBMonitor::LOCKS_MAJORITY_ALL, "majority_of_all"},
+    }, MariaDBMonitor::LOCKS_NONE, cfg::Param::AT_RUNTIME);
+
+cfg::ParamEnumMask<uint32_t> s_master_conditions(
+    &s_spec, MASTER_CONDITIONS,
+    "Conditions that the master servers must meet",
+    {
+        {MasterConds::MCOND_NONE, "none"},
+        {MasterConds::MCOND_CONNECTING_S, "connecting_slave"},
+        {MasterConds::MCOND_CONNECTED_S, "connected_slave"},
+        {MasterConds::MCOND_RUNNING_S, "running_slave"},
+        {MasterConds::MCOND_COOP_M, "primary_monitor_master"},
+        {MasterConds::MCOND_DISK_OK, "disk_space_ok"}
+    },
+    MasterConds::MCOND_COOP_M | MasterConds::MCOND_DISK_OK, cfg::Param::AT_RUNTIME);
+
+cfg::ParamEnumMask<uint32_t> s_slave_conditions(
+    &s_spec, SLAVE_CONDITIONS,
+    "Conditions that the slave servers must meet",
+    {
+        {SlaveConds::SCOND_NONE, "none"},
+        {SlaveConds::SCOND_LINKED_M, "linked_master"},
+        {SlaveConds::SCOND_RUNNING_M, "running_master"},
+        {SlaveConds::SCOND_WRITABLE_M, "writable_master"},
+        {SlaveConds::SCOND_COOP_M, "primary_monitor_master"},
+        {SlaveConds::SCOND_DISK_OK, "disk_space_ok"}
+    },
+    SlaveConds::SCOND_NONE, cfg::Param::AT_RUNTIME);
+
+cfg::ParamInteger s_script_max_rlag(
+    &s_spec, SCRIPT_MAX_RLAG,
+    "Replication lag limit at which the script is run",
+    -1, cfg::Param::AT_RUNTIME);
+
+cfg::ParamCount s_cs_admin_port(
+    &s_spec, "cs_admin_port", "Port of the ColumnStore administrative daemon.", 8640);
+
+const char CS_ADMIN_BASE_PATH_DESC[] =
+    "The base path to be used when accessing the ColumnStore administrative daemon. "
+    "If, for instance, a daemon URL is https://localhost:8640/cmapi/0.4.0/node/start "
+    "then the admin_base_path is \"/cmapi/0.4.0\".";
+cfg::ParamString s_cs_admin_base_path(&s_spec, "cs_admin_base_path", CS_ADMIN_BASE_PATH_DESC, "/cmapi/0.4.0");
+
+cfg::ParamString s_cs_admin_api_key(&s_spec, "cs_admin_api_key", "The API key used in communication with the "
+                                                                 "ColumnStore admin daemon.", "");
+
+cfg::ParamString s_ssh_user(&s_spec, CONFIG_SSH_USER,
+                            "SSH username. Used for running remote commands on servers.", "");
+cfg::ParamPath s_ssh_keyfile(&s_spec, CONFIG_SSH_KEYFILE,
+                             "SSH keyfile. Used for running remote commands on servers.",
+                             cfg::ParamPath::R | cfg::ParamPath::F, "");
+cfg::ParamBool s_ssh_check_host_key(&s_spec, "ssh_check_host_key", "Is SSH host key check enabled.", true,
+                                    cfg::Param::AT_RUNTIME);
+cfg::ParamSeconds s_ssh_timeout(&s_spec, "ssh_timeout", "SSH connection and command timeout", 10s,
+                                cfg::Param::AT_RUNTIME);
+cfg::ParamCount s_ssh_port(&s_spec, "ssh_port", "SSH port. Used for running remote commands on servers.",
+                           22, 0, 65535, cfg::Param::AT_RUNTIME);
+cfg::ParamCount s_rebuild_port(&s_spec, "rebuild_port", "Listen port used for transferring server backup.",
+                               4444, 0, 65535, cfg::Param::AT_RUNTIME);
+cfg::ParamString s_mbu_use_memory(&s_spec, "mariabackup_use_memory", "Mariabackup buffer pool size.",
+                                  "1G", cfg::Param::AT_RUNTIME);
+cfg::ParamInteger s_mbu_parallel(&s_spec, "mariabackup_parallel", "Mariabackup thread count.",
+                                 1, 1, 1000, cfg::Param::AT_RUNTIME);
+cfg::ParamString s_backup_storage_addr(&s_spec, CONFIG_BACKUP_ADDR, "Address of backup storage.", "",
+                                       cfg::Param::AT_RUNTIME);
+cfg::ParamString s_backup_storage_path(&s_spec, CONFIG_BACKUP_PATH, "Backup storage directory path.", "",
+                                       cfg::Param::AT_RUNTIME);
+cfg::ParamSeconds s_write_test_interval(&s_spec, "write_test_interval", "Primary server write test interval.",
+                                        0s, cfg::Param::AT_RUNTIME);
+cfg::ParamString s_write_test_table(&s_spec, "write_test_table", "Primary server write test table.",
+                                    "mxs.maxscale_write_test", cfg::Param::AT_RUNTIME);
+cfg::ParamEnum<MariaDBMonitor::WriteTestFailAction> s_write_test_action(
+    &s_spec, "write_test_fail_action", "Action to take on write test failure.",
+    {{MariaDBMonitor::WriteTestFailAction::LOG, "log"},
+     {MariaDBMonitor::WriteTestFailAction::FAILOVER, "failover"}},
+    MariaDBMonitor::WriteTestFailAction::LOG, cfg::Param::AT_RUNTIME);
+
+template<class Params>
+bool Spec::do_post_validate(Params& params) const
+{
+    bool ok = true;
+    auto repl_user = s_replication_user.get(params);
+    auto repl_pw = s_replication_password.get(params);
+
+    if (repl_user.empty() != repl_pw.empty())
+    {
+        MXB_ERROR("Both '%s' and '%s' must be defined.",
+                  s_replication_user.name().c_str(), s_replication_password.name().c_str());
+        ok = false;
+    }
+
+    if (!s_assume_unique_hostnames.get(params))
+    {
+        const char PARAM_REQUIRES[] = "'%s' requires that '%s' is enabled.";
+        if (s_auto_failover.get(params) != MariaDBMonitor::AutoFailover::NONE)
+        {
+            MXB_ERROR(PARAM_REQUIRES, s_auto_failover.name().c_str(),
+                      s_assume_unique_hostnames.name().c_str());
+            ok = false;
+        }
+        if (s_switchover_on_low_disk_space.get(params))
+        {
+            MXB_ERROR(PARAM_REQUIRES, s_switchover_on_low_disk_space.name().c_str(),
+                      s_assume_unique_hostnames.name().c_str());
+            ok = false;
+        }
+        if (s_auto_rejoin.get(params))
+        {
+            MXB_ERROR(PARAM_REQUIRES, s_auto_rejoin.name().c_str(), s_assume_unique_hostnames.name().c_str());
+            ok = false;
+        }
+    }
+
+    return ok;
+}
+
+auto mo_relaxed = std::memory_order_relaxed;
+auto mo_acquire = std::memory_order_acquire;
+auto mo_release = std::memory_order_release;
+}
+
+MariaDBMonitor::MariaDBMonitor(const string& name, const string& module)
+    : Monitor(name, module)
+    , m_settings(name, this)
+{
+}
+
+/**
+ * Reset and initialize server arrays and related data.
+ */
+void MariaDBMonitor::reset_server_info()
+{
+    m_servers_by_id.clear();
+    assign_new_master(nullptr);
+    m_next_master = nullptr;
+    m_master_gtid_domain = GTID_DOMAIN_UNKNOWN;
+    m_resolver = DNSResolver();     // Erases result cache.
+}
+
+void MariaDBMonitor::reset_node_index_info()
+{
+    for (auto server : m_servers)
+    {
+        server->m_node.reset_indexes();
+    }
+}
+
+MariaDBServer* MariaDBMonitor::get_server_by_addr(const EndPoint& search_ep)
+{
+    MariaDBServer* found = nullptr;
+    for (auto* server : m_servers)
+    {
+        if (search_ep.points_to_server(*server->server))
+        {
+            found = server;
+            break;
+        }
+    }
+
+    if (!found)
+    {
+        // Server was not found with simple string compare. Try DNS resolving for endpoints with
+        // matching ports. Name lookup both the search target and server normal and private addresses.
+        DNSResolver::StringSet search_addrs = m_resolver.resolve_server(search_ep.host());
+        if (!search_addrs.empty())
+        {
+            auto server_host_matches_addr = [this, &search_addrs](const char* server_host) {
+                if (*server_host)
+                {
+                    auto server_addresses = m_resolver.resolve_server(server_host);
+                    auto server_address_matches = [&search_addrs](const string& srv_addr) {
+                        return search_addrs.count(srv_addr) > 0;
+                    };
+                    return std::any_of(server_addresses.begin(), server_addresses.end(),
+                                       server_address_matches);
+                }
+                return false;
+            };
+
+            for (auto* server : m_servers)
+            {
+                SERVER* srv = server->server;
+                if (srv->port() == search_ep.port())
+                {
+                    if (server_host_matches_addr(srv->address())
+                        || server_host_matches_addr(srv->private_address()))
+                    {
+                        found = server;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    return found;
+}
+
+MariaDBServer* MariaDBMonitor::get_server(int64_t id)
+{
+    auto found = m_servers_by_id.find(id);
+    return (found != m_servers_by_id.end()) ? (*found).second : NULL;
+}
+
+MariaDBServer* MariaDBMonitor::get_server(MonitorServer* mon_server) const
+{
+    return get_server(mon_server->server);
+}
+
+MariaDBServer* MariaDBMonitor::get_server(SERVER* server) const
+{
+    for (auto& srv : m_servers)
+    {
+        if (srv->server == server)
+        {
+            return srv;
+        }
+    }
+    return nullptr;
+}
+
+MariaDBMonitor* MariaDBMonitor::create(const string& name, const string& module)
+{
+    return new MariaDBMonitor(name, module);
+}
+
+mxs::config::Configuration& MariaDBMonitor::configuration()
+{
+    return m_settings;
+}
+
+MariaDBMonitor::Settings::Settings(const std::string& name, MariaDBMonitor* monitor)
+    : mxs::config::Configuration(name, &s_spec)
+    , m_monitor(monitor)
+{
+    using Shared = MariaDBServer::SharedSettings;
+
+    add_native(&Settings::assume_unique_hostnames, &s_assume_unique_hostnames);
+    add_native(&Settings::failcount, &s_failcount);
+    add_native(&Settings::failover_timeout, &s_failover_timeout);
+    add_native(&Settings::shared, &Shared::switchover_timeout, &s_switchover_timeout);
+    add_native(&Settings::auto_failover, &s_auto_failover);
+    add_native(&Settings::auto_rejoin, &s_auto_rejoin);
+    add_native(&Settings::enforce_read_only_slaves, &s_enforce_read_only_slaves);
+    add_native(&Settings::enforce_read_only_servers, &s_enforce_read_only_servers);
+    add_native(&Settings::enforce_writable_master, &s_enforce_writable_master);
+    add_native(&Settings::enforce_simple_topology, &s_enforce_simple_topology);
+    add_native(&Settings::verify_master_failure, &s_verify_master_failure);
+    add_native(&Settings::master_failure_timeout, &s_master_failure_timeout);
+    add_native(&Settings::switchover_on_low_disk_space, &s_switchover_on_low_disk_space);
+    add_native(&Settings::maintenance_on_low_disk_space, &s_maintenance_on_low_disk_space);
+    add_native(&Settings::require_server_locks, &s_cooperative_monitoring_locks);
+    add_native(&Settings::shared, &Shared::master_conds, &s_master_conditions);
+    add_native(&Settings::shared, &Shared::slave_conds, &s_slave_conditions);
+    add_native(&Settings::script_max_rlag, &s_script_max_rlag);
+    add_native(&Settings::servers_no_promotion, &s_server_no_promotion);
+    add_native(&Settings::shared, &Shared::promotion_sql_file, &s_promotion_sql_file);
+    add_native(&Settings::shared, &Shared::demotion_sql_file, &s_demotion_sql_file);
+    add_native(&Settings::shared, &Shared::handle_event_scheduler, &s_handle_events);
+    add_native(&Settings::shared, &Shared::replication_ssl, &s_replication_master_ssl);
+    add_native(&Settings::shared, &Shared::replication_custom_opts, &s_replication_custom_opts);
+    add_native(&Settings::shared, &Shared::replication_user, &s_replication_user);
+    add_native(&Settings::shared, &Shared::replication_password, &s_replication_password);
+    add_native(&Settings::cs_admin_port, &s_cs_admin_port);
+    add_native(&Settings::cs_admin_base_path, &s_cs_admin_base_path);
+    add_native(&Settings::cs_admin_api_key, &s_cs_admin_api_key);
+    add_native(&Settings::ssh_user, &s_ssh_user);
+    add_native(&Settings::ssh_keyfile, &s_ssh_keyfile);
+    add_native(&Settings::ssh_host_check, &s_ssh_check_host_key);
+    add_native(&Settings::ssh_timeout, &s_ssh_timeout);
+    add_native(&Settings::ssh_port, &s_ssh_port);
+    add_native(&Settings::rebuild_port, &s_rebuild_port);
+    add_native(&Settings::mbu_use_memory, &s_mbu_use_memory);
+    add_native(&Settings::mbu_parallel, &s_mbu_parallel);
+    add_native(&Settings::backup_storage_addr, &s_backup_storage_addr);
+    add_native(&Settings::backup_storage_path, &s_backup_storage_path);
+    add_native(&Settings::master_write_test_interval, &s_write_test_interval);
+    add_native(&Settings::master_write_test_table, &s_write_test_table);
+    add_native(&Settings::write_test_fail_action, &s_write_test_action);
+}
+
+bool MariaDBMonitor::Settings::post_configure(const std::map<std::string,
+                                                             mxs::ConfigParameters>& nested_params)
+{
+    shared.server_locks_enabled = require_server_locks != RequireLocks::LOCKS_NONE;
+
+    if (enforce_simple_topology)
+    {
+        // This is a "mega-setting" which turns on several other features regardless of their individual
+        // settings.
+        const char setting_activated[] = "%s enables %s, overriding any existing setting or default.";
+        auto warn_and_enable = [&setting_activated](bool* setting, const char* setting_name) {
+
+            if (*setting == false)
+            {
+                *setting = true;
+                MXB_WARNING(setting_activated, CN_ENFORCE_SIMPLE_TOPOLOGY, setting_name);
+            }
+        };
+
+        warn_and_enable(&assume_unique_hostnames, CN_ASSUME_UNIQUE_HOSTNAMES);
+        warn_and_enable(&auto_rejoin, CN_AUTO_REJOIN);
+        if (auto_failover == AutoFailover::NONE)
+        {
+            auto_failover = AutoFailover::ALLOW_TRX_LOSS;
+            MXB_WARNING(setting_activated, CN_ENFORCE_SIMPLE_TOPOLOGY, CN_AUTO_FAILOVER);
+        }
+    }
+
+    shared.auto_op_configured = m_monitor->cluster_ops_configured();
+    return m_monitor->post_configure();
+}
+
+/**
+ * Load config parameters
+ *
+ * @param params Config parameters
+ * @return True if settings are ok
+ */
+bool MariaDBMonitor::post_configure()
+{
+    calc_standard_wait_timeout();
+    /* Reset all monitored state info. The server dependent values must be reset as servers could have been
+     * added, removed and modified. */
+    reset_server_info();
+    // Operation data is cleared in post_run.
+
+    if (m_settings.shared.replication_user.empty())
+    {
+        m_settings.shared.replication_user = conn_settings().username;
+        m_settings.shared.replication_password = conn_settings().password;
+    }
+
+    auto [ok, excluded] = get_monitored_serverlist(m_settings.servers_no_promotion);
+
+    if (ok)
+    {
+        m_excluded_servers.clear();
+
+        for (auto* srv : excluded)
+        {
+            m_excluded_servers.push_back(static_cast<MariaDBServer*>(srv));
+        }
+
+        m_http_config.headers["x-api-key"] = m_settings.cs_admin_api_key;
+        m_http_config.headers["content-type"] = "application/json";
+
+        // The CS daemon uses a self-signed certificate.
+        m_http_config.ssl_verifypeer = false;
+        m_http_config.ssl_verifyhost = false;
+    }
+
+    return ok;
+}
+
+json_t* MariaDBMonitor::diagnostics() const
+{
+    mxb_assert(mxs::MainWorker::is_current());
+    return to_json();
+}
+
+json_t* MariaDBMonitor::diagnostics(MonitorServer* srv) const
+{
+    mxb_assert(mxs::MainWorker::is_current());
+    json_t* result = nullptr;
+
+    if (auto server = get_server(srv))
+    {
+        result = server->to_json();
+    }
+
+    return result;
+}
+
+json_t* MariaDBMonitor::to_json(State op)
+{
+    switch (op)
+    {
+    case State::IDLE:
+        return json_string("Idle");
+
+    case State::MONITOR:
+        return json_string("Monitoring servers");
+
+    case State::EXECUTE_SCRIPTS:
+        return json_string("Executing scripts");
+
+    case State::DEMOTE:
+        return json_string("Demoting old primary");
+
+    case State::WAIT_FOR_TARGET_CATCHUP:
+        return json_string("Waiting for candidate primary to catch up");
+
+    case State::PROMOTE_TARGET:
+        return json_string("Promoting candidate primary");
+
+    case State::REJOIN:
+        return json_string("Rejoining slave servers");
+
+    case State::CONFIRM_REPLICATION:
+        return json_string("Confirming that replication works");
+
+    case State::RESET_REPLICATION:
+        return json_string("Resetting replication on all servers");
+    }
+
+    mxb_assert(!true);
+    return nullptr;
+}
+
+json_t* MariaDBMonitor::to_json() const
+{
+    mxb_assert(mxs::MainWorker::is_current());
+    json_t* rval = Monitor::diagnostics();
+
+    // The m_master-pointer can be modified during a tick, but the pointed object cannot be deleted.
+    auto master = mxb::atomic::load(&m_master, mxb::atomic::RELAXED);
+    json_object_set_new(rval, "master", master == nullptr ? json_null() : json_string(master->name()));
+    json_object_set_new(rval,
+                        "master_gtid_domain_id",
+                        m_master_gtid_domain == GTID_DOMAIN_UNKNOWN ? json_null() :
+                        json_integer(m_master_gtid_domain));
+    json_object_set_new(rval, "state", to_json(m_state));
+    json_object_set_new(rval, "primary",
+                        server_locks_in_use() ? json_boolean(is_cluster_owner()) : json_null());
+
+    json_t* server_info = json_array();
+    // Accessing servers-array is ok since it's only changed from main worker thread.
+    for (auto& server : m_servers)
+    {
+        json_array_append_new(server_info, server->to_json());
+    }
+    json_object_set_new(rval, "server_info", server_info);
+    return rval;
+}
+
+bool MariaDBMonitor::can_be_disabled(const mxs::MonitorServer& mserver, DisableType type,
+                                     std::string* errmsg_out) const
+{
+    // If the server is the master, it cannot be disabled.
+    bool can_be = !status_is_master(mserver.server->status());
+
+    if (!can_be)
+    {
+        *errmsg_out =
+            "The server is primary, so it cannot be set in maintenance or draining mode. "
+            "First perform a switchover and then retry the operation.";
+    }
+
+    return can_be;
+}
+
+bool MariaDBMonitor::is_cluster_owner() const
+{
+    return m_locks_info.have_lock_majority.load(std::memory_order_relaxed);
+}
+
+void MariaDBMonitor::pre_loop()
+{
+    // Read the journal and the last known master.
+    read_journal();
+
+    m_locks_info.reset();
+    m_op_info.monitor_stopping = false;
+
+    m_last_master_gtid_change = m_worker->epoll_tick_now();
+    m_write_test_tbl_status = MariaDBServer::WriteTestTblStatus::UNKNOWN;
+    m_write_test_fails = 0;
+}
+
+void MariaDBMonitor::post_loop()
+{
+    write_journal();
+    // The operation data needs to be cleared on stop. The monitor may be reconfigured, and the operation
+    // data may not be compatible with the new config. This will also cut any SSH connections used by
+    // server rebuild.
+    m_running_op = nullptr;
+    m_op_info.monitor_stopping = true;
+
+    for (auto srv : m_servers)
+    {
+        srv->close_conn();
+    }
+}
+
+std::tuple<bool, std::string> MariaDBMonitor::prepare_to_stop()
+{
+    using ExecState = mon_op::ExecState;
+    mxb_assert(Monitor::is_main_worker());
+    mxb_assert(is_running());
+
+    bool stopping = false;
+    string errmsg;
+    std::unique_lock<std::mutex> lock(m_op_info.lock);
+    auto op_state = m_op_info.exec_state.load(mo_acquire);
+    if (op_state == ExecState::SCHEDULED || op_state == ExecState::RUNNING)
+    {
+        const char* state_str = (op_state == ExecState::SCHEDULED) ? "pending" : "running";
+        errmsg = mxb::string_printf("Command '%s' is %s.", m_op_info.op_name.c_str(), state_str);
+    }
+    else
+    {
+        stopping = true;
+        // Ensure that monitor cannot start another operation during shutdown.
+        m_op_info.monitor_stopping = true;
+    }
+    lock.unlock();
+
+    return {stopping, errmsg};
+}
+
+void MariaDBMonitor::tick()
+{
+    m_state = State::MONITOR;
+    check_maintenance_requests();
+
+    for (auto srv : m_servers)
+    {
+        srv->stash_current_status();
+    }
+
+    // Query all servers for their status.
+    bool first_tick = ticks_complete() == 0;
+    bool should_update_disk_space = check_disk_space_this_tick();
+
+    // Concurrently query all servers for their status. Force a reconnect on all servers if a command failed
+    // due to a missing privilege. Reconnecting refreshes connection privileges.
+    bool reconnect = m_grant_fail;
+    m_grant_fail = false;
+
+    auto update_task = [this, should_update_disk_space, first_tick, reconnect](MariaDBServer* server) {
+        server->update_server(should_update_disk_space, first_tick, server == m_master, reconnect);
+    };
+    execute_task_all_servers(update_task);
+
+    update_cluster_lock_status();
+
+    for (MariaDBServer* server : m_servers)
+    {
+        if (server->m_topology_changed)
+        {
+            m_cluster_topology_changed = true;
+            server->m_topology_changed = false;
+        }
+        if (server->m_cmd_grant_fail)
+        {
+            m_grant_fail = true;
+            server->m_cmd_grant_fail = false;
+        }
+    }
+    update_topology();
+
+    if (m_cluster_topology_changed)
+    {
+        m_cluster_topology_changed = false;
+        // If cluster operations are enabled, check topology support and disable if needed.
+        if ((m_settings.auto_failover != AutoFailover::NONE)
+            || m_settings.switchover_on_low_disk_space || m_settings.auto_rejoin)
+        {
+            check_cluster_operations_support();
+        }
+    }
+
+    // Always re-assign master, slave etc bits as these depend on other factors outside topology
+    // (e.g. slave sql state).
+    assign_server_roles();
+
+    if (m_master && m_master->is_master())
+    {
+        // Update cluster-wide values dependant on the current master.
+        update_gtid_domain();
+
+        if (m_master->m_gtid_binlog_pos != m_master_gtid)
+        {
+            m_master_gtid = m_master->m_gtid_binlog_pos;
+            m_last_master_gtid_change = m_worker->epoll_tick_now();
+        }
+
+        if (m_settings.auto_failover != AutoFailover::NONE)
+        {
+            m_master->check_semisync_master_status();
+        }
+    }
+
+    /* Set low disk space slaves to maintenance. This needs to happen after roles have been assigned.
+     * Is not a real cluster operation, since nothing on the actual backends is changed. */
+    if (m_settings.maintenance_on_low_disk_space)
+    {
+        set_low_disk_slaves_maintenance();
+    }
+
+    // Sanity check. Master may not be both slave and master.
+    mxb_assert(m_master == nullptr || !m_master->has_status(SERVER_SLAVE | SERVER_MASTER));
+
+    if (server_locks_in_use() && is_cluster_owner())
+    {
+        check_acquire_masterlock();
+    }
+
+    flush_mdb_server_status();
+    process_state_changes();
+    hangup_failed_servers();
+    write_journal_if_needed();
+    if (m_cluster_modified)
+    {
+        request_fast_ticks();
+    }
+    m_state = State::IDLE;
+}
+
+void MariaDBMonitor::process_state_changes()
+{
+    using ExecState = mon_op::ExecState;
+    m_state = State::EXECUTE_SCRIPTS;
+    detect_handle_state_changes();
+
+    m_cluster_modified = false;
+    if (cluster_operation_disable_timer > 0)
+    {
+        cluster_operation_disable_timer--;
+    }
+
+    auto run_operation = [this]() {
+        if (m_op_info.cancel_op.load())
+        {
+            m_running_op->cancel();
+            m_running_op = nullptr;
+            std::lock_guard<std::mutex> guard(m_op_info.lock);
+            MXB_NOTICE("Running %s canceled.", m_op_info.op_name.c_str());
+            m_op_info.op_name.clear();
+            m_op_info.exec_state = ExecState::DONE;
+            m_op_info.current_op_is_manual = false;
+        }
+        else
+        {
+            auto complete = m_running_op->run();
+            if (complete)
+            {
+                bool running_cmd_is_manual = false;
+                // Operation complete. If it was user-triggered, save results and notify the waiting thread
+                // (if any) that it can continue.
+                std::unique_lock<std::mutex> lock(m_op_info.lock);
+
+                mxb_assert(m_op_info.exec_state == ExecState::RUNNING);
+                running_cmd_is_manual = m_op_info.current_op_is_manual;
+                if (running_cmd_is_manual)
+                {
+                    // Should not have any previous results, since previous results were erased when
+                    // the current command was scheduled.
+                    auto& res_storage = m_op_info.result_info;
+                    mxb_assert(!res_storage);
+                    res_storage = std::make_unique<mon_op::ResultInfo>();
+                    res_storage->res = m_running_op->result();
+                    res_storage->cmd_name = m_op_info.op_name;
+                }
+                m_op_info.exec_state = ExecState::DONE;
+                m_op_info.op_name.clear();
+
+                lock.unlock();
+
+                if (running_cmd_is_manual)
+                {
+                    m_op_info.result_ready_notifier.notify_one();
+                }
+                m_running_op = nullptr;
+            }
+        }
+    };
+
+    if (m_running_op)
+    {
+        // An operation (user or self-triggered) is in progress, continue it.
+        run_operation();
+    }
+    else
+    {
+        // No current running op, check if a command is scheduled.
+        std::unique_lock<std::mutex> lock(m_op_info.lock);
+        if (m_op_info.exec_state == ExecState::SCHEDULED)
+        {
+            // Move the scheduled command into execution.
+            m_running_op = move(m_op_info.scheduled_op);
+            m_op_info.exec_state = ExecState::RUNNING;
+        }
+        lock.unlock();
+
+        if (m_running_op)
+        {
+            // An operation was just scheduled, run it.
+            run_operation();
+        }
+    }
+
+    // Run automatic operations. Only start an op if no op is currently running and cluster is
+    // stable.
+    if (!m_running_op && can_perform_cluster_ops())
+    {
+        if (m_settings.auto_failover != AutoFailover::NONE)
+        {
+            handle_auto_failover();
+        }
+
+        // Lock status or "passive" cannot change between these functions, but operation delay or
+        // modification state can.
+
+        // Do not auto-join servers on this monitor loop if a failover (or any other cluster modification)
+        // has been performed, as server states have not been updated yet. It will happen next iteration.
+        if (m_settings.auto_rejoin && cluster_can_be_joined() && !cluster_operations_disabled_short())
+        {
+            // Check if any servers should be autojoined to the cluster and try to join them.
+            handle_auto_rejoin();
+        }
+
+        /* Check if the master server is on low disk space and act on it. */
+        if (m_settings.switchover_on_low_disk_space && !cluster_operations_disabled_short())
+        {
+            handle_low_disk_space_master();
+        }
+
+        if (m_settings.master_write_test_interval > 0s && !cluster_operations_disabled_short())
+        {
+            handle_master_write_test();
+        }
+
+        /* Check if the master has read-only on and turn it off if user so wishes. */
+        if (m_settings.enforce_writable_master && !cluster_operations_disabled_short())
+        {
+            enforce_writable_on_master();
+        }
+
+        /* Set read_only on [Slave] and other servers if the corresponding setting is on. Again, do not
+         * perform this if cluster has been modified this loop since server roles may be changing. */
+        if (!cluster_operations_disabled_short())
+        {
+            enforce_read_only();
+        }
+    }
+
+    m_state = State::MONITOR;
+}
+
+std::string MariaDBMonitor::annotate_state_change(MonitorServer* server)
+{
+    std::string rval;
+
+    if (server->get_event_type() == LOST_SLAVE_EVENT)
+    {
+        MariaDBServer* srv = get_server(server);
+        rval = srv->print_changed_slave_connections();
+    }
+
+    return rval;
+}
+
+/**
+ * Save info on the master server's multimaster group, if any. This is required when checking for changes
+ * in the topology.
+ */
+void MariaDBMonitor::update_master_cycle_info()
+{
+    if (m_master)
+    {
+        int new_cycle_id = m_master->m_node.cycle;
+        m_master_cycle_status.cycle_id = new_cycle_id;
+        if (new_cycle_id == NodeData::CYCLE_NONE)
+        {
+            m_master_cycle_status.cycle_members.clear();
+        }
+        else
+        {
+            m_master_cycle_status.cycle_members = m_cycles[new_cycle_id];
+        }
+    }
+    else
+    {
+        m_master_cycle_status.cycle_id = NodeData::CYCLE_NONE;
+        m_master_cycle_status.cycle_members.clear();
+    }
+}
+
+void MariaDBMonitor::update_gtid_domain()
+{
+    int64_t old_domain = m_master_gtid_domain;
+    int64_t new_domain = m_master->m_gtid_domain_id;
+
+    if (new_domain != old_domain)
+    {
+        if (old_domain != GTID_DOMAIN_UNKNOWN)
+        {
+            MXB_NOTICE("Gtid domain id of primary has changed: %li -> %li.",
+                       old_domain, new_domain);
+        }
+        request_journal_update();
+        m_master_gtid_domain = new_domain;
+    }
+}
+
+void MariaDBMonitor::assign_new_master(MariaDBServer* new_master)
+{
+    if (m_master != new_master)
+    {
+        mxb::atomic::store(&m_master, new_master, mxb::atomic::RELAXED);
+        request_journal_update();
+
+        // Reset master gtid tracking info.
+        m_last_master_gtid_change = m_worker->epoll_tick_now();
+        m_master_gtid = m_master ? m_master->m_gtid_binlog_pos : GtidList();
+    }
+    update_master_cycle_info();
+    m_warn_current_master_invalid = true;
+    m_warn_cannot_find_master = true;
+}
+
+/**
+ * Run a manual command. It will be ran during the next monitor tick. This method waits
+ * for the command to have finished running.
+ *
+ * @param command Function object containing the method the monitor should execute.
+ * @param cmd_name Command name, for logging
+ * @param error_out Json error output
+ * @return True if command execution succeeded. False if monitor was in an invalid state
+ * to run the command or command failed.
+ */
+bool MariaDBMonitor::execute_manual_command(mon_op::CmdMethod command, const string& cmd_name,
+                                            json_t** error_out)
+{
+    bool rval = false;
+    if (schedule_manual_command(std::move(command), cmd_name, error_out))
+    {
+        // Wait for the result.
+        std::unique_lock<std::mutex> lock(m_op_info.lock);
+        auto cmd_complete = [this] {
+            return m_op_info.exec_state == mon_op::ExecState::DONE;
+        };
+        m_op_info.result_ready_notifier.wait(lock, cmd_complete);
+
+        // Copy results similar to fetch-results.
+        mon_op::Result res = m_op_info.result_info->res.deep_copy();
+
+        // There should not be any existing errors in the error output.
+        mxb_assert(*error_out == nullptr);
+        rval = res.success;
+        if (res.output.object_size() > 0)
+        {
+            *error_out = res.output.release();
+        }
+    }
+    return rval;
+}
+
+/**
+ * Schedule a manual command for execution. Does not wait for the command to complete.
+ *
+ * @param command Function object containing the method the monitor should execute.
+ * @param cmd_name Command name, for logging
+ * @param error_out Json error output
+ * @return True if command execution was attempted. False if monitor was in an invalid state
+ * to run the command.
+ */
+bool MariaDBMonitor::schedule_manual_command(mon_op::CmdMethod command, const string& cmd_name,
+                                             json_t** error_out)
+{
+    auto op = std::make_unique<mon_op::SimpleOp>(move(command));
+    return schedule_manual_command(move(op), cmd_name, error_out);
+}
+
+bool MariaDBMonitor::schedule_manual_command(mon_op::SOperation op, const std::string& cmd_name,
+                                             json_t** error_out)
+{
+    using ExecState = mon_op::ExecState;
+    mxb_assert(is_main_worker() && !cmd_name.empty());
+    bool cmd_sent = false;
+    if (!is_running())
+    {
+        PRINT_MXS_JSON_ERROR(error_out, "The monitor is not running, cannot execute manual command.");
+    }
+    else
+    {
+        const char prev_cmd[] = "Cannot run manual %s, previous %s is still %s.";
+        std::lock_guard<std::mutex> guard(m_op_info.lock);
+        auto op_state = m_op_info.exec_state.load(mo_acquire);
+        if (op_state == ExecState::SCHEDULED)
+        {
+            PRINT_MXS_JSON_ERROR(error_out, prev_cmd, cmd_name.c_str(), m_op_info.op_name.c_str(), "pending");
+        }
+        else if (op_state == ExecState::RUNNING)
+        {
+            PRINT_MXS_JSON_ERROR(error_out, prev_cmd, cmd_name.c_str(), m_op_info.op_name.c_str(), "running");
+        }
+        else if (m_op_info.monitor_stopping)
+        {
+            // Should be very rare, if not impossible to get.
+            PRINT_MXS_JSON_ERROR(error_out, "Cannot run manual %s, monitor is stopping.", cmd_name.c_str());
+        }
+        else
+        {
+            // Write the command. No need to notify monitor thread, as it checks for commands every tick.
+            mxb_assert(!m_op_info.scheduled_op);
+            m_op_info.scheduled_op = move(op);
+            m_op_info.op_name = cmd_name;
+            m_op_info.exec_state.store(ExecState::SCHEDULED, mo_release);
+            m_op_info.current_op_is_manual = true;
+            m_op_info.cancel_op = false;
+
+            // Remove any previous results.
+            m_op_info.result_info = nullptr;
+            cmd_sent = true;
+        }
+    }
+
+    if (cmd_sent)
+    {
+        request_fast_ticks();
+    }
+    return cmd_sent;
+}
+
+bool MariaDBMonitor::start_long_running_op(mon_op::SOperation op, const std::string& cmd_name)
+{
+    using ExecState = mon_op::ExecState;
+    bool cmd_sent = false;
+    std::lock_guard<std::mutex> lock(m_op_info.lock);
+    auto op_state = m_op_info.exec_state.load(mo_acquire);
+    // Can only start a long op if no op is scheduled or running.
+    if (!m_op_info.monitor_stopping && op_state == ExecState::DONE)
+    {
+        mxb_assert(!m_op_info.scheduled_op && !m_running_op && m_op_info.op_name.empty());
+        m_op_info.op_name = cmd_name;
+        m_running_op = move(op);
+        m_op_info.exec_state.store(ExecState::RUNNING, mo_release);
+        m_op_info.current_op_is_manual = false;
+        m_op_info.cancel_op = false;
+        cmd_sent = true;
+    }
+    return cmd_sent;
+}
+
+bool MariaDBMonitor::server_locks_in_use() const
+{
+    return (m_settings.require_server_locks == LOCKS_MAJORITY_ALL)
+           || (m_settings.require_server_locks == LOCKS_MAJORITY_RUNNING);
+}
+
+bool MariaDBMonitor::try_acquire_locks_this_tick()
+{
+    mxb_assert(server_locks_in_use());
+
+    auto calc_interval = [this](int base_intervals, int deviation_max_intervals) {
+        // Scale the interval calculation by the monitor interval.
+        int mon_interval_ms = settings().interval.count();
+        int deviation = m_random_gen.b_to_e_co(0, deviation_max_intervals);
+        return (base_intervals + deviation) * mon_interval_ms;
+    };
+
+    bool try_acquire_locks = false;
+    if (m_locks_info.time_to_update())
+    {
+        try_acquire_locks = true;
+        // Calculate time until next update check. Randomize a bit to reduce possibility that multiple
+        // monitors would attempt to get locks simultaneously. The randomization parameters are not user
+        // configurable, but the correct values are not obvious.
+        int next_check_interval = calc_interval(5, 3);
+        m_locks_info.next_lock_attempt_delay = std::chrono::milliseconds(next_check_interval);
+        m_locks_info.last_locking_attempt.restart();
+    }
+    return try_acquire_locks;
+}
+
+bool MariaDBMonitor::cluster_operations_disabled_short() const
+{
+    return cluster_operation_disable_timer > 0 || m_cluster_modified;
+}
+
+void MariaDBMonitor::check_acquire_masterlock()
+{
+    // Check that the correct server has the masterlock. If not, release and reacquire.
+    // The lock status has already been fetched by the server update code.
+    const MariaDBServer* masterlock_target = nullptr;
+    if (m_master && m_master->is_master())
+    {
+        masterlock_target = m_master;
+    }
+
+    const auto ml = MariaDBServer::LockType::MASTER;
+    for (auto server : m_servers)
+    {
+        if (server != masterlock_target)
+        {
+            if (server->lock_owned(ml))
+            {
+                // Should not have the lock, release.
+                server->release_lock(ml);
+            }
+        }
+        else if (server == masterlock_target)
+        {
+            auto masterlock = server->masterlock_status();
+            if (masterlock.is_free())
+            {
+                // Don't have the lock when should.
+                server->get_lock(ml);
+            }
+            else if (masterlock.status() == ServerLock::Status::OWNED_OTHER)
+            {
+                // Someone else is holding the masterlock, even when this monitor has lock majority.
+                // Not a problem for this monitor, but secondary MaxScales may select a wrong master.
+                MXB_ERROR("Cannot acquire lock '%s' on '%s' as it's claimed by another connection (id %li). "
+                          "Secondary MaxScales may select the wrong primary.",
+                          MASTER_LOCK_NAME, name(), masterlock.owner());
+            }
+        }
+    }
+}
+
+bool MariaDBMonitor::is_slave_maxscale() const
+{
+    return server_locks_in_use() && !is_cluster_owner();
+}
+
+void MariaDBMonitor::execute_task_all_servers(const ServerFunction& task)
+{
+    execute_task_on_servers(task, m_servers);
+}
+
+void MariaDBMonitor::execute_task_on_servers(const ServerFunction& task, const ServerArray& servers)
+{
+    mxb::Semaphore task_complete;
+    for (auto server : servers)
+    {
+        auto server_task = [&task, &task_complete, server]() {
+            task(server);
+            task_complete.post();
+        };
+        m_threadpool.execute(server_task, "monitor-task");
+    }
+    task_complete.wait_n(servers.size());
+}
+
+bool MariaDBMonitor::ClusterLocksInfo::time_to_update() const
+{
+    return last_locking_attempt.split() > next_lock_attempt_delay;
+}
+
+bool MariaDBMonitor::cluster_ops_configured() const
+{
+    return m_settings.auto_failover != AutoFailover::NONE || m_settings.auto_rejoin
+           || m_settings.enforce_read_only_slaves || m_settings.enforce_read_only_servers
+           || m_settings.enforce_writable_master || m_settings.switchover_on_low_disk_space;
+}
+
+namespace journal_fields
+{
+const char MASTER[] = "master_server";
+const char MASTER_GTID_DOMAIN[] = "master_gtid_domain";
+}
+
+void MariaDBMonitor::save_monitor_specific_journal_data(mxb::Json& data)
+{
+    data.set_string(journal_fields::MASTER, m_master ? m_master->name() : "");
+    data.set_int(journal_fields::MASTER_GTID_DOMAIN, m_master_gtid_domain);
+}
+
+void MariaDBMonitor::load_monitor_specific_journal_data(const mxb::Json& data)
+{
+    string master_name = data.get_string(journal_fields::MASTER);
+    for (auto* elem : m_servers)
+    {
+        if (strcmp(elem->name(), master_name.c_str()) == 0)
+        {
+            assign_new_master(elem);
+            break;
+        }
+    }
+    m_master_gtid_domain = data.get_int(journal_fields::MASTER_GTID_DOMAIN);
+}
+
+void MariaDBMonitor::flush_mdb_server_status()
+{
+    // Update shared status.
+    bool status_changed = false;
+    auto rlag_limit = m_settings.script_max_rlag;
+    for (auto server : m_servers)
+    {
+        SERVER* srv = server->server;
+        srv->set_replication_lag(server->m_replication_lag);
+        if (server->flush_status())
+        {
+            status_changed = true;
+        }
+
+        if (rlag_limit >= 0)
+        {
+            server->update_rlag_state(rlag_limit);
+        }
+    }
+
+    if (status_changed)
+    {
+        request_journal_update();
+    }
+}
+
+void MariaDBMonitor::configured_servers_updated(const std::vector<SERVER*>& servers)
+{
+    for (auto srv : m_servers)
+    {
+        delete srv;
+    }
+
+    auto& shared_settings = settings().shared;
+    m_servers.resize(servers.size());
+    for (size_t i = 0; i < servers.size(); i++)
+    {
+        m_servers[i] = new MariaDBServer(servers[i], i, shared_settings, m_settings.shared);
+    }
+
+    // The configured servers and the active servers are the same.
+    set_active_servers(std::vector<MonitorServer*>(m_servers.begin(), m_servers.end()));
+}
+
+void MariaDBMonitor::calc_standard_wait_timeout()
+{
+    // Only modify wait_timeout when locks are used, as it's mostly meant for getting rid of stale locks.
+    if (!m_settings.shared.server_locks_enabled)
+    {
+        m_settings.shared.wait_timeout_normal_s = -1;
+        return;
+    }
+
+    // During standard operation, use monitor_interval + 2 * max(read_timeout, write_timeout).
+    // This is based on the assumption that ping is at most the max timeout (as otherwise the connector
+    // would time out waiting for a response), and the monitor does a query every interval. With this,
+    // stale cooperative monitoring locks typically release within a minute after a network failure.
+    std::chrono::milliseconds interval = settings().interval;
+    int interval_s_ceil = (interval + 999ms).count() / 1000;
+    m_settings.shared.wait_timeout_normal_s = calc_operation_wait_timeout(interval_s_ceil * 1s);
+    MXB_NOTICE("%s will set connection wait_timeout to %i seconds during normal operation.",
+               name(), m_settings.shared.wait_timeout_normal_s);
+}
+
+void MariaDBMonitor::reset_wait_timeout_all_servers()
+{
+    int wait_timeout = m_settings.shared.wait_timeout_normal_s;
+    if (wait_timeout > 0)
+    {
+        auto timeout_task = [wait_timeout](MariaDBServer* server) {
+            if (server->is_running() && server->is_database())
+            {
+                server->set_wait_timout(wait_timeout);
+            }
+        };
+        execute_task_all_servers(timeout_task);
+    }
+}
+
+/**
+ * Set wait_timeout on all running monitored servers.
+ *
+ * @param base_op_timeout Base operation timeout. The actual set timeout is
+ * base_timeout + 2 * max(read_timeout, write_timeout).
+ */
+void MariaDBMonitor::maybe_set_wait_timeout_all_servers(std::chrono::seconds base_op_timeout)
+{
+    // Only alter wait_timeout if the monitor will also reset it later.
+    if (m_settings.shared.wait_timeout_normal_s > 0)
+    {
+        int wait_timeout = calc_operation_wait_timeout(base_op_timeout);
+        MXB_INFO("Setting connection wait_timeout to %i seconds for the duration of the cluster operation.",
+                 wait_timeout);
+        auto timeout_task = [wait_timeout](MariaDBServer* server) {
+            if (server->is_running() && server->is_database())
+            {
+                server->set_wait_timout(wait_timeout);
+            }
+        };
+        execute_task_all_servers(timeout_task);
+    }
+}
+
+int MariaDBMonitor::calc_operation_wait_timeout(std::chrono::seconds base_op_timeout)
+{
+    auto& conn_sett = conn_settings();
+    // Calculate a reasonable wait_timeout for use during the operation. This timeout must be greater
+    // than operation base timeout. Since the operation timeout setting is not strict, add some extra
+    // time deduced from connection timeouts. If connection timeouts are 0 (infinite), add the base timeout
+    // again.
+    auto max_conn_timeout = std::max(conn_sett.read_timeout, conn_sett.write_timeout);
+    if (max_conn_timeout <= 0s)
+    {
+        max_conn_timeout = std::max(base_op_timeout, 10s);      // In case operation timeout is short.
+    }
+    int wait_timeout_s = (base_op_timeout + 2 * max_conn_timeout).count();
+
+    // Use some reasonable safety limits.
+    int min_timeout = 5;
+    int max_timeout = 28800;    // Server default value.
+    return (wait_timeout_s < min_timeout) ? min_timeout :
+           (wait_timeout_s > max_timeout) ? max_timeout : wait_timeout_s;
+}
+
+string monitored_servers_to_string(const ServerArray& servers)
+{
+    string rval;
+    size_t array_size = servers.size();
+    if (array_size > 0)
+    {
+        const char* separator = "";
+        for (size_t i = 0; i < array_size; i++)
+        {
+            rval += separator;
+            rval += string("'") + servers[i]->name() + "'";
+            separator = ", ";
+        }
+    }
+    return rval;
+}
+
+/*
+ * Register module commands. Should only be called once when loading the module.
+ */
+void register_monitor_commands();
+
+/**
+ * The module entry point routine. This routine populates the module object structure.
+ *
+ * @return The module object
+ */
+extern "C" MXS_MODULE* MXS_CREATE_MODULE()
+{
+    register_monitor_commands();
+
+    static MXS_MODULE info =
+    {
+        mxs::MODULE_INFO_VERSION,
+        MXB_MODULE_NAME,
+        mxs::ModuleType::MONITOR,
+        mxs::ModuleStatus::GA,
+        MXS_MONITOR_VERSION,
+        "A MySQL 8.x Primary/Replica replication monitor (GTID failover)",
+        "V1.0.0",
+        MXS_NO_MODULE_CAPABILITIES,
+        &maxscale::MonitorApi<MariaDBMonitor>::s_api,
+        nullptr,                                    /* Process init. */
+        nullptr,                                    /* Process finish. */
+        nullptr,                                    /* Thread init. */
+        nullptr,                                    /* Thread finish. */
+        &s_spec
+    };
+    return &info;
+}

--- a/server/modules/monitor/mysqlrepmon/mariadbmon.hh
+++ b/server/modules/monitor/mysqlrepmon/mariadbmon.hh
@@ -1,0 +1,673 @@
+/*
+ * Copyright (c) 2018 MariaDB Corporation Ab
+ * Copyright (c) 2023 MariaDB plc, Finnish Branch
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file and at www.mariadb.com/bsl11.
+ *
+ * Change Date: 2027-09-09
+ *
+ * On the date above, in accordance with the Business Source License, use
+ * of this software will be governed by version 2 or later of the General
+ * Public License.
+ */
+#pragma once
+#include "mariadbmon_common.hh"
+
+#include <condition_variable>
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <maxbase/http.hh>
+#include <maxbase/stopwatch.hh>
+#include <maxbase/threadpool.hh>
+#include <maxscale/monitor.hh>
+#include "mariadbserver.hh"
+#include "monitor_commands.hh"
+
+// Used by multiple source files.
+extern const char* const CN_AUTO_FAILOVER;
+extern const char* const CN_SWITCHOVER_ON_LOW_DISK_SPACE;
+extern const char* const CN_MAINTENANCE_ON_LOW_DISK_SPACE;
+extern const char* const CN_PROMOTION_SQL_FILE;
+extern const char* const CN_DEMOTION_SQL_FILE;
+
+// Map of server id:s to MariaDBServer. Useful when constructing the replication graph.
+typedef std::unordered_map<int64_t, MariaDBServer*> IdToServerMap;
+// Map of cycle number to cycle members. The elements should be ordered for predictability when iterating.
+typedef std::map<int, ServerArray> CycleMap;
+
+// MariaDB Monitor instance data
+class MariaDBMonitor : public maxscale::Monitor
+{
+public:
+    MariaDBMonitor(const MariaDBMonitor&) = delete;
+    MariaDBMonitor& operator=(const MariaDBMonitor&) = delete;
+
+    class Test;
+    friend class Test;
+    friend class mon_op::BackupOperation;
+    friend class mon_op::RebuildServer;
+    friend class mon_op::CreateBackup;
+    friend class mon_op::RestoreFromBackup;
+
+    // Weakly-typed enums since cast to integer.
+    enum RequireLocks
+    {
+        LOCKS_NONE = 0,
+        LOCKS_MAJORITY_RUNNING,
+        LOCKS_MAJORITY_ALL
+    };
+
+    enum class AutoFailover
+    {
+        NONE,           /**< No auto-failover */
+        SAFE,           /**< Auto-failover only if it looks like replica has all data. Not fool-proof. */
+        ALLOW_TRX_LOSS  /**< Auto-failover even if replica is clearly missing data. */
+    };
+
+    enum class WriteTestFailAction
+    {
+        LOG,        /**< Just log the error */
+        FAILOVER    /**< Failover, possibly losing data */
+    };
+
+    /**
+     * Create the monitor instance and return the instance data.
+     *
+     * @param name Monitor config name
+     * @param module Module name
+     * @return MariaDBMonitor instance
+     */
+    static MariaDBMonitor* create(const std::string& name, const std::string& module);
+
+    /**
+     * Print diagnostics to json object.
+     *
+     * @return Diagnostics messages
+     */
+    json_t* diagnostics() const override;
+
+    /**
+     * Return information about a single server
+     */
+    json_t* diagnostics(mxs::MonitorServer* server) const override;
+
+    /**
+     * Perform user-activated switchover.
+     *
+     * @param type            Normal or forced
+     * @param new_master      The specified new master. If NULL, monitor will autoselect.
+     * @param current_master  The specified current master. If NULL, monitor will autoselect.
+     * @param error_out       Json error output
+     * @return True if switchover was performed
+     */
+    bool run_manual_switchover(SwitchoverType type, AfterDemotion after_demotion,
+                               SERVER* new_master, SERVER* current_master, json_t** error_out);
+
+    /**
+     * Perform user-activated switchover. Does not wait for results, which should be fetched separately.
+     *
+     * @param new_master      The specified new master. If NULL, monitor will autoselect.
+     * @param current_master  The specified current master. If NULL, monitor will autoselect.
+     * @param error_out       Json error output
+     * @return True if switchover was scheduled
+     */
+    bool schedule_async_switchover(AfterDemotion after_demotion, SERVER* new_master, SERVER* current_master,
+                                   json_t** error_out);
+
+    /**
+     * Perform user-activated failover.
+     *
+     * @param error_out Json error output
+     * @return True if failover was performed
+     */
+    bool run_manual_failover(FailoverType fo_type, json_t** error_out);
+
+    /**
+     * Perform user-activated failover. Does not wait for results, which should be fetched separately.
+     *
+     * @param error_out Json error output
+     * @return True if failover was scheduled
+     */
+    bool schedule_async_failover(FailoverType fo_type, json_t** error_out);
+
+    /**
+     * Perform user-activated rejoin
+     *
+     * @param rejoin_server Server to join
+     * @param error_out Json error output
+     * @return True if rejoin was performed
+     */
+    bool run_manual_rejoin(SERVER* rejoin_server, json_t** error_out);
+
+    /**
+     * Perform user-activated rejoin. Does not wait for results, which should be fetched separately.
+     *
+     * @param rejoin_server Server to join
+     * @param error_out Json error output
+     * @return True if rejoin was scheduled
+     */
+    bool schedule_async_rejoin(SERVER* rejoin_server, json_t** error_out);
+
+    /**
+     * Perform user-activated reset-replication
+     *
+     * @param master_server The server to promote. If NULL, monitor will select the current master.
+     * @param error_out Error output
+     * @return True if operation completed successfully
+     */
+    bool run_manual_reset_replication(SERVER* master_server, json_t** error_out);
+
+    /**
+     * Perform user-activated reset-replication. Does not wait for results, which should be fetched
+     * separately.
+     *
+     * @param master_server The server to promote. If NULL, monitor will select the current master.
+     * @param error_out Error output
+     * @return True if operation was scheduled
+     */
+    bool schedule_reset_replication(SERVER* master_server, json_t** error_out);
+
+    /**
+     * Perform user-activated lock release.
+     *
+     * @param error_out Error output
+     * @return True if locks are in use, even if none were released
+     */
+    bool run_release_locks(json_t** error_out);
+
+    /**
+     * Perform user-activated lock release. Does not wait for results, which should be fetched
+     * separately.
+     *
+     * @param error_out Error output
+     * @return True if locks are in use, even if none were released
+     */
+    bool schedule_release_locks(json_t** error_out);
+
+    /**
+     * Fetch results of last asynchronous command. If an async command is still running, outputs
+     * "<command> in still pending/running".
+     *
+     * @param output Output
+     * @return True if results of a manual command were available.
+     */
+    bool fetch_cmd_result(json_t** output);
+
+    /**
+     * Cancel currently pending or running manual command.
+     *
+     * @param output Output
+     * @return True if an operation was pending or running. Even if true is returned, the operation may
+     * have managed to complete before cancelling.
+     */
+    bool cancel_cmd(json_t** output);
+
+    /**
+     * Perform user-activated ColumnStore add node. Does not wait for results, which should be fetched
+     * separately.
+     *
+     * @param host The host to add
+     * @param timeout Timeout in seconds
+     * @param error_out Error output
+     * @return True if operation was scheduled
+     */
+    bool schedule_cs_add_node(const std::string& host, std::chrono::seconds timeout, json_t** error_out);
+
+    /**
+     * Perform user-activated ColumnStore remove node. Does not wait for results, which should be fetched
+     * separately.
+     *
+     * @param host The host to remove
+     * @param timeout Timeout in seconds
+     * @param error_out Error output
+     * @return True if operation was scheduled
+     */
+    bool schedule_cs_remove_node(const std::string& host, std::chrono::seconds timeout, json_t** error_out);
+
+    /**
+     * Get ColumnStore cluster status.
+     *
+     * @param output Output
+     * @return True if status was fetched
+     */
+    bool run_cs_get_status(json_t** output);
+
+    /**
+     * Get ColumnStore cluster status. Does not wait for results, which should be fetched separately.
+     *
+     * @param output Output
+     * @return True if operation was scheduled
+     */
+    bool schedule_cs_get_status(json_t** output);
+
+    /**
+     * Perform user-activated ColumnStore start/stop cluster. Does not wait for results, which should be
+     * fetched
+     * separately.
+     *
+     * @param timeout Timeout in seconds
+     * @param error_out Error output
+     * @return True if operation was scheduled
+     */
+    bool schedule_cs_start_cluster(std::chrono::seconds timeout, json_t** error_out);
+    bool schedule_cs_stop_cluster(std::chrono::seconds timeout, json_t** error_out);
+
+    /**
+     * Set ColumnStore cluster read-only/readwrite. Does not wait for results, which should be fetched
+     * separately.
+     *
+     * @param timeout Timeout in seconds
+     * @param error_out Error output
+     * @return True if operation was scheduled
+     */
+    bool schedule_cs_set_readonly(std::chrono::seconds timeout, json_t** error_out);
+    bool schedule_cs_set_readwrite(std::chrono::seconds timeout, json_t** error_out);
+
+    bool schedule_rebuild_server(SERVER* target, SERVER* source, const std::string& datadir,
+                                 json_t** error_out);
+    bool schedule_create_backup(SERVER* source, const std::string& bu_name, json_t** error_out);
+    bool schedule_restore_from_backup(SERVER* target, const std::string& bu_name, const std::string& datadir,
+                                      json_t** error_out);
+    bool is_cluster_owner() const override;
+
+    mxs::config::Configuration& configuration() override final;
+
+protected:
+    bool can_be_disabled(const mxs::MonitorServer& server, DisableType type,
+                         std::string* errmsg_out) const override;
+
+    void        tick() override;
+    void        process_state_changes();
+    void        flush_mdb_server_status();
+    std::string annotate_state_change(mxs::MonitorServer* server) override final;
+
+private:
+    using ServerFunction = std::function<void (MariaDBServer*)>;
+
+    // Some methods need a log on/off setting.
+    enum class Log
+    {
+        OFF,
+        ON
+    };
+
+    enum class RequireRunning
+    {
+        REQUIRED,
+        OPTIONAL
+    };
+
+    enum class State
+    {
+        IDLE,
+        MONITOR,
+        EXECUTE_SCRIPTS,
+        DEMOTE,
+        WAIT_FOR_TARGET_CATCHUP,
+        PROMOTE_TARGET,
+        REJOIN,
+        CONFIRM_REPLICATION,
+        RESET_REPLICATION,
+    };
+
+    class SwitchoverParams
+    {
+    public:
+        ServerOperation promotion;
+        ServerOperation demotion;
+        GeneralOpData   general;
+        SwitchoverType  type {SwitchoverType::NORMAL};
+        AfterDemotion   after_demotion {AfterDemotion::REDIRECT};
+
+        SwitchoverParams(ServerOperation promotion, ServerOperation demotion,
+                         const GeneralOpData& general, SwitchoverType type, AfterDemotion after_demotion);
+    };
+
+    class FailoverParams
+    {
+    public:
+        ServerOperation            promotion;   // Required by MariaDBServer->promote()
+        const MariaDBServer* const demotion_target;
+        GeneralOpData              general;
+
+        FailoverParams(ServerOperation promotion, const MariaDBServer* demotion_target,
+                       const GeneralOpData& general);
+    };
+
+    // Information about a multimaster group (replication cycle)
+    struct CycleInfo
+    {
+        int         cycle_id = NodeData::CYCLE_NONE;
+        ServerArray cycle_members;
+    };
+
+    class DNSResolver
+    {
+    public:
+        using StringSet = std::unordered_set<std::string>;
+        StringSet resolve_server(const std::string& host);
+
+    private:
+        struct MapElement
+        {
+            StringSet      addresses;   // A hostname can map to multiple addresses
+            mxb::TimePoint timestamp;
+        };
+
+        std::unordered_map<std::string, MapElement> m_mapping;      // hostname -> address cache
+    };
+
+    mon_op::OperationInfo m_op_info;    /* Manual/automatic op info */
+    mon_op::SOperation    m_running_op; /* Currently running op */
+
+    IdToServerMap               m_servers_by_id;    /**< Map from server id:s to MariaDBServer */
+    std::vector<MariaDBServer*> m_servers;          /**< All monitored servers */
+
+    /* The current state of a cluster modifying operation */
+    std::atomic<State> m_state {State::IDLE};
+
+    mxb::ThreadPool m_threadpool;   /* Threads used in concurrent operations */
+
+    // Topology related fields
+    MariaDBServer* m_master = NULL;         /* The most "master-like" server in the cluster. Is the only
+                                             * server which can get the Master status. */
+    MariaDBServer* m_next_master = NULL;    /* When a cluster operation changes the master, the new master is
+                                             * written here so the next monitor tick picks it up. */
+    bool m_cluster_topology_changed = true; /* Has cluster topology changed since last monitor loop?
+                                             * Causes a topology rebuild on the current tick. */
+    bool m_cluster_modified = false;        /* Has a cluster operation been performed this loop? Prevents
+                                             * other operations during this tick. */
+    bool m_grant_fail = false;              /* Did an operation fail because of missing privs? Causes a
+                                             * reconnection on all servers at start of next tick. */
+
+    DNSResolver m_resolver;                 /* DNS-resolver with cache */
+
+    /* Counter for temporary automatic cluster operation disabling. */
+    int cluster_operation_disable_timer = 0;
+
+    CycleMap  m_cycles;                     /* Map from cycle number to cycle member servers */
+    CycleInfo m_master_cycle_status;        /* Info about master server cycle from previous round */
+
+    // Miscellaneous info
+    int64_t m_master_gtid_domain = GTID_DOMAIN_UNKNOWN;     /* gtid_domain_id most recently seen on
+                                                             * the master */
+
+    GtidList       m_master_gtid;               /* Most recent gtid seen on master */
+    mxb::TimePoint m_last_master_gtid_change;   /* When did master gtid last change? */
+    int            m_write_test_fails {0};      /* How many times write test has failed */
+
+    MariaDBServer::WriteTestTblStatus m_write_test_tbl_status {MariaDBServer::WriteTestTblStatus::UNKNOWN};
+
+    bool m_warn_current_master_invalid {true};  /* Print warning if current master is not valid? */
+    bool m_warn_cannot_find_master {true};      /* Print warning if a master cannot be found? */
+    bool m_warn_master_down {true};             /* Print warning that failover may happen soon? */
+    bool m_warn_failover_precond {true};        /* Print failover preconditions error message? */
+    bool m_warn_switchover_precond {true};      /* Print switchover preconditions error message? */
+    bool m_warn_cannot_rejoin {true};           /* Print warning if auto_rejoin fails because of invalid
+                                                 * gtid:s? */
+    bool m_warn_write_test_fail {true};         /* Print warning if master fails write test? */
+    bool m_warn_write_fail_fo_precond {true};   /* Print write test failover preconditions error message? */
+
+    struct ClusterLocksInfo
+    {
+        bool time_to_update() const;
+
+        std::atomic_bool have_lock_majority {false};/* Is this the primary monitor for the cluster? */
+        mxb::StopWatch   last_locking_attempt;      /* Time since last server lock attempt */
+
+        /* Time until next locking attempt. Initialized to zero to allow an attempt during first loop. */
+        mxb::Duration next_lock_attempt_delay {0};
+
+        void reset()
+        {
+            have_lock_majority = false;
+            last_locking_attempt = mxb::StopWatch();
+            next_lock_attempt_delay = mxb::Duration(0);
+        }
+    };
+    ClusterLocksInfo m_locks_info;
+
+    mxb::XorShiftRandom m_random_gen;
+
+    // MariaDB-Monitor specific settings. These are only written to when configuring the monitor.
+    class Settings : public mxs::config::Configuration
+    {
+    public:
+        Settings(const std::string& name, MariaDBMonitor* monitor);
+
+        bool post_configure(const std::map<std::string, mxs::ConfigParameters>& nested_params) override final;
+
+        /* The default setting values given here may not be the actual defaults given by
+         * the module configuration. */
+
+        // Replication topology detection settings.
+
+        bool assume_unique_hostnames;   /* Are server hostnames consistent between MaxScale and servers */
+
+        int64_t failcount;      /* Number of ticks master must be down before it's considered
+                                 * totally down, allowing failover or master change. */
+
+        // Cluster operations activation settings
+
+        AutoFailover auto_failover;         /* Automatic master failover enabled? */
+
+        bool auto_rejoin;                   /* Automatic rejoin enabled? */
+        bool switchover_on_low_disk_space;  /* Automatically switch over a master low on disk space */
+        bool maintenance_on_low_disk_space; /* Automatically set slave and unreplicating servers low
+                                             * on disk space to maintenance. */
+        bool enforce_read_only_slaves;      /* If true, the monitor checks and enforces every tick
+                                             * that all slaves are in read-only-mode. */
+        bool enforce_read_only_servers;     /* Same as above, extended to all non-primary servers */
+        bool enforce_writable_master;       /* If true, set master writable if it's read-only. */
+        bool enforce_simple_topology;       /* Can the monitor assume and enforce a simple, 1-master
+                                             * and N slaves topology? Also allows unsafe failover */
+
+        /* Should all cluster modification commands require a majority of server locks?
+         * Used in multi-Maxscale situations. */
+        RequireLocks require_server_locks;
+
+        // Cluster operations additional settings
+        using seconds = std::chrono::seconds;
+        seconds failover_timeout;           /* Time limit in seconds for failover */
+        bool    verify_master_failure;      /* Is master failure is verified via slaves? */
+        seconds master_failure_timeout;     /* Master failure verification (via slaves) time in seconds */
+
+        std::vector<SERVER*> servers_no_promotion;      /* Servers which cannot be autoselected when deciding
+                                                         * which slave to promote during failover switchover.
+                                                         */
+
+        int64_t script_max_rlag;            /* Repl. lag limit for triggering custom event for script */
+
+        MariaDBServer::SharedSettings shared;   /* Settings required by MariaDBServer objects */
+
+        int64_t     cs_admin_port;      /* ColumnStore admin port. Assumed same on all servers. */
+        std::string cs_admin_base_path; /* ColumnStore rest-api base path */
+        std::string cs_admin_api_key;   /* ColumnStore rest-api key */
+
+        std::string          ssh_user;              /**< SSH username for accessing servers */
+        std::string          ssh_keyfile;           /**< SSH keyfile for accessing server */
+        bool                 ssh_host_check {true}; /**< Check that host is in known_hosts */
+        std::chrono::seconds ssh_timeout;           /**< SSH connection and command timeout */
+        int64_t              ssh_port {0};          /**< SSH port on all servers */
+        int64_t              rebuild_port {0};      /**< Listen port for server backup transfer */
+        std::string          mbu_use_memory;        /**< Given to mariabackup --prepare --use-memory=<val> */
+        int64_t              mbu_parallel {1};      /**< Given to mariabackup --parallel=<val> */
+        std::string          backup_storage_addr;   /**< Backup storage host */
+        std::string          backup_storage_path;   /**< Backup storage directory */
+
+        seconds     master_write_test_interval {0}; /**< How often to perform write test */
+        std::string master_write_test_table;        /**< Write test target table */
+
+        /** Action to take when write test fails. */
+        WriteTestFailAction write_test_fail_action {WriteTestFailAction::LOG};
+
+    private:
+        MariaDBMonitor* m_monitor;
+    };
+
+    Settings          m_settings;
+    ServerArray       m_excluded_servers;
+    mxb::http::Config m_http_config;    /* Http-configuration. Used for ColumnStore commands. */
+
+    // Base methods
+    MariaDBMonitor(const std::string& name, const std::string& module);
+    std::tuple<bool, std::string> prepare_to_stop() override;
+    void                          pre_loop() override;
+    void                          post_loop() override;
+
+    void reset_server_info();
+    void reset_node_index_info();
+    bool execute_manual_command(mon_op::CmdMethod command, const std::string& cmd_name,
+                                json_t** error_out);
+    bool schedule_manual_command(mon_op::CmdMethod command, const std::string& cmd_name,
+                                 json_t** error_out);
+    bool schedule_manual_command(mon_op::SOperation op, const std::string& cmd_name,
+                                 json_t** error_out);
+    bool start_long_running_op(mon_op::SOperation op, const std::string& cmd_name);
+    bool server_locks_in_use() const;
+    void execute_task_all_servers(const ServerFunction& task);
+    void execute_task_on_servers(const ServerFunction& task, const ServerArray& servers);
+
+    json_t*        to_json() const;
+    static json_t* to_json(State op);
+
+    MariaDBServer* get_server_by_addr(const EndPoint& srv_addr);
+    MariaDBServer* get_server(int64_t id);
+    MariaDBServer* get_server(mxs::MonitorServer* mon_server) const;
+    MariaDBServer* get_server(SERVER* server) const;
+
+    void save_monitor_specific_journal_data(mxb::Json& data) override;
+    void load_monitor_specific_journal_data(const mxb::Json& data) override;
+
+    // Cluster discovery and status assignment methods, top levels
+    void update_topology();
+    void build_replication_graph();
+    void update_master();
+    void assign_new_master(MariaDBServer* new_master);
+    void find_graph_cycles();
+    bool master_is_valid(std::string* reason_out);
+    void assign_server_roles();
+    void assign_slave_and_relay_master();
+    void check_cluster_operations_support();
+    bool try_acquire_locks_this_tick();
+    void update_cluster_lock_status();
+    int  get_free_locks();
+    bool is_slave_maxscale() const;
+
+    MariaDBServer* find_topology_master_server(RequireRunning req_running, std::string* msg_out = nullptr);
+    MariaDBServer* find_best_reach_server(const ServerArray& candidates);
+
+    // Cluster discovery and status assignment methods, low level
+    void tarjan_scc_visit_node(MariaDBServer* node, ServerArray* stack, int* index, int* cycle);
+    void calculate_node_reach(MariaDBServer* search_root);
+    int  running_slaves(MariaDBServer* search_root);
+    bool cycle_has_master_server(ServerArray& cycle_servers);
+    void update_gtid_domain();
+    void check_acquire_masterlock();
+    void update_master_cycle_info();
+    bool is_candidate_valid(MariaDBServer* cand, RequireRunning req_running, std::string* why_not = nullptr);
+
+    // Cluster operation launchers
+    mon_op::Result manual_switchover(SwitchoverType type, AfterDemotion after_demotion,
+                                     SERVER* new_master, SERVER* current_master);
+    mon_op::Result manual_failover(FailoverType fo_type);
+    mon_op::Result manual_rejoin(SERVER* rejoin_cand_srv);
+    mon_op::Result manual_reset_replication(SERVER* master_server);
+    mon_op::Result manual_release_locks();
+    void           handle_low_disk_space_master();
+    void           handle_auto_failover();
+    void           handle_auto_rejoin();
+    void           handle_master_write_test();
+
+    // ColumnStore operations
+    mon_op::Result manual_cs_add_node(const std::string& node_host, std::chrono::seconds timeout);
+    mon_op::Result manual_cs_remove_node(const std::string& node_host, std::chrono::seconds timeout);
+    mon_op::Result manual_cs_get_status();
+    mon_op::Result manual_cs_start_cluster(std::chrono::seconds timeout);
+    mon_op::Result manual_cs_stop_cluster(std::chrono::seconds timeout);
+    mon_op::Result manual_cs_set_readonly(std::chrono::seconds timeout);
+    mon_op::Result manual_cs_set_readwrite(std::chrono::seconds timeout);
+
+    enum class HttpCmd
+    {
+        GET, PUT, DELETE
+    };
+    using RestDataFields = std::vector<std::pair<std::string, std::string>>;
+    using CsRestResult = std::tuple<bool, std::string, mxb::Json>;
+    CsRestResult run_cs_rest_cmd(HttpCmd httcmd, const std::string& rest_cmd, const RestDataFields& data,
+                                 std::chrono::seconds cs_timeout);
+    static CsRestResult check_cs_rest_result(const mxb::http::Response& resp);
+
+    const MariaDBServer* slave_receiving_events(const MariaDBServer* demotion_target,
+                                                maxbase::Duration* event_age_out,
+                                                maxbase::Duration* delay_out) const;
+    std::unique_ptr<SwitchoverParams>
+    switchover_prepare(SwitchoverType type, AfterDemotion after_demotion, SERVER* new_master,
+                       SERVER* current_master, Log log_mode, OpStart start, mxb::Json& error_out);
+    std::unique_ptr<FailoverParams> failover_prepare(FailoverType fo_type, Log log_mode, OpStart start,
+                                                     mxb::Json& error_out);
+
+    bool switchover_perform(SwitchoverParams& operation);
+    bool failover_perform(FailoverParams& op);
+
+    void delay_auto_cluster_ops(Log log = Log::ON);
+    bool can_perform_cluster_ops();
+    bool cluster_ops_configured() const;
+    bool cluster_operations_disabled_short() const;
+    bool lock_status_is_ok() const;
+
+    // Methods used by failover/switchover/rejoin
+    MariaDBServer* select_promotion_target(MariaDBServer* demotion_target, OperationType op, Log log_mode,
+                                           int64_t* gtid_domain_out, mxb::Json& error_out);
+    bool is_candidate_better(const MariaDBServer* candidate, const MariaDBServer* current_best,
+                             const MariaDBServer* demotion_target, uint32_t gtid_domain,
+                             std::string* reason_out = nullptr);
+    bool server_is_excluded(const MariaDBServer* server);
+    bool check_gtid_replication(Log log_mode, const MariaDBServer* demotion_target,
+                                int64_t cluster_gtid_domain, mxb::Json& error_out);
+    int64_t guess_gtid_domain(MariaDBServer* demotion_target, const ServerArray& candidates,
+                              int* id_missing_out) const;
+
+    ServerArray get_redirectables(const MariaDBServer* old_master, const MariaDBServer* ignored_slave);
+
+    int redirect_slaves_ex(GeneralOpData& op,
+                           OperationType type,
+                           const MariaDBServer* promotion_target,
+                           const MariaDBServer* demotion_target,
+                           ServerArray* redirected_to_promo,
+                           ServerArray* redirected_to_demo);
+
+    void wait_cluster_stabilization(GeneralOpData& op, const ServerArray& slaves,
+                                    const MariaDBServer* new_master);
+
+    // Rejoin methods
+    bool     cluster_can_be_joined();
+    bool     get_joinable_servers(GeneralOpData& op, ServerArray* output);
+    bool     server_is_rejoin_suspect(GeneralOpData& op, MariaDBServer* rejoin_cand);
+    uint32_t do_rejoin(GeneralOpData& op, const ServerArray& joinable_servers);
+
+    void enforce_read_only();
+    void enforce_writable_on_master();
+    void set_low_disk_slaves_maintenance();
+
+    void calc_standard_wait_timeout();
+    int  calc_operation_wait_timeout(std::chrono::seconds base_op_timeout);
+    void maybe_set_wait_timeout_all_servers(std::chrono::seconds base_op_timeout);
+    void reset_wait_timeout_all_servers();
+
+    bool        post_configure();
+    friend bool Settings::post_configure(const std::map<std::string, mxs::ConfigParameters>& nested_params);
+    void        configured_servers_updated(const std::vector<SERVER*>& servers) override;
+};
+
+/**
+ * Generates a list of server names separated by ', '
+ *
+ * @param servers The servers
+ * @return Server names
+ */
+std::string monitored_servers_to_string(const ServerArray& servers);

--- a/server/modules/monitor/mysqlrepmon/mariadbmon_common.cc
+++ b/server/modules/monitor/mysqlrepmon/mariadbmon_common.cc
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018 MariaDB Corporation Ab
+ * Copyright (c) 2023 MariaDB plc, Finnish Branch
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file and at www.mariadb.com/bsl11.
+ *
+ * Change Date: 2027-09-09
+ *
+ * On the date above, in accordance with the Business Source License, use
+ * of this software will be governed by version 2 or later of the General
+ * Public License.
+ */
+
+#include "mariadbmon_common.hh"
+
+/** Default gtid domain */
+const int64_t GTID_DOMAIN_UNKNOWN = -1;
+/** Default port */
+const int PORT_UNKNOWN = 0;
+/** Server lock names */
+const char* SERVER_LOCK_NAME = "maxscale_mariadbmonitor";
+const char* MASTER_LOCK_NAME = "maxscale_mariadbmonitor_master";
+
+using std::string;
+
+DelimitedPrinter::DelimitedPrinter(string separator)
+    : m_separator(std::move(separator))
+{
+}
+
+void DelimitedPrinter::cat(string& target, const string& addition)
+{
+    target += m_current_separator + addition;
+    m_current_separator = m_separator;
+}
+
+void DelimitedPrinter::cat(const std::string& addition)
+{
+    cat(m_message, addition);
+    m_current_separator = m_separator;
+}
+
+std::string DelimitedPrinter::message() const
+{
+    return m_message;
+}

--- a/server/modules/monitor/mysqlrepmon/mariadbmon_common.hh
+++ b/server/modules/monitor/mysqlrepmon/mariadbmon_common.hh
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2018 MariaDB Corporation Ab
+ * Copyright (c) 2023 MariaDB plc, Finnish Branch
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file and at www.mariadb.com/bsl11.
+ *
+ * Change Date: 2027-09-09
+ *
+ * On the date above, in accordance with the Business Source License, use
+ * of this software will be governed by version 2 or later of the General
+ * Public License.
+ */
+#pragma once
+
+/**
+ * Common definitions for MariaDBMonitor module. Should be included in every header or source file.
+ */
+
+#define MXB_MODULE_NAME "mysqlrepmon"
+
+#include <maxscale/ccdefs.hh>
+
+#include <string>
+#include <maxscale/json_api.hh>
+
+/** Utility macros for printing both MXB_ERROR and json error */
+#define PRINT_MXS_JSON_ERROR(err_out, format, ...) \
+    do { \
+        MXB_ERROR(format, ##__VA_ARGS__); \
+        if (err_out) \
+        { \
+            *err_out = mxs_json_error_append(*err_out, format, ##__VA_ARGS__); \
+        } \
+    } while (false)
+
+#define PRINT_ERROR_IF(log_mode, err_out, format, ...) \
+    if (log_mode == Log::ON) \
+    { \
+        PRINT_JSON_ERROR(err_out, format, ##__VA_ARGS__); \
+    } \
+
+#define PRINT_JSON_ERROR(err_out, format, ...) \
+    do { \
+        MXB_ERROR(format, ##__VA_ARGS__); \
+        mxs_json_error_append(err_out, format, ##__VA_ARGS__); \
+    } while (false)
+
+extern const int64_t GTID_DOMAIN_UNKNOWN;
+constexpr int64_t CONN_ID_UNKNOWN = -1;     /** Default connection id */
+extern const int PORT_UNKNOWN;
+extern const char* const CN_HANDLE_EVENTS;
+extern const char* SERVER_LOCK_NAME;
+extern const char* MASTER_LOCK_NAME;
+
+constexpr char CN_ENFORCE_SIMPLE_TOPOLOGY[] = "enforce_simple_topology";
+
+constexpr char CONFIG_SSH_USER[] = "ssh_user";
+constexpr char CONFIG_SSH_KEYFILE[] = "ssh_keyfile";
+constexpr char CONFIG_BACKUP_ADDR[] = "backup_storage_address";
+constexpr char CONFIG_BACKUP_PATH[] = "backup_storage_path";
+
+// Helper class for concatenating strings with a delimiter.
+class DelimitedPrinter
+{
+public:
+    DelimitedPrinter(const DelimitedPrinter&) = delete;
+    DelimitedPrinter& operator=(const DelimitedPrinter&) = delete;
+    DelimitedPrinter() = delete;
+    explicit DelimitedPrinter(std::string separator);
+
+    /**
+     * Add to string.
+     *
+     * @param target String to modify
+     * @param addition String to add. The delimiter is printed before the addition.
+     */
+    void cat(std::string& target, const std::string& addition);
+
+    /**
+     * Add to internal string.
+     *
+     * @param addition The string to add.
+     */
+    void cat(const std::string& addition);
+
+    std::string message() const;
+
+private:
+    const std::string m_separator;
+    std::string       m_current_separator;
+    std::string       m_message;
+};

--- a/server/modules/monitor/mysqlrepmon/mariadbserver.cc
+++ b/server/modules/monitor/mysqlrepmon/mariadbserver.cc
@@ -1,0 +1,3451 @@
+/*
+ * Copyright (c) 2018 MariaDB Corporation Ab
+ * Copyright (c) 2023 MariaDB plc, Finnish Branch
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file and at www.mariadb.com/bsl11.
+ *
+ * Change Date: 2027-09-09
+ *
+ * On the date above, in accordance with the Business Source License, use
+ * of this software will be governed by version 2 or later of the General
+ * Public License.
+ */
+
+#include "mariadbserver.hh"
+
+#include <fstream>
+#include <cinttypes>
+#include <set>
+#include <map>
+#include <mutex>
+#include <algorithm>
+#include <cstdlib>
+#include <utility>
+#include <mysql.h>
+#include <mysqld_error.h>
+#include <maxbase/format.hh>
+#include <maxsql/mariadb.hh>
+#include <maxscale/protocol/mariadb/maxscale.hh>
+
+using std::string;
+using maxbase::string_printf;
+using maxbase::Duration;
+using maxbase::StopWatch;
+using maxbase::QueryResult;
+using Guard = std::lock_guard<std::mutex>;
+using maxscale::MonitorServer;
+using ConnectResult = maxscale::MonitorServer::ConnectResult;
+using GtidMode = SlaveStatus::Settings::GtidMode;
+using namespace std::chrono_literals;
+
+namespace
+{
+const char not_a_db[] = "it is not a valid database.";
+const string grant_test_query = "SHOW SLAVE STATUS;";
+// MySQL 8.4 removed "SHOW SLAVE STATUS"; the equivalent permission test uses the new spelling.
+const string grant_test_query_mysql = "SHOW REPLICA STATUS;";
+
+// --- MySQL GTID support -----------------------------------------------------------------------------
+// MySQL GTIDs are "server_uuid:interval[:interval]" sets, e.g.
+//   "3E11FA47-71CA-11E1-9E33-C80AA9429562:1-5:8-10,A1B2...:1-3".
+// The mariadbmon failover/switchover engine is built around MariaDB GtidLists
+// ("domain-server_id-sequence"). To reuse that engine unchanged, every distinct server_uuid is mapped
+// to a stable synthetic "domain" id and the highest transaction number seen for that uuid becomes the
+// "sequence". This preserves the only properties the engine relies on: per-origin ordering and
+// "who is furthest ahead". The mapping is process-wide and stable across monitor ticks and servers.
+std::mutex uuid_domain_lock;
+std::map<std::string, uint32_t> uuid_domain_map;
+
+uint32_t synth_domain_for_uuid(const std::string& uuid)
+{
+    std::lock_guard<std::mutex> guard(uuid_domain_lock);
+    auto it = uuid_domain_map.find(uuid);
+    if (it != uuid_domain_map.end())
+    {
+        return it->second;
+    }
+    uint32_t d = (uint32_t)uuid_domain_map.size() + 1;      // domains start at 1
+    uuid_domain_map[uuid] = d;
+    return d;
+}
+
+// Convert a MySQL GTID set string into an equivalent synthetic MariaDB GtidList string
+// ("domain-domain-maxseq,..."). Returns an empty string for an empty/invalid set.
+std::string mysql_gtid_to_synthetic(const std::string& mysql_set)
+{
+    std::string s = mysql_set;
+    s.erase(std::remove_if(s.begin(), s.end(),
+                           [](char c) {
+                               return c == '\n' || c == '\r' || c == ' ' || c == '\t';
+                           }), s.end());
+    std::string out;
+    size_t pos = 0;
+    while (pos < s.size())
+    {
+        size_t comma = s.find(',', pos);
+        std::string block = s.substr(pos, comma == std::string::npos ? std::string::npos : comma - pos);
+        pos = (comma == std::string::npos) ? s.size() : comma + 1;
+        if (block.empty())
+        {
+            continue;
+        }
+        size_t colon = block.find(':');
+        if (colon == std::string::npos)
+        {
+            continue;
+        }
+        std::string uuid = block.substr(0, colon);
+        std::string intervals = block.substr(colon + 1);
+        uint64_t maxseq = 0;
+        size_t ip = 0;
+        while (ip < intervals.size())
+        {
+            size_t c2 = intervals.find(':', ip);
+            std::string iv = intervals.substr(ip, c2 == std::string::npos ? std::string::npos : c2 - ip);
+            ip = (c2 == std::string::npos) ? intervals.size() : c2 + 1;
+            if (iv.empty())
+            {
+                continue;
+            }
+            size_t dash = iv.find('-');
+            const char* endp = (dash == std::string::npos) ? iv.c_str() : iv.c_str() + dash + 1;
+            uint64_t end = strtoull(endp, nullptr, 10);
+            if (end > maxseq)
+            {
+                maxseq = end;
+            }
+        }
+        uint32_t domain = synth_domain_for_uuid(uuid);
+        if (!out.empty())
+        {
+            out += ",";
+        }
+        out += std::to_string(domain) + "-" + std::to_string(domain) + "-" + std::to_string(maxseq);
+    }
+    return out;
+}
+}
+
+MariaDBServer::MariaDBServer(SERVER* server, int config_index,
+                             const MonitorServer::SharedSettings& base_settings,
+                             const MariaDBServer::SharedSettings& settings)
+    : MariaServer(server, base_settings)
+    , m_config_index(config_index)
+    , m_settings(settings)
+{
+}
+
+NodeData::NodeData()
+    : index(INDEX_NOT_VISITED)
+    , lowest_index(INDEX_NOT_VISITED)
+    , in_stack(false)
+    , cycle(CYCLE_NONE)
+    , reach(REACH_UNKNOWN)
+{
+}
+
+void NodeData::reset_results()
+{
+    cycle = CYCLE_NONE;
+    parents.clear();
+    parents_failed.clear();
+    children.clear();
+    children_failed.clear();
+    external_masters.clear();
+}
+
+void NodeData::reset_indexes()
+{
+    index = INDEX_NOT_VISITED;
+    lowest_index = INDEX_NOT_VISITED;
+    in_stack = false;
+}
+
+uint64_t MariaDBServer::relay_log_events(const SlaveStatus& slave_conn) const
+{
+    /* The events_ahead-call below ignores domains where current_pos is ahead of io_pos. This situation is
+     * rare but is possible (I guess?) if the server is replicating a domain from multiple masters
+     * and decides to process events from one relay log before getting new events to the other. In
+     * any case, such events are obsolete and the server can be considered to have processed such logs. */
+    return slave_conn.gtid_io_pos.events_ahead(m_gtid_current_pos, GtidList::MISSING_DOMAIN_IGNORE);
+}
+
+/**
+ * Execute a query which does not return data. If the query returns data, an error is returned.
+ *
+ * @param cmd The query
+ * @param masked_cmd Optional logged version of the query
+ * @param mode Retry a failed query using the global query retry settings or not
+ * @param errmsg_out Error output.
+ * @return True on success, false on error or if query returned data
+ */
+bool MariaDBServer::execute_cmd_ex(const string& cmd, const std::string& masked_cmd, QueryRetryMode mode,
+                                   std::string* errmsg_out, unsigned int* errno_out)
+{
+    auto conn = con;
+    bool query_success = false;
+    if (mode == QueryRetryMode::ENABLED)
+    {
+        query_success = (mxs_mysql_query(conn, cmd.c_str()) == 0);
+    }
+    else
+    {
+        query_success = (maxsql::mysql_query_ex(conn, cmd, 0, 0) == 0);
+    }
+
+    auto& logged_query = masked_cmd.empty() ? cmd : masked_cmd;
+    bool rval = false;
+    if (query_success)
+    {
+        // In case query was a multiquery, loop for more resultsets. Error message is produced from first
+        // non-empty resultset and does not specify the subquery.
+        string results_errmsg;
+        do
+        {
+            MYSQL_RES* result = mysql_store_result(conn);
+            if (result)
+            {
+                unsigned int cols = mysql_num_fields(result);
+                my_ulonglong rows = mysql_num_rows(result);
+                if (results_errmsg.empty())
+                {
+                    results_errmsg = string_printf("Query '%s' on '%s' returned %u columns and %llu rows "
+                                                   "of data when none was expected.",
+                                                   logged_query.c_str(), name(), cols, rows);
+                }
+            }
+        }
+        while (mysql_next_result(conn) == 0);
+
+        if (results_errmsg.empty())
+        {
+            rval = true;
+        }
+    }
+    else
+    {
+        auto error_num = mysql_errno(conn);
+        if (errno_out)
+        {
+            *errno_out = error_num;
+        }
+
+        if (error_num == ER_SPECIFIC_ACCESS_DENIED_ERROR || error_num == ER_KILL_DENIED_ERROR)
+        {
+            // Monitor did not have grants for this command. Should reconnect at the start of the next
+            // monitor loop in case user has added the grant. Not reconnecting here to avoid losing
+            // connection state.
+            m_cmd_grant_fail = true;
+            if (errmsg_out)
+            {
+                *errmsg_out = string_printf(
+                    "Query '%s' failed on '%s': '%s' (%i). Monitor lacks the required privileges for the "
+                    "operation. Please GRANT '%s' the appropriate privileges. Then, either restart the "
+                    "monitor ('maxctrl stop monitor %s' and 'maxctrl start monitor %s') or retry "
+                    "the operation twice.",
+                    logged_query.c_str(), name(), mysql_error(conn), error_num,
+                    conn_settings().username.c_str(), monitor_name(), monitor_name());
+            }
+        }
+        else if (errmsg_out)
+        {
+            *errmsg_out = string_printf("Query '%s' failed on '%s': '%s' (%i).",
+                                        logged_query.c_str(), name(), mysql_error(conn), error_num);
+        }
+    }
+    return rval;
+}
+
+bool MariaDBServer::execute_cmd(const std::string& cmd, std::string* errmsg_out)
+{
+    return execute_cmd_ex(cmd, "", QueryRetryMode::ENABLED, errmsg_out);
+}
+
+bool MariaDBServer::execute_cmd_no_retry(const std::string& cmd, const std::string& masked_cmd,
+                                         std::string* errmsg_out, unsigned int* errno_out)
+{
+    return execute_cmd_ex(cmd, masked_cmd, QueryRetryMode::DISABLED, errmsg_out, errno_out);
+}
+
+/**
+ * Execute a query which does not return data. If the query fails because of a network error
+ * (e.g. Connector-C timeout), automatically retry the query until time is up. Uses max_statement_time
+ * when available to ensure no lingering timed out commands are left on the server.
+ *
+ * @param cmd The query to execute. Should be a query with a predictable effect even when retried or
+ * ran several times.
+ * @param time_limit How long to retry. This does not overwrite the connector-c timeouts which are always
+ * respected.
+ * @param errmsg_out Error message output
+ * @param errnum_out Error number output
+ * @return True, if successful.
+ */
+bool MariaDBServer::execute_cmd_time_limit(const std::string& cmd, maxbase::Duration time_limit,
+                                           string* errmsg_out, unsigned int* errnum_out)
+{
+    return execute_cmd_time_limit(cmd, "", time_limit, errmsg_out, errnum_out);
+}
+
+bool MariaDBServer::execute_cmd_time_limit(const string& cmd, const string& masked_cmd,
+                                           maxbase::Duration time_limit,
+                                           string* errmsg_out, unsigned int* errnum_out)
+{
+    auto build_cmds = [this, &cmd, &masked_cmd](mxb::Duration time_lim) -> std::tuple<string, string> {
+        string max_stmt_time;
+        if (m_capabilities.max_statement_time)
+        {
+            // The effective statement timeout should be <= connector timeout, but not much greater than
+            // total time limit.
+            int conn_to = -1;
+            MXB_AT_DEBUG(int rv = ) mysql_get_optionv(con, MYSQL_OPT_READ_TIMEOUT, &conn_to);
+            mxb_assert(rv == 0);
+            // Even if time has effectively run out, give an individual query a few seconds to complete.
+            auto time_lim_s = std::max(round_to_seconds(time_lim), 5);
+
+            int eff_stmt_time = -1;
+            if (conn_to <= 0)
+            {
+                eff_stmt_time = time_lim_s;
+            }
+            else if (conn_to <= 4)
+            {
+                // Should not happen with switchover, but perhaps can happen with some other operation.
+                eff_stmt_time = conn_to;
+            }
+            else
+            {
+                // Use a statement timeout a bit smaller than hard connector timeout to ensure it's hit first.
+                eff_stmt_time = std::min(conn_to - 1, time_lim_s);
+            }
+            max_stmt_time = string_printf("SET STATEMENT max_statement_time=%i FOR ", eff_stmt_time);
+        }
+
+        string complete_cmd = max_stmt_time;
+        complete_cmd.append(cmd);
+
+        string complete_masked_cmd;
+        if (!masked_cmd.empty())
+        {
+            complete_masked_cmd.append(max_stmt_time).append(masked_cmd);
+        }
+        return {std::move(complete_cmd), std::move(complete_masked_cmd)};
+    };
+
+    StopWatch timer;
+
+    // If a query lasts less than 1s, sleep so that at most 1 query/s is sent.
+    // This prevents busy-looping when faced with some network errors.
+    const Duration min_query_time {1s};
+
+    // Even if time is up, try at least once.
+    bool cmd_success = false;
+    bool keep_trying = true;
+    do
+    {
+        auto time_remaining = time_limit - timer.split();
+        auto [complete_cmd, complete_masked_cmd] = build_cmds(time_remaining);
+        StopWatch query_timer;
+        string error_msg;
+        unsigned int errornum = 0;
+        cmd_success = execute_cmd_no_retry(complete_cmd, complete_masked_cmd, &error_msg, &errornum);
+        auto query_time = query_timer.lap();
+
+        // Check if there is time to retry.
+        time_remaining -= query_time;
+        bool net_error = maxsql::mysql_is_net_error(errornum);
+        keep_trying = (time_remaining.count() > 0)
+            // Either a connector-c timeout or query was interrupted by max_statement_time.
+            && (net_error || (m_capabilities.max_statement_time && errornum == ER_STATEMENT_TIMEOUT));
+
+        if (!cmd_success)
+        {
+            if (keep_trying)
+            {
+                string retrying = string_printf("Retrying with %.1f seconds left.",
+                                                mxb::to_secs(time_remaining));
+                if (net_error)
+                {
+                    MXB_WARNING("%s %s", error_msg.c_str(), retrying.c_str());
+                }
+                else
+                {
+                    // Timed out because of max_statement_time.
+                    auto& logged_query = complete_masked_cmd.empty() ? complete_cmd : complete_masked_cmd;
+                    MXB_WARNING("Query '%s' timed out on '%s'. %s",
+                                logged_query.c_str(), name(), retrying.c_str());
+                }
+
+                if (query_time < min_query_time)
+                {
+                    Duration query_sleep = min_query_time - query_time;
+                    Duration this_sleep = std::min(time_remaining, query_sleep);
+                    std::this_thread::sleep_for(this_sleep);
+                }
+            }
+            else
+            {
+                if (errmsg_out)
+                {
+                    *errmsg_out = error_msg;
+                }
+                if (errnum_out)
+                {
+                    *errnum_out = errornum;
+                }
+            }
+        }
+    }
+    while (!cmd_success && keep_trying);
+    return cmd_success;
+}
+
+bool MariaDBServer::do_show_slave_status(string* errmsg_out)
+{
+    string query;
+    bool all_slaves_status = false;
+    // MySQL 8.0.22+ uses the "REPLICA" command vocabulary and renamed the SHOW SLAVE STATUS columns
+    // (Master_* -> Source_*, Slave_*_Running -> Replica_*_Running, Seconds_Behind_Master ->
+    // Seconds_Behind_Source). MySQL 8.4 removed the legacy "SLAVE" spelling completely.
+    const bool mysql_replica = m_capabilities.mysql_replica_syntax;
+    if (m_capabilities.slave_status_all)
+    {
+        all_slaves_status = true;
+        query = "SHOW ALL SLAVES STATUS;";
+    }
+    else if (mysql_replica)
+    {
+        query = "SHOW REPLICA STATUS;";
+    }
+    else if (m_capabilities.basic_support)
+    {
+        query = "SHOW SLAVE STATUS;";
+    }
+    else
+    {
+        mxb_assert(!true);      // This method should not be called for versions < 5.5
+        return false;
+    }
+
+    auto result = execute_query(query, errmsg_out);
+    if (!result)
+    {
+        return false;
+    }
+
+    // Column names differ between the MariaDB ("Master_*"/"Slave_*") and the MySQL 8.0.22+
+    // ("Source_*"/"Replica_*") replication dialects.
+    const char* col_master_host = mysql_replica ? "Source_Host" : "Master_Host";
+    const char* col_master_port = mysql_replica ? "Source_Port" : "Master_Port";
+    const char* col_io_running = mysql_replica ? "Replica_IO_Running" : "Slave_IO_Running";
+    const char* col_sql_running = mysql_replica ? "Replica_SQL_Running" : "Slave_SQL_Running";
+    const char* col_master_server_id = mysql_replica ? "Source_Server_Id" : "Master_Server_Id";
+    const char* col_seconds_behind = mysql_replica ? "Seconds_Behind_Source" : "Seconds_Behind_Master";
+
+    // Fields common to all server versions
+    auto i_master_host = result->get_col_index(col_master_host);
+    auto i_master_port = result->get_col_index(col_master_port);
+    auto i_slave_io_running = result->get_col_index(col_io_running);
+    auto i_slave_sql_running = result->get_col_index(col_sql_running);
+    auto i_master_server_id = result->get_col_index(col_master_server_id);
+    auto i_last_io_errno = result->get_col_index("Last_IO_Errno");
+    auto i_last_io_error = result->get_col_index("Last_IO_Error");
+    auto i_last_sql_error = result->get_col_index("Last_SQL_Error");
+    auto i_seconds_behind_master = result->get_col_index(col_seconds_behind);
+
+    const char INVALID_DATA[] = "'%s' returned invalid data.";
+    if (i_master_host < 0 || i_master_port < 0 || i_slave_io_running < 0 || i_slave_sql_running < 0
+        || i_master_server_id < 0 || i_last_io_errno < 0 || i_last_io_error < 0 || i_last_sql_error < 0
+        || i_seconds_behind_master < 0)
+    {
+        MXB_ERROR(INVALID_DATA, query.c_str());
+        return false;
+    }
+
+    int64_t i_connection_name = -1, i_slave_rec_hbs = -1, i_slave_hb_period = -1;
+    int64_t i_using_gtid = -1, i_gtid_io_pos = -1;
+    int64_t i_retrieved_gtid = -1, i_executed_gtid = -1;
+    if (all_slaves_status)
+    {
+        i_connection_name = result->get_col_index("Connection_name");
+        i_slave_rec_hbs = result->get_col_index("Slave_received_heartbeats");
+        i_slave_hb_period = result->get_col_index("Slave_heartbeat_period");
+        i_using_gtid = result->get_col_index("Using_Gtid");
+        i_gtid_io_pos = result->get_col_index("Gtid_IO_Pos");
+        if (i_connection_name < 0 || i_slave_rec_hbs < 0 || i_slave_hb_period < 0
+            || i_using_gtid < 0 || i_gtid_io_pos < 0)
+        {
+            MXB_ERROR(INVALID_DATA, query.c_str());
+            return false;
+        }
+    }
+    else if (mysql_replica)
+    {
+        // MySQL "SHOW REPLICA STATUS" returns one row per replication channel. The default channel
+        // name is empty, which matches the default (unnamed) MariaDB connection.
+        i_connection_name = result->get_col_index("Channel_Name");
+        // Retrieved_Gtid_Set = GTIDs received into the relay log (= MariaDB's Gtid_IO_Pos);
+        // Executed_Gtid_Set = GTIDs already applied. Used to gauge how far this replica has progressed.
+        i_retrieved_gtid = result->get_col_index("Retrieved_Gtid_Set");
+        i_executed_gtid = result->get_col_index("Executed_Gtid_Set");
+    }
+
+    SlaveStatusArray slave_status_new;
+    bool parse_error = false;
+    while (result->next_row())
+    {
+        SlaveStatus new_row(name());
+        new_row.settings.master_endpoint = EndPoint(result->get_string(i_master_host),
+                                                    result->get_int(i_master_port));
+        new_row.last_io_errno = result->get_int(i_last_io_errno);
+        new_row.last_io_error = result->get_string(i_last_io_error);
+        new_row.last_sql_error = result->get_string(i_last_sql_error);
+
+        new_row.slave_io_running =
+            SlaveStatus::slave_io_from_string(result->get_string(i_slave_io_running));
+        new_row.slave_sql_running = (result->get_string(i_slave_sql_running) == "Yes");
+        new_row.master_server_id = result->get_int(i_master_server_id);
+
+        // If slave connection is stopped, the value given by the backend is null.
+        if (result->field_is_null(i_seconds_behind_master))
+        {
+            new_row.seconds_behind_master = mxs::Target::RLAG_UNDEFINED;
+        }
+        else
+        {
+            // Seconds_Behind_Master is actually uint64, but it will take a long time until it goes over
+            // int64 limit.
+            new_row.seconds_behind_master = result->get_int(i_seconds_behind_master);
+        }
+
+        if (all_slaves_status)
+        {
+            new_row.settings.name = result->get_string(i_connection_name);
+            new_row.received_heartbeats = result->get_int(i_slave_rec_hbs);
+
+            string using_gtid = result->get_string(i_using_gtid);
+            if (strcasecmp(using_gtid.c_str(), "Current_Pos") == 0)
+            {
+                new_row.settings.gtid_mode = GtidMode::CURRENT;
+            }
+            else if (strcasecmp(using_gtid.c_str(), "Slave_Pos") == 0)
+            {
+                new_row.settings.gtid_mode = GtidMode::SLAVE;
+            }
+
+            string gtid_io_pos = result->get_string(i_gtid_io_pos);
+            if (!gtid_io_pos.empty() && new_row.settings.gtid_mode != GtidMode::NONE)
+            {
+                new_row.gtid_io_pos = GtidList::from_string(gtid_io_pos);
+            }
+        }
+        else if (mysql_replica)
+        {
+            if (i_connection_name >= 0)
+            {
+                new_row.settings.name = result->get_string(i_connection_name);
+            }
+            // The MySQL module always drives replication with SOURCE_AUTO_POSITION=1, i.e. GTID mode.
+            // Map it to CURRENT so the engine treats this as a GTID-based connection.
+            new_row.settings.gtid_mode = GtidMode::CURRENT;
+
+            // gtid_io_pos = GTIDs in the relay log. Prefer Retrieved_Gtid_Set; if the IO thread has not
+            // retrieved anything this session yet, fall back to Executed_Gtid_Set so the position is not
+            // spuriously empty (an empty gtid_io_pos would block this replica from being promoted).
+            string io_set;
+            if (i_retrieved_gtid >= 0)
+            {
+                io_set = mysql_gtid_to_synthetic(result->get_string(i_retrieved_gtid));
+            }
+            if (io_set.empty() && i_executed_gtid >= 0)
+            {
+                io_set = mysql_gtid_to_synthetic(result->get_string(i_executed_gtid));
+            }
+            if (!io_set.empty())
+            {
+                new_row.gtid_io_pos = GtidList::from_string(io_set);
+            }
+        }
+
+        // If parsing fails, discard all query results.
+        if (result->error())
+        {
+            parse_error = true;
+            MXB_ERROR("Query '%s' returned invalid data: %s", query.c_str(), result->error_string().c_str());
+            break;
+        }
+
+        // Before adding this row to the SlaveStatus array, compare the row to the one from the previous
+        // monitor tick and fill in the last pieces of data.
+        auto old_row = sstatus_find_previous_row(new_row, slave_status_new.size());
+        if (old_row)
+        {
+            // When the new row was created, 'last_data_time' was set to the current time. If it seems
+            // like the slave is not receiving data from the master, set the time to the one
+            // in the previous monitor tick.
+            if (new_row.received_heartbeats == old_row->received_heartbeats
+                && new_row.gtid_io_pos == old_row->gtid_io_pos)
+            {
+                new_row.last_data_time = old_row->last_data_time;
+            }
+
+            // Copy master server pointer from old row. If this line is not reached because old row does
+            // not exist, then the topology rebuild will set the master pointer.
+            new_row.master_server = old_row->master_server;
+        }
+
+        // Finally, set the connection status.
+        if (new_row.slave_io_running == SlaveStatus::SLAVE_IO_YES)
+        {
+            mxb_assert(new_row.master_server_id > 0);
+            new_row.seen_connected = true;
+        }
+        else if (new_row.slave_io_running == SlaveStatus::SLAVE_IO_CONNECTING && old_row)
+        {
+            // Old connection data found. Even in this case the server id:s could be wrong if the
+            // slave connection was cleared and remade between monitor loops.
+            if (new_row.master_server_id == old_row->master_server_id && old_row->seen_connected)
+            {
+                new_row.seen_connected = true;
+            }
+        }
+
+        // Row complete, add it to the array.
+        slave_status_new.push_back(new_row);
+    }
+
+    if (!parse_error)
+    {
+        // Compare the previous array to the new one.
+        if (!sstatus_array_topology_equal(slave_status_new))
+        {
+            m_topology_changed = true;
+        }
+
+        // Always write to m_slave_status. Even if the new status is equal by topology,
+        // gtid:s etc may have changed.
+        Guard guard(m_arraylock);
+        m_old_slave_status = std::move(m_slave_status);
+        m_slave_status = std::move(slave_status_new);
+    }
+
+    return !parse_error;
+}
+
+bool MariaDBServer::update_gtids(string* errmsg_out)
+{
+    // MySQL exposes the executed/purged GTID sets, not MariaDB's gtid_current_pos/gtid_binlog_pos.
+    // gtid_executed is the set this server has applied; with log_replica_updates it is also what the
+    // server has in its own binlog, so it serves as both current_pos and binlog_pos for the engine.
+    static const string query = "SELECT @@global.gtid_executed, @@global.gtid_purged;";
+    const int i_current_pos = 0;
+    const int i_binlog_pos = 0;     // same column: MySQL has a single executed set
+
+    bool rval = false;
+    auto result = execute_query(query, errmsg_out);
+    if (result)
+    {
+        GtidList current_pos;
+        GtidList binlog_pos;
+
+        if (result->next_row())
+        {
+            // Query returned at least some data.
+            auto current_str = mysql_gtid_to_synthetic(result->get_string(i_current_pos));
+            auto binlog_str = mysql_gtid_to_synthetic(result->get_string(i_binlog_pos));
+            if (!current_str.empty())
+            {
+                current_pos = GtidList::from_string(current_str);
+            }
+
+            if (!binlog_str.empty())
+            {
+                binlog_pos = GtidList::from_string(binlog_str);
+            }
+        }
+        else
+        {
+            // Query succeeded but returned 0 rows. This means that the server has no gtid:s. Write defaults.
+        }
+
+        rval = true;
+        if (!(current_pos == m_gtid_current_pos && binlog_pos == m_gtid_binlog_pos))
+        {
+            // Gtid:s changed. If the new current_pos is valid, save it to server.
+            if (!current_pos.empty())
+            {
+                std::vector<std::pair<uint32_t, uint64_t>> positions;
+                const auto& triplets = current_pos.triplets();
+                positions.reserve(triplets.size());
+                for (const auto& gtid : triplets)
+                {
+                    positions.emplace_back(gtid.m_domain, gtid.m_sequence);
+                }
+                server->set_gtid_list(positions);
+            }
+
+            Guard guard(m_arraylock);
+            m_gtid_current_pos = std::move(current_pos);
+            m_gtid_binlog_pos = std::move(binlog_pos);
+        }
+    }   // If query failed, do not update gtid:s.
+    return rval;
+}
+
+bool MariaDBServer::update_replication_settings(std::string* errmsg_out)
+{
+    // MySQL has no gtid_strict_mode, and log_slave_updates was renamed log_replica_updates (the legacy
+    // name was removed in 8.4). enforce_gtid_consistency is the closest analogue to strict mode.
+    const string query = "SELECT @@enforce_gtid_consistency, @@log_bin, @@log_replica_updates;";
+    bool rval = false;
+
+    auto result = execute_query(query, errmsg_out);
+    if (result && result->next_row())
+    {
+        rval = true;
+        // enforce_gtid_consistency is an enum ('OFF'/'ON'/'WARN'); treat ON as strict.
+        m_rpl_settings.gtid_strict_mode = (result->get_string(0) == "ON");
+        m_rpl_settings.log_bin = result->get_bool(1);
+        m_rpl_settings.log_slave_updates = result->get_bool(2);
+    }
+    return rval;
+}
+
+bool MariaDBServer::read_server_variables(string* errmsg_out)
+{
+    // MySQL has no gtid_domain_id. Instead, every server's own server_uuid is mapped to a stable
+    // synthetic domain id, which becomes the cluster "GTID domain" (the primary's uuid-domain) used by
+    // the promotion/catchup engine. read_only is read here; super_read_only is handled at promote/demote.
+    const string query_no_gtid = "SELECT @@global.server_id, @@read_only;";
+    const string query_with_gtid = "SELECT @@global.server_id, @@read_only, @@global.server_uuid;";
+    const bool use_gtid = m_capabilities.gtid;
+    const string& query = use_gtid ? query_with_gtid : query_no_gtid;
+
+    int i_id = 0;
+    int i_ro = 1;
+    int i_domain = 2;
+    bool rval = false;
+    auto result = execute_query(query, errmsg_out);
+    if (result != nullptr)
+    {
+        if (!result->next_row())
+        {
+            // This should not really happen, means that server is buggy.
+            *errmsg_out = string_printf("Query '%s' did not return any rows.", query.c_str());
+        }
+        else
+        {
+            int64_t server_id_parsed = result->get_int(i_id);
+            bool read_only_parsed = result->get_bool(i_ro);
+            int64_t domain_id_parsed = GTID_DOMAIN_UNKNOWN;
+            if (use_gtid)
+            {
+                // MySQL: derive the synthetic GTID domain from this server's server_uuid.
+                string server_uuid = result->get_string(i_domain);
+                if (!server_uuid.empty())
+                {
+                    domain_id_parsed = synth_domain_for_uuid(server_uuid);
+                }
+            }
+
+            if (result->error())
+            {
+                // This is unlikely as well.
+                *errmsg_out = string_printf("Query '%s' returned invalid data: %s",
+                                            query.c_str(), result->error_string().c_str());
+            }
+            else
+            {
+                // All values parsed and within expected limits.
+                rval = true;
+                if (server_id_parsed != m_server_id)
+                {
+                    m_server_id = server_id_parsed;
+                    m_topology_changed = true;
+                }
+                node_id = server_id_parsed;
+
+                if (read_only_parsed != m_read_only)
+                {
+                    m_read_only = read_only_parsed;
+                    m_topology_changed = true;
+                }
+
+                m_gtid_domain_id = domain_id_parsed;
+            }
+        }
+    }
+    return rval;
+}
+
+void MariaDBServer::check_semisync_master_status()
+{
+    if (server_type() == ServerType::MYSQL)
+    {
+        m_ss_status = SemiSyncStatus::UNKNOWN;
+        return;
+    }
+
+    // MySQL 8.0.26+ renamed the semi-sync "master" plugin variables to "source".
+    const char* query = m_capabilities.mysql_replica_syntax ?
+        "SELECT c.VARIABLE_VALUE, s.VARIABLE_VALUE FROM "
+        "INFORMATION_SCHEMA.GLOBAL_VARIABLES c JOIN INFORMATION_SCHEMA.GLOBAL_STATUS s "
+        "ON(c.VARIABLE_NAME = 'rpl_semi_sync_source_enabled' AND s.VARIABLE_NAME = 'rpl_semi_sync_source_status')"
+        :
+        "SELECT c.VARIABLE_VALUE, s.VARIABLE_VALUE FROM "
+        "INFORMATION_SCHEMA.GLOBAL_VARIABLES c JOIN INFORMATION_SCHEMA.GLOBAL_STATUS s "
+        "ON(c.VARIABLE_NAME = 'rpl_semi_sync_master_enabled' AND s.VARIABLE_NAME = 'rpl_semi_sync_master_status')";
+    std::string errmsg;
+
+    if (auto result = execute_query(query, &errmsg))
+    {
+        if (!result->next_row())
+        {
+            // This should not really happen, means that server is buggy.
+            MXB_WARNING("Query '%s' did not return any rows.", query);
+            m_ss_status = SemiSyncStatus::UNKNOWN;
+        }
+        else if (result->get_string(0) == "ON")
+        {
+            // Semi-sync is enabled
+            auto old_ss_status = m_ss_status;
+            m_ss_status = result->get_string(1) == "ON" ? SemiSyncStatus::ON : SemiSyncStatus::OFF;
+
+            if (old_ss_status == SemiSyncStatus::ON && m_ss_status == SemiSyncStatus::OFF)
+            {
+                MXB_WARNING("Semi-synchronous replication on server '%s' has stopped working. "
+                            "Transactions may be lost if a failover occurs.", name());
+            }
+            else if (old_ss_status == SemiSyncStatus::OFF && m_ss_status == SemiSyncStatus::ON)
+            {
+                MXB_NOTICE("Semi-synchronous replication on server '%s' is working again.", name());
+            }
+        }
+        else
+        {
+            m_ss_status = SemiSyncStatus::UNKNOWN;
+        }
+    }
+    else
+    {
+        MXB_WARNING("Failed to query semi-sync status of server '%s': %s", name(), errmsg.c_str());
+        m_ss_status = SemiSyncStatus::UNKNOWN;
+    }
+}
+
+void MariaDBServer::warn_replication_settings() const
+{
+    const char* servername = name();
+    if (m_rpl_settings.gtid_strict_mode == false)
+    {
+        const char NO_STRICT[] =
+            "Replica '%s' has gtid_strict_mode disabled. Enabling this setting is recommended. "
+            "For more information, see https://mariadb.com/kb/en/library/gtid/#gtid_strict_mode";
+        MXB_WARNING(NO_STRICT, servername);
+    }
+    if (m_rpl_settings.log_slave_updates == false)
+    {
+        const char NO_SLAVE_UPDATES[] =
+            "Replica '%s' has log_slave_updates disabled. It is a valid candidate but replication "
+            "will break for lagging replicas if '%s' is promoted.";
+        MXB_WARNING(NO_SLAVE_UPDATES, servername, servername);
+    }
+}
+
+bool MariaDBServer::catchup_to_master(GeneralOpData& op, const GtidList& target)
+{
+    /* Prefer to use gtid_binlog_pos, as that is more reliable. But if log_slave_updates is not on,
+     * use gtid_current_pos. */
+    const bool use_binlog_pos = m_rpl_settings.log_bin && m_rpl_settings.log_slave_updates;
+    bool time_is_up = false;    // Check at least once.
+    bool gtid_reached = false;
+    bool error = false;
+    auto& error_out = op.error_out;
+
+    Duration sleep_time(200ms);     // How long to sleep before next iteration. Incremented slowly.
+    StopWatch timer;
+
+    while (!time_is_up && !gtid_reached && !error)
+    {
+        string error_msg;
+        if (update_gtids(&error_msg))
+        {
+            const GtidList& compare_to = use_binlog_pos ? m_gtid_binlog_pos : m_gtid_current_pos;
+            if (target.events_ahead(compare_to, GtidList::MISSING_DOMAIN_IGNORE) == 0)
+            {
+                gtid_reached = true;
+            }
+            else
+            {
+                // Query was successful but target gtid not yet reached. Check how much time left.
+                op.time_remaining -= timer.lap();
+                if (op.time_remaining.count() > 0)
+                {
+                    // Sleep for a moment, then try again.
+                    Duration this_sleep = std::min(sleep_time, op.time_remaining);
+                    std::this_thread::sleep_for(this_sleep);
+                    sleep_time += 100ms;    // Sleep a bit more next iteration.
+                }
+                else
+                {
+                    time_is_up = true;
+                }
+            }
+        }
+        else
+        {
+            error = true;
+            PRINT_JSON_ERROR(error_out, "Failed to update gtid on '%s' while waiting for catchup: %s",
+                             name(), error_msg.c_str());
+        }
+    }
+
+    if (!error && !gtid_reached)
+    {
+        PRINT_JSON_ERROR(error_out, "Replica catchup timed out on replica '%s'.", name());
+    }
+    return gtid_reached;
+}
+
+bool MariaDBServer::binlog_on() const
+{
+    return m_rpl_settings.log_bin;
+}
+
+bool MariaDBServer::is_master() const
+{
+    return status_is_master(m_pending_status);
+}
+
+bool MariaDBServer::is_slave() const
+{
+    return status_is_slave(m_pending_status);
+}
+
+bool MariaDBServer::is_usable() const
+{
+    return status_is_usable(m_pending_status);
+}
+
+bool MariaDBServer::is_running() const
+{
+    return status_is_running(m_pending_status);
+}
+
+bool MariaDBServer::is_down() const
+{
+    return status_is_down(m_pending_status);
+}
+
+bool MariaDBServer::is_in_maintenance() const
+{
+    return status_is_in_maint(m_pending_status);
+}
+
+bool MariaDBServer::is_relay_master() const
+{
+    return status_is_relay(m_pending_status);
+}
+
+bool MariaDBServer::is_low_on_disk_space() const
+{
+    return status_is_disk_space_exhausted(m_pending_status);
+}
+
+bool MariaDBServer::is_read_only() const
+{
+    return m_read_only;
+}
+
+const char* MariaDBServer::name() const
+{
+    return server->name();
+}
+
+std::string MariaDBServer::print_changed_slave_connections()
+{
+    std::stringstream ss;
+    const char* separator = "";
+
+    for (size_t i = 0; i < m_old_slave_status.size(); i++)
+    {
+        const auto& old_row = m_old_slave_status[i];
+        const auto* new_row = sstatus_find_previous_row(old_row, i);
+
+        if (new_row && !new_row->equal(old_row))
+        {
+            ss << "Host: " << new_row->settings.master_endpoint.to_string()
+               << ", IO Running: " << SlaveStatus::slave_io_to_string(new_row->slave_io_running)
+               << ", SQL Running: " << (new_row->slave_sql_running ? "Yes" : "No");
+
+            if (!new_row->last_io_error.empty())
+            {
+                ss << ", IO Error: " << new_row->last_io_error;
+            }
+
+            if (!new_row->last_sql_error.empty())
+            {
+                ss << ", SQL Error: " << new_row->last_sql_error;
+            }
+
+            ss << separator;
+            separator = "; ";
+        }
+    }
+
+    return ss.str();
+}
+
+json_t* MariaDBServer::to_json() const
+{
+    json_t* result = json_object();
+    json_object_set_new(result, "name", json_string(name()));
+    json_object_set_new(result, "server_id", json_integer(m_server_id));
+    json_object_set_new(result, "read_only", json_boolean(m_read_only));
+
+    Guard guard(m_arraylock);
+    json_object_set_new(result,
+                        "gtid_current_pos",
+                        m_gtid_current_pos.empty() ? json_null() :
+                        json_string(m_gtid_current_pos.to_string().c_str()));
+
+    json_object_set_new(result,
+                        "gtid_binlog_pos",
+                        m_gtid_binlog_pos.empty() ? json_null() :
+                        json_string(m_gtid_binlog_pos.to_string().c_str()));
+
+    json_object_set_new(result,
+                        "master_group",
+                        (m_node.cycle == NodeData::CYCLE_NONE) ? json_null() : json_integer(m_node.cycle));
+
+    auto lock = m_serverlock.status();
+    json_object_set_new(result, "lock_held", (lock == ServerLock::Status::UNKNOWN) ? json_null() :
+                        json_boolean(lock == ServerLock::Status::OWNED_SELF));
+
+    if (is_running() && !m_node.external_masters.empty())
+    {
+        json_object_set_new(result, "state_details", json_string("Slave of External Server"));
+    }
+
+    json_t* slave_connections = json_array();
+    for (const auto& sstatus : m_slave_status)
+    {
+        json_array_append_new(slave_connections, sstatus.to_json());
+    }
+    json_object_set_new(result, "slave_connections", slave_connections);
+    return result;
+}
+
+bool MariaDBServer::can_replicate_from(MariaDBServer* master, string* reason_out) const
+{
+    mxb_assert(reason_out);
+    mxb_assert(is_usable());    // The server must be running.
+
+    bool can_replicate = false;
+    if (m_gtid_current_pos.empty())
+    {
+        *reason_out = string_printf("'%s' does not have a valid gtid_current_pos.", name());
+    }
+    else if (master->m_gtid_binlog_pos.empty())
+    {
+        *reason_out = string_printf("'%s' does not have a valid gtid_binlog_pos.", master->name());
+    }
+    else
+    {
+        can_replicate = m_gtid_current_pos.can_replicate_from(master->m_gtid_binlog_pos);
+        if (!can_replicate)
+        {
+            *reason_out = string_printf("gtid_current_pos of '%s' (%s) is incompatible with "
+                                        "gtid_binlog_pos of '%s' (%s).",
+                                        name(), m_gtid_current_pos.to_string().c_str(),
+                                        master->name(), master->m_gtid_binlog_pos.to_string().c_str());
+        }
+    }
+    return can_replicate;
+}
+
+bool MariaDBServer::run_sql_from_file(const string& path, mxb::Json& error_out)
+{
+    MYSQL* conn = con;
+    bool error = false;
+    std::ifstream sql_file(path);
+    if (sql_file.is_open())
+    {
+        MXB_NOTICE("Executing sql queries from file '%s' on server '%s'.", path.c_str(), name());
+        int lines_executed = 0;
+
+        while (!sql_file.eof() && !error)
+        {
+            string line;
+            std::getline(sql_file, line);
+            if (sql_file.bad())
+            {
+                PRINT_JSON_ERROR(error_out, "Error when reading sql text file '%s': '%s'.", path.c_str(),
+                                 mxb_strerror(errno));
+                error = true;
+            }
+            // Skip empty lines and comment lines
+            else if (!line.empty() && line[0] != '#')
+            {
+                if (mxs_mysql_query(conn, line.c_str()) == 0)
+                {
+                    lines_executed++;
+                    // Discard results if any.
+                    MYSQL_RES* res = mysql_store_result(conn);
+                    if (res)
+                    {
+                        mysql_free_result(res);
+                    }
+                }
+                else
+                {
+                    PRINT_JSON_ERROR(error_out, "Failed to execute sql from text file '%s'. Query: '%s'. "
+                                                "Error: '%s'.", path.c_str(), line.c_str(),
+                                     mysql_error(conn));
+                    error = true;
+                }
+            }
+        }
+        MXB_NOTICE("%d queries executed successfully.", lines_executed);
+    }
+    else
+    {
+        PRINT_JSON_ERROR(error_out, "Could not open sql text file '%s'.", path.c_str());
+        error = true;
+    }
+    return !error;
+}
+
+void MariaDBServer::monitor_server()
+{
+    string errmsg;
+    /* Query different things depending on server version/type. */
+    // TODO: Handle binlog router?
+    bool query_ok = read_server_variables(&errmsg) && update_slave_status(&errmsg);
+    if (query_ok && m_capabilities.gtid)
+    {
+        query_ok = update_gtids(&errmsg);
+    }
+    if (query_ok && m_settings.handle_event_scheduler && m_capabilities.events)
+    {
+        query_ok = update_enabled_events();
+    }
+
+    if (query_ok)
+    {
+        m_print_update_errormsg = true;
+    }
+    /* If one of the queries ran to an error, print the error message, assuming it hasn't already been
+     * printed. Some really unlikely errors won't produce an error message, but these are visible in other
+     * ways. */
+    else if (!errmsg.empty() && m_print_update_errormsg)
+    {
+        MXB_WARNING("Error during monitor update of server '%s': %s", name(), errmsg.c_str());
+        m_print_update_errormsg = false;
+    }
+}
+
+/**
+ * Update slave status of the server.
+ *
+ * @param errmsg_out Where to store an error message if query fails. Can be null.
+ * @return True on success
+ */
+bool MariaDBServer::update_slave_status(string* errmsg_out)
+{
+    bool rval = do_show_slave_status(errmsg_out);
+    if (rval)
+    {
+        /** Store master_id of current node. */
+        master_id = !m_slave_status.empty() ?
+            m_slave_status[0].master_server_id : Gtid::SERVER_ID_UNKNOWN;
+    }
+    return rval;
+}
+
+void MariaDBServer::update_server_version()
+{
+    auto conn = con;
+    auto srv = server;
+
+    m_capabilities = Capabilities();
+    auto& info = srv->info();
+    auto type = info.type();
+
+    if (type == ServerType::MARIADB || type == ServerType::MYSQL || type == ServerType::BLR)
+    {
+        // Recognized server type, check version number and supported features.
+        // TODO: most of the features could be just assumed if support for really old MariaDB Server versions
+        // is dropped.
+        auto total = info.version_num().total;
+        // MariaDB/MySQL 5.5 is the oldest supported version. MySQL 6 and later are treated as 5.5.
+        if (total >= 50500)
+        {
+            m_capabilities.basic_support = true;
+            // MySQL 8.0.22 introduced the "REPLICA"/"SOURCE" command vocabulary and 8.4 removed the
+            // legacy "SLAVE"/"MASTER" spelling entirely. From 8.0.22 onwards the monitor must speak the
+            // new dialect, e.g. "SHOW REPLICA STATUS" instead of "SHOW SLAVE STATUS".
+            if (type == ServerType::MYSQL && total >= 80022)
+            {
+                m_capabilities.mysql_replica_syntax = true;
+                // MySQL 8.x GTID auto-positioning enables failover/switchover/rejoin. The engine's
+                // gtid capability is reused; GTID data is read from gtid_executed (see update_gtids)
+                // and replication is set up with SOURCE_AUTO_POSITION=1 (see generate_change_master_cmd).
+                m_capabilities.gtid = true;
+            }
+            // For more specific features, at least MariaDB 10.4 is needed.
+            if ((type == ServerType::MARIADB || type == ServerType::BLR) && total >= 100400)
+            {
+                m_capabilities.gtid = true;
+                m_capabilities.slave_status_all = true;
+
+                if (type == ServerType::MARIADB)
+                {
+                    m_capabilities.events = true;
+                    m_capabilities.max_statement_time = true;
+                    // 10.5.2 adds read-only admin.
+                    if (total >= 100502)
+                    {
+                        m_capabilities.read_only_admin = true;
+                        if (total >= 101000)
+                        {
+                            m_capabilities.demote_to_slave = true;
+                            // 10.11.0 separates read-only admin from super.
+                            if (total >= 101100)
+                            {
+                                m_capabilities.separate_ro_admin = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (m_capabilities.basic_support)
+    {
+        if (!m_capabilities.gtid)
+        {
+            MXB_WARNING("Server '%s' (%s) does not support MariaDB gtid.", name(), info.version_string());
+        }
+    }
+    else
+    {
+        MXB_ERROR("Server '%s' (%s) is unsupported. The server is ignored by the monitor.",
+                  name(), info.version_string());
+    }
+}
+
+void MariaDBServer::clear_status(uint64_t bits)
+{
+    clear_pending_status(bits);
+}
+
+void MariaDBServer::set_status(uint64_t bits)
+{
+    set_pending_status(bits);
+}
+
+/**
+ * Compare if the given slave status array is equal to the one stored in the MariaDBServer.
+ * Only compares the parts relevant for building replication topology: slave IO/SQL state,
+ * host:port and master server id:s. When unsure, return false. This must match
+ * 'build_replication_graph()' in the monitor class.
+ *
+ * @param new_slave_status Right hand side
+ * @return True if equal
+ */
+bool MariaDBServer::sstatus_array_topology_equal(const SlaveStatusArray& new_slave_status) const
+{
+    bool rval = true;
+    const SlaveStatusArray& old_slave_status = m_slave_status;
+    if (old_slave_status.size() != new_slave_status.size())
+    {
+        rval = false;
+    }
+    else
+    {
+        for (size_t i = 0; i < old_slave_status.size(); i++)
+        {
+            const auto& new_row = new_slave_status[i];
+            const auto& old_row = old_slave_status[i];
+
+            if (!new_row.equal(old_row))
+            {
+                rval = false;
+                break;
+            }
+        }
+    }
+    return rval;
+}
+
+/**
+ * Check the slave status array stored in the MariaDBServer and find the row matching the connection in
+ * 'search_row'.
+ *
+ * @param search_row What connection to search for
+ * @param guess_ind Index where the search row could be located at. If incorrect, the array is searched.
+ * @return The found row or NULL if not found
+ */
+const SlaveStatus* MariaDBServer::sstatus_find_previous_row(const SlaveStatus& search_row, size_t guess_ind)
+{
+    // Helper function. Checks if the connection in the new row is to the same server than in the old row.
+    auto compare_rows = [](const SlaveStatus& lhs, const SlaveStatus& rhs) -> bool {
+        return lhs.settings.name == rhs.settings.name
+               && lhs.settings.master_endpoint == rhs.settings.master_endpoint;
+    };
+
+    // Usually the same slave connection can be found from the same index than in the previous slave
+    // status array, but this is not 100% (e.g. dba has just added a new connection).
+    const SlaveStatus* rval = nullptr;
+    if (guess_ind < m_slave_status.size() && compare_rows(m_slave_status[guess_ind], search_row))
+    {
+        rval = &m_slave_status[guess_ind];
+    }
+    else
+    {
+        // The correct connection was not found where it should have been. Try looping.
+        for (const SlaveStatus& old_row : m_slave_status)
+        {
+            if (compare_rows(old_row, search_row))
+            {
+                rval = &old_row;
+                break;
+            }
+        }
+    }
+    return rval;
+}
+
+bool MariaDBServer::can_be_demoted_switchover(SwitchoverType type, string* reason_out)
+{
+    bool demotable = false;
+    string reason;
+    string query_error;
+
+    if (!is_usable())
+    {
+        reason = "it is not running or it is in maintenance.";
+    }
+    else if (!is_database())
+    {
+        reason = not_a_db;
+    }
+    else if (type == SwitchoverType::NORMAL || type == SwitchoverType::AUTO)
+    {
+        if (!update_replication_settings(&query_error))
+        {
+            reason = string_printf("it could not be queried: %s", query_error.c_str());
+        }
+        else if (!binlog_on())
+        {
+            reason = "its binary log is disabled.";
+        }
+        // Allow this when auto-switching as master has likely lost its [Master]-flag.
+        else if (type == SwitchoverType::NORMAL && !is_master() && !m_rpl_settings.log_slave_updates)
+        {
+            // This means that gtid_binlog_pos cannot be trusted.
+            // TODO: reduce dependency on gtid_binlog_pos to get rid of this requirement
+            reason = "it is not the master and log_slave_updates is disabled.";
+        }
+        else if (m_gtid_binlog_pos.empty())
+        {
+            reason = "it does not have a 'gtid_binlog_pos'.";
+        }
+        else
+        {
+            demotable = true;
+        }
+    }
+    else
+    {
+        // Forcing switchover. Update replication settings but don't require success or valid settings.
+        update_replication_settings(&query_error);
+        demotable = true;
+    }
+
+    if (!demotable && reason_out)
+    {
+        *reason_out = reason;
+    }
+    return demotable;
+}
+
+bool MariaDBServer::can_be_demoted_failover(FOBinlogPosPolicy binlog_policy, string* reason_out) const
+{
+    bool demotable = false;
+    string reason;
+
+    if (is_master())
+    {
+        reason = "it is a running master.";
+    }
+    else if (is_running())
+    {
+        reason = "it is running.";
+    }
+    else if (binlog_policy == FOBinlogPosPolicy::FAIL_UNKNOWN && m_gtid_binlog_pos.empty())
+    {
+        reason = mxb::string_printf("its gtid_binlog_pos is unknown and unsafe failover (%s) is not enabled.",
+                                    CN_ENFORCE_SIMPLE_TOPOLOGY);
+    }
+    else
+    {
+        demotable = true;
+    }
+
+    if (!demotable && reason_out)
+    {
+        *reason_out = reason;
+    }
+    return demotable;
+}
+
+bool MariaDBServer::can_be_promoted(OperationType op, const MariaDBServer* demotion_target,
+                                    string* reason_out)
+{
+    const bool is_failover = (op == OperationType::FAILOVER || op == OperationType::FAILOVER_SAFE);
+    mxb_assert(op == OperationType::SWITCHOVER || op == OperationType::SWITCHOVER_FORCE || is_failover);
+
+    bool promotable = false;
+    string reason;
+    string query_error;
+
+    auto sstatus = slave_connection_status(demotion_target);
+    if (is_master())
+    {
+        reason = "it is already the primary.";
+    }
+    else if (!is_usable())
+    {
+        reason = "it is down or in maintenance.";
+    }
+    else if (!is_database())
+    {
+        reason = not_a_db;
+    }
+    // Failover promotion with low disk space is allowed since it's better than nothing. Unsafe switch
+    // also allowed.
+    else if (op == OperationType::SWITCHOVER && is_low_on_disk_space())
+    {
+        reason = "it is low on disk space.";
+    }
+    else if (sstatus == nullptr)
+    {
+        reason = string_printf("it is not replicating from '%s'.", demotion_target->name());
+    }
+    else if (sstatus->gtid_io_pos.empty())
+    {
+        reason = string_printf("its replica connection to '%s' is not using gtid.", demotion_target->name());
+    }
+    else if (op == OperationType::FAILOVER_SAFE
+             && relay_log_missing_events(sstatus->gtid_io_pos, demotion_target->m_gtid_binlog_pos))
+    {
+        reason = string_printf("its relay log is missing transactions that the primary had before going "
+                               "down. %s Gtid_IO_Pos: %s. %s last known gtid_binlog_pos: %s",
+                               name(), sstatus->gtid_io_pos.to_string().c_str(),
+                               demotion_target->name(),
+                               demotion_target->m_gtid_binlog_pos.to_string().c_str());
+    }
+    // Allow forced switchover with broken replication connection.
+    else if (op == OperationType::SWITCHOVER && sstatus->slave_io_running != SlaveStatus::SLAVE_IO_YES)
+    {
+        reason = string_printf("its replica connection to '%s' is broken.", demotion_target->name());
+    }
+    // Check operation type condition second so that the function is run even for forced switchover.
+    else if (!update_replication_settings(&query_error)
+             && (op == OperationType::SWITCHOVER || is_failover))
+    {
+        reason = string_printf("it could not be queried: %s", query_error.c_str());
+    }
+    else if (!binlog_on() && (op == OperationType::SWITCHOVER || is_failover))
+    {
+        reason = "its binary log is disabled.";
+    }
+    // The following will miss cases where seconds_behind_master is undefined (-1).
+    else if (op == OperationType::SWITCHOVER
+             && sstatus->seconds_behind_master > m_settings.switchover_timeout.count())
+    {
+        reason = string_printf("its replication lag (%lis) is greater than switchover_timeout (%lis).",
+                               sstatus->seconds_behind_master, m_settings.switchover_timeout.count());
+    }
+    else
+    {
+        promotable = true;
+    }
+
+    if (!promotable && reason_out)
+    {
+        *reason_out = reason;
+    }
+    return promotable;
+}
+
+const SlaveStatus* MariaDBServer::slave_connection_status(const MariaDBServer* target) const
+{
+    mxb_assert(target);
+    // The slave node may have several slave connections, need to find the one that is
+    // connected to the parent. Most of this has already been done in 'build_replication_graph'.
+    const SlaveStatus* rval = nullptr;
+    for (const SlaveStatus& ss : m_slave_status)
+    {
+        if (ss.master_server == target)
+        {
+            rval = &ss;
+            break;
+        }
+    }
+    return rval;
+}
+
+const SlaveStatus* MariaDBServer::slave_connection_status_host_port(const MariaDBServer* target) const
+{
+    for (const SlaveStatus& ss : m_slave_status)
+    {
+        if (ss.settings.master_endpoint.points_to_server(*target->server))
+        {
+            return &ss;
+        }
+    }
+    return nullptr;
+}
+
+bool
+MariaDBServer::enable_events(BinlogMode binlog_mode, const EventNameSet& event_names, mxb::Json& error_out)
+{
+    EventStatusMapper mapper = [&event_names](const EventInfo& event) {
+        string rval;
+        if (event_names.count(event.name) > 0
+            && (event.status == "SLAVESIDE_DISABLED" || event.status == "DISABLED"))
+        {
+            rval = "ENABLE";
+        }
+        return rval;
+    };
+    return alter_events(binlog_mode, mapper, error_out);
+}
+
+bool MariaDBServer::disable_events(BinlogMode binlog_mode, mxb::Json& error_out)
+{
+    EventStatusMapper mapper = [](const EventInfo& event) {
+        string rval;
+        if (event.status == "ENABLED")
+        {
+            rval = "DISABLE ON SLAVE";
+        }
+        return rval;
+    };
+    return alter_events(binlog_mode, mapper, error_out);
+}
+
+/**
+ * Alter scheduled server events.
+ *
+ * @param binlog_mode Should binary logging be disabled while performing this task.
+ * @param mapper A function which takes an event and returns the requested event state. If empty is returned,
+ * event is not altered.
+ * @param error_out Error output
+ * @return True if all requested alterations succeeded.
+ */
+bool
+MariaDBServer::alter_events(BinlogMode binlog_mode, const EventStatusMapper& mapper, mxb::Json& error_out)
+{
+    // If the server is rejoining the cluster, no events may be added to binlog. The ALTER EVENT query
+    // itself adds events. To prevent this, disable the binlog for this method.
+    string error_msg;
+    const bool disable_binlog = (binlog_mode == BinlogMode::BINLOG_OFF);
+    if (disable_binlog)
+    {
+        if (!execute_cmd("SET @@session.sql_log_bin=0;", &error_msg))
+        {
+            const char FMT[] = "Could not disable session binlog on '%s': %s Server events not disabled.";
+            PRINT_JSON_ERROR(error_out, FMT, name(), error_msg.c_str());
+            return false;
+        }
+    }
+
+    int target_events = 0;
+    int events_altered = 0;
+    // Helper function which alters an event depending on the mapper-function.
+    EventManipulator alterer = [this, &target_events, &events_altered, &mapper](const EventInfo& event,
+                                                                                mxb::Json& err_out) {
+        string target_state = mapper(event);
+        if (!target_state.empty())
+        {
+            target_events++;
+            if (alter_event(event, target_state, err_out))
+            {
+                events_altered++;
+            }
+        }
+    };
+
+    bool rval = false;
+    // TODO: For better error handling, this function should try to re-enable any disabled events if a later
+    // disable fails.
+    if (events_foreach(alterer, error_out))
+    {
+        if (target_events > 0)
+        {
+            // Reset character set and collation.
+            string charset_errmsg;
+            if (!execute_cmd("SET NAMES latin1 COLLATE latin1_swedish_ci;", &charset_errmsg))
+            {
+                MXB_ERROR("Could not reset character set: %s", charset_errmsg.c_str());
+            }
+            warn_event_scheduler();
+        }
+        if (target_events == events_altered)
+        {
+            rval = true;
+        }
+    }
+
+    if (disable_binlog)
+    {
+        // Failure in re-enabling the session binlog doesn't really matter because we don't want the monitor
+        // generating binlog events anyway.
+        execute_cmd("SET @@session.sql_log_bin=1;");
+    }
+    return rval;
+}
+
+/**
+ * Print a warning if the event scheduler is off.
+ */
+void MariaDBServer::warn_event_scheduler()
+{
+    string error_msg;
+    const string scheduler_query = "SELECT * FROM information_schema.PROCESSLIST "
+                                   "WHERE User = 'event_scheduler' AND Command = 'Daemon';";
+    auto proc_list = execute_query(scheduler_query, &error_msg);
+    if (proc_list == nullptr)
+    {
+        MXB_ERROR("Could not query the event scheduler status of '%s': %s", name(), error_msg.c_str());
+    }
+    else
+    {
+        if (proc_list->get_row_count() < 1)
+        {
+            // This is ok, though unexpected since events were found.
+            MXB_WARNING("Event scheduler is inactive on '%s' although events were found.", name());
+        }
+    }
+}
+
+/**
+ * Run the manipulator function on every server event.
+ *
+ * @param func The manipulator function
+ * @param error_out Error output
+ * @return True if event information could be read from information_schema.EVENTS. The return value does not
+ * depend on the manipulator function.
+ */
+bool MariaDBServer::events_foreach(EventManipulator& func, mxb::Json& error_out)
+{
+    string error_msg;
+    // Get info about all scheduled events on the server.
+    auto event_info = execute_query("SELECT * FROM information_schema.EVENTS;", &error_msg);
+    if (event_info == nullptr)
+    {
+        MXB_ERROR("Could not query event status of '%s': %s Event handling can be disabled by "
+                  "setting '%s' to false.",
+                  name(), error_msg.c_str(), CN_HANDLE_EVENTS);
+        return false;
+    }
+
+    auto db_name_ind = event_info->get_col_index("EVENT_SCHEMA");
+    auto event_name_ind = event_info->get_col_index("EVENT_NAME");
+    auto event_definer_ind = event_info->get_col_index("DEFINER");
+    auto event_status_ind = event_info->get_col_index("STATUS");
+    auto charset_ind = event_info->get_col_index("CHARACTER_SET_CLIENT");
+    auto collation_ind = event_info->get_col_index("COLLATION_CONNECTION");
+    mxb_assert(db_name_ind > 0 && event_name_ind > 0 && event_definer_ind > 0 && event_status_ind > 0
+               && charset_ind > 0 && collation_ind > 0);
+
+    while (event_info->next_row())
+    {
+        EventInfo event;
+        event.name = event_info->get_string(db_name_ind) + "." + event_info->get_string(event_name_ind);
+        event.definer = event_info->get_string(event_definer_ind);
+        event.status = event_info->get_string(event_status_ind);
+        event.charset = event_info->get_string(charset_ind);
+        event.collation = event_info->get_string(collation_ind);
+        func(event, error_out);
+    }
+    return true;
+}
+
+/**
+ * Alter a scheduled server event, setting its status.
+ *
+ * @param event Event to alter
+ * @param target_status Status to set
+ * @param error_out Error output
+ * @return True if status was set
+ */
+bool MariaDBServer::alter_event(const EventInfo& event, const string& target_status, mxb::Json& error_out)
+{
+    bool rval = false;
+    string error_msg;
+    // An ALTER EVENT by default changes the definer (owner) of the event to the monitor user.
+    // This causes problems if the monitor user does not have privileges to run
+    // the event contents. Prevent this by setting definer explicitly.
+    // The definer may be of the form user@host. If host includes %, then it must be quoted.
+    // For simplicity, quote the host always.
+    string quoted_definer;
+    auto loc_at = event.definer.find('@');
+    if (loc_at != string::npos)
+    {
+        auto host_begin = loc_at + 1;
+        quoted_definer = event.definer.substr(0, loc_at + 1)
+            +   // host_begin may be the null-char if @ was the last char
+            "'" + event.definer.substr(host_begin, string::npos) + "'";
+    }
+    else
+    {
+        // Just the username
+        quoted_definer = event.definer;
+    }
+
+    // Change character set and collation to the values in the event description. Otherwise, the event
+    // values could be changed to whatever the monitor connection happens to be using.
+    string set_names = string_printf("SET NAMES %s COLLATE %s;", event.charset.c_str(),
+                                     event.collation.c_str());
+    if (execute_cmd(set_names, &error_msg))
+    {
+        string alter_event_query = string_printf("ALTER DEFINER = %s EVENT %s %s;", quoted_definer.c_str(),
+                                                 event.name.c_str(), target_status.c_str());
+        if (execute_cmd(alter_event_query, &error_msg))
+        {
+            rval = true;
+            const char FMT[] = "Event '%s' on server '%s' set to '%s'.";
+            MXB_NOTICE(FMT, event.name.c_str(), name(), target_status.c_str());
+        }
+        else
+        {
+            const char FMT[] = "Could not alter event '%s' on server '%s': %s";
+            PRINT_JSON_ERROR(error_out, FMT, event.name.c_str(), name(), error_msg.c_str());
+        }
+    }
+    else
+    {
+        PRINT_JSON_ERROR(error_out, "Could not set character set: %s", error_msg.c_str());
+    }
+    return rval;
+}
+
+bool MariaDBServer::reset_all_slave_conns(mxb::Json& error_out)
+{
+    string error_msg;
+    bool error = false;
+    for (const auto& slave_conn : m_slave_status)
+    {
+        auto conn_name = slave_conn.settings.name;
+        auto stop = string_printf("STOP REPLICA FOR CHANNEL '%s';", conn_name.c_str());
+        auto reset = string_printf("RESET REPLICA ALL FOR CHANNEL '%s';", conn_name.c_str());
+        if (!execute_cmd(stop, &error_msg) || !execute_cmd(reset, &error_msg))
+        {
+            error = true;
+            string log_message = conn_name.empty() ?
+                string_printf("Error when reseting the default replica connection of '%s': %s",
+                              name(), error_msg.c_str()) :
+                string_printf("Error when reseting the replica connection '%s' of '%s': %s",
+                              conn_name.c_str(), name(), error_msg.c_str());
+            PRINT_JSON_ERROR(error_out, "%s", log_message.c_str());
+            break;
+        }
+    }
+
+    if (!error && !m_slave_status.empty())
+    {
+        MXB_NOTICE("Removed %lu replica connection(s) from '%s'.", m_slave_status.size(), name());
+    }
+    return !error;
+}
+
+bool MariaDBServer::promote(GeneralOpData& general, ServerOperation& promotion, OperationType type,
+                            const MariaDBServer* demotion_target)
+{
+    const bool is_switchover = (type == OperationType::SWITCHOVER || type == OperationType::SWITCHOVER_FORCE);
+    const bool is_failover = (type == OperationType::FAILOVER || type == OperationType::FAILOVER_SAFE);
+    mxb_assert(is_switchover || is_failover || type == OperationType::UNDO_DEMOTION);
+    auto& error_out = general.error_out;
+
+    StopWatch timer;
+    bool stopped = false;
+    if (is_switchover || is_failover)
+    {
+        // In normal circumstances, this should only be called for a master-slave pair.
+        auto master_conn = slave_connection_status(demotion_target);
+        mxb_assert(master_conn);
+        if (master_conn == nullptr)
+        {
+            PRINT_JSON_ERROR(error_out, "'%s' is not a replica of '%s' and cannot be promoted to its place.",
+                             name(), demotion_target->name());
+            return false;
+        }
+
+        // Step 1: Stop & reset slave connections. If doing a failover, only remove the connection to demotion
+        // target. In case of switchover, remove other slave connections as well since the demotion target
+        // will take them over.
+        if (is_switchover)
+        {
+            stopped = remove_slave_conns(general, m_slave_status);
+        }
+        else
+        {
+            stopped = remove_slave_conns(general, {*master_conn});
+        }
+    }
+
+    bool success = false;
+    if (stopped || type == OperationType::UNDO_DEMOTION)
+    {
+        // Step 2: If demotion target is master, meaning this server will become the master,
+        // enable writing and scheduled events. Also, run promotion_sql_file.
+        bool promotion_error = false;
+        if (promotion.target_type == ServerOperation::TargetType::MASTER)
+        {
+            // Disabling read-only should be quick.
+            bool ro_disabled = set_read_only(ReadOnlySetting::DISABLE, general.time_remaining, error_out);
+            general.time_remaining -= timer.restart();
+            if (!ro_disabled)
+            {
+                promotion_error = true;
+            }
+            else
+            {
+                if (m_settings.handle_event_scheduler)
+                {
+                    // TODO: Add query replying to enable_events
+                    bool events_enabled = enable_events(BinlogMode::BINLOG_OFF, promotion.events_to_enable,
+                                                        error_out);
+                    general.time_remaining -= timer.restart();
+                    if (!events_enabled)
+                    {
+                        promotion_error = true;
+                        PRINT_JSON_ERROR(error_out, "Failed to enable events on '%s'.", name());
+                    }
+                }
+
+                // Run promotion_sql_file if no errors so far.
+                const string& sql_file = m_settings.promotion_sql_file;
+                if (!promotion_error && !sql_file.empty())
+                {
+                    bool file_ran_ok = run_sql_from_file(sql_file, error_out);
+                    general.time_remaining -= timer.restart();
+                    if (!file_ran_ok)
+                    {
+                        promotion_error = true;
+                        PRINT_JSON_ERROR(error_out, "Execution of file '%s' failed during promotion of "
+                                                    "server '%s'.", sql_file.c_str(), name());
+                    }
+                }
+            }
+        }
+
+        // Step 3: Copy or merge slave connections from demotion target. The logic used depends on the
+        // operation.
+        if (!promotion_error)
+        {
+            if (is_switchover)
+            {
+                // Standard promotion of a previous replica. The server should have been
+                // properly replicating and has a gtid_slave_pos.
+                if (copy_slave_conns(general, promotion.conns_to_copy, demotion_target,
+                                     ReplicationOp::PROMOTE))
+                {
+                    success = true;
+                }
+                else
+                {
+                    PRINT_JSON_ERROR(error_out, "Could not copy replica connections from '%s' to '%s'.",
+                                     demotion_target->name(), name());
+                }
+            }
+            else if (is_failover)
+            {
+                // Same as above, use gtid_slave_pos.
+                if (merge_slave_conns(general, promotion.conns_to_copy, ReplicationOp::PROMOTE))
+                {
+                    success = true;
+                }
+                else
+                {
+                    PRINT_JSON_ERROR(error_out, "Could not merge replica connections from '%s' to '%s'.",
+                                     demotion_target->name(), name());
+                }
+            }
+            else if (type == OperationType::UNDO_DEMOTION)
+            {
+                // Reversing demotion on a previous master. Since the master is getting back its previous
+                // slave connections, preserve the gtid mode of the original connection.
+                if (copy_slave_conns(general, promotion.conns_to_copy, nullptr, ReplicationOp::CONN_SETT))
+                {
+                    success = true;
+                }
+                else
+                {
+                    PRINT_JSON_ERROR(error_out, "Could not restore replica connections of '%s' when "
+                                                "reversing demotion.", name());
+                }
+            }
+        }
+    }
+    return success;
+}
+
+bool MariaDBServer::demote(GeneralOpData& general, ServerOperation& demotion, OperationType type)
+{
+    mxb_assert(demotion.target == this);
+    const bool force_switch = (type == OperationType::SWITCHOVER_FORCE);
+    mxb_assert(type == OperationType::SWITCHOVER || type == OperationType::REJOIN || force_switch);
+    auto& error_out = general.error_out;
+    bool success = false;
+
+    // Step 1: Stop & reset slave connections. The promotion target will copy them. The connection
+    // information has been backed up in the operation object.
+    if (remove_slave_conns(general, m_slave_status) || force_switch)
+    {
+        const bool demoting_master = demotion.target_type == ServerOperation::TargetType::MASTER;
+        bool demotion_ok;
+        if (demoting_master)
+        {
+            // Step 2: Disable writes and scheduled events, etc.
+            demotion_ok = demote_master(general, type);
+        }
+        else
+        {
+            // If demoting a relay, it's enough to check that gtid is stable.
+            demotion_ok = check_gtid_stable(error_out) || force_switch;
+        }
+
+        if (!demotion_ok && demoting_master)
+        {
+            // Read_only was enabled (or tried to be enabled) but a later step failed.
+            // Disable read_only. Connection is likely broken so use a short time limit.
+            // Even this is insufficient, because the server may still be executing the old
+            // 'SET GLOBAL read_only=1' query.
+            // TODO: add smarter undo, KILL QUERY etc.
+            mxb::Json dummy(mxb::Json::Type::UNDEFINED);
+            set_read_only(ReadOnlySetting::DISABLE, 0s, dummy);
+        }
+        success = demotion_ok;
+    }
+    return success;
+}
+
+bool MariaDBServer::demote_master(GeneralOpData& general, OperationType type)
+{
+    // The server should either be the master or be a standalone being rejoined.
+    mxb_assert(is_master() || m_slave_status.empty());
+    auto& time_remaining = general.time_remaining;
+    auto& error_out = general.error_out;
+    // If forcing a switchover, most errors are ignored. The forced switchover is meant to be used in a
+    // situation the master is effectively hanged, but still connectable.
+    const bool force_switch = (type == OperationType::SWITCHOVER_FORCE);
+    const bool is_switchover = (type == OperationType::SWITCHOVER || force_switch);
+    // Step 2a: Remove [Master] from this server. This prevents compatible routers (RWS)
+    // from routing writes to this server. Writes in flight will go through, at least until
+    // read_only is set. Also set draining so that no new connections come from MaxScale.
+    server->clear_status(SERVER_MASTER);
+    bool was_draining = server->is_draining();
+    if (!was_draining)
+    {
+        server->set_status(SERVER_DRAINING);
+    }
+
+    bool demotion_ok = true;
+    // Step 2b: Enabling read-only can take a while if large trx are committing or table locks taken.
+    StopWatch timer;
+    bool ro_enabled = set_read_only(ReadOnlySetting::ENABLE, general.time_remaining, error_out);
+    time_remaining -= timer.lap();
+    if (ro_enabled || force_switch)
+    {
+        bool supers_handled = true;
+        // In the rejoin-case, just leave read-only on. If super-users are causing problems it's probably
+        // too late to prevent anyway.
+        if (is_switchover)
+        {
+            // Step 2c: If other users with SUPER privileges are on, kick them out now since
+            // read_only doesn't stop them from doing writes. As the server is draining, MaxScale
+            // should not make new routing connections. Outside connections cannot be prevented.
+            // Kick super-users while "FLUSH TABLES WITH READ LOCK" is on to ensure no trx from
+            // super-users are committing.
+            string error_msg;
+            bool lock_ok = execute_cmd_time_limit("FLUSH TABLES WITH READ LOCK;", time_remaining, &error_msg);
+            if (!lock_ok)
+            {
+                PRINT_JSON_ERROR(error_out, "Failed to lock tables on '%s': %s", name(), error_msg.c_str());
+            }
+            time_remaining -= timer.lap();
+
+            bool kick_ok = lock_ok && kick_out_super_users(general);
+            timer.restart();
+
+            // Run unlock regardless of previous success, just to be certain any lingering locks are freed.
+            // Need to unlock here as otherwise the next steps would be blocked.
+            bool unlock_ok = execute_cmd_time_limit("UNLOCK TABLES;", time_remaining, &error_msg);
+            if (!unlock_ok)
+            {
+                PRINT_JSON_ERROR(error_out, "Failed to unlock tables on '%s': %s", name(), error_msg.c_str());
+            }
+            time_remaining -= timer.lap();
+            supers_handled = (lock_ok && kick_ok && unlock_ok) || force_switch;
+        }
+
+        if (supers_handled)
+        {
+            if (m_settings.handle_event_scheduler)
+            {
+                // Step 2d: Using BINLOG_OFF to avoid adding any gtid events which could break external
+                // replication.
+                if (!disable_events(BinlogMode::BINLOG_OFF, error_out))
+                {
+                    demotion_ok = force_switch;
+                    PRINT_JSON_ERROR(error_out, "Failed to disable events on '%s'.", name());
+                }
+                time_remaining -= timer.lap();
+            }
+
+            // Step 2e: Run demotion_sql_file if no errors so far.
+            const string& sql_file = m_settings.demotion_sql_file;
+            if (demotion_ok && !sql_file.empty())
+            {
+                if (!run_sql_from_file(sql_file, error_out))
+                {
+                    demotion_ok = force_switch;
+                    PRINT_JSON_ERROR(error_out,
+                                     "Execution of file '%s' failed during demotion of server '%s'.",
+                                     sql_file.c_str(), name());
+                }
+                time_remaining -= timer.lap();
+            }
+
+            if (demotion_ok)
+            {
+                // Step 2f: FLUSH LOGS to ensure that all events have been written to binlog.
+                string error_msg;
+                if (!execute_cmd_time_limit("FLUSH LOGS;", time_remaining, &error_msg))
+                {
+                    demotion_ok = force_switch;
+                    PRINT_JSON_ERROR(error_out, "Failed to flush binary logs of '%s' during demotion: %s.",
+                                     name(), error_msg.c_str());
+                }
+                time_remaining -= timer.lap();
+            }
+
+            if (demotion_ok && is_switchover)
+            {
+                // At this point, the gtid:s should be stable. Check it.
+                demotion_ok = check_gtid_stable(error_out) || force_switch;
+            }
+        }
+        else
+        {
+            demotion_ok = false;
+        }
+    }
+    else
+    {
+        demotion_ok = false;
+    }
+
+    if (!was_draining)
+    {
+        // TODO: Do this later?
+        server->clear_status(SERVER_DRAINING);
+    }
+    return demotion_ok;
+}
+
+/**
+ * Stop and optionally reset/reset-all a slave connection.
+ *
+ * @param conn_name Slave connection name. Use empty string for the nameless connection.
+ * @param mode STOP, RESET or RESET ALL
+ * @param time_limit Operation time limit
+ * @param error_out Error output
+ * @return True on success
+ */
+bool MariaDBServer::stop_slave_conn(const std::string& conn_name, StopMode mode, Duration time_limit,
+                                    mxb::Json& error_out)
+{
+    /* STOP SLAVE is a bit problematic, since sometimes it seems to take several seconds to complete.
+     * If this time is greater than the connection read timeout, connector-c will cut the connection/
+     * query. The query is likely completed afterwards by the server. To prevent false errors,
+     * try the query repeatedly until time is up. Fortunately, the server doesn't consider stopping
+     * an already stopped slave connection an error. */
+    Duration time_left = time_limit;
+    StopWatch timer;
+    string stop = string_printf("STOP REPLICA FOR CHANNEL '%s';", conn_name.c_str());
+    string error_msg;
+    bool stop_success = execute_cmd_time_limit(stop, time_left, &error_msg);
+    time_left -= timer.restart();
+
+    bool rval = false;
+    if (stop_success)
+    {
+        // The RESET REPLICA-query can also take a while if there is lots of relay log to delete.
+        // Very rare, though.
+        if (mode == StopMode::RESET || mode == StopMode::RESET_ALL)
+        {
+            string reset = string_printf("RESET REPLICA%s FOR CHANNEL '%s';",
+                                         (mode == StopMode::RESET_ALL) ? " ALL" : "", conn_name.c_str());
+            if (execute_cmd_time_limit(reset, time_left, &error_msg))
+            {
+                rval = true;
+            }
+            else
+            {
+                PRINT_JSON_ERROR(error_out, "Failed to reset replica connection on '%s': %s", name(),
+                                 error_msg.c_str());
+            }
+        }
+        else
+        {
+            rval = true;
+        }
+    }
+    else
+    {
+        PRINT_JSON_ERROR(error_out, "Failed to stop replica connection on '%s': %s", name(), error_msg.c_str());
+    }
+    return rval;
+}
+
+/**
+ * Removes the given slave connections from the server and then updates slave connection status.
+ * The slave connections of the server object will change during this method, so any pointers and
+ * references to such may be invalidated and should be re-acquired.
+ *
+ * @param op Operation descriptor
+ * @param conns_to_remove Which connections should be removed
+ * @return True if successful
+ */
+bool MariaDBServer::remove_slave_conns(GeneralOpData& op, const SlaveStatusArray& conns_to_remove)
+{
+    auto& error_out = op.error_out;
+    maxbase::Duration& time_remaining = op.time_remaining;
+    StopWatch timer;
+    // Take a backup of the soon to be removed connections so they can be compared properly after an update.
+    SlaveStatusArray conns_to_remove_copy = conns_to_remove;
+
+    bool stop_slave_error = false;
+    for (size_t i = 0; !stop_slave_error && i < conns_to_remove.size(); i++)
+    {
+        if (!stop_slave_conn(conns_to_remove[i].settings.name, StopMode::RESET_ALL, time_remaining,
+                             error_out))
+        {
+            stop_slave_error = true;
+        }
+        time_remaining -= timer.lap();
+    }
+
+    bool success = false;
+    if (stop_slave_error)
+    {
+        PRINT_JSON_ERROR(error_out, "Failed to remove replica connection(s) from '%s'.", name());
+    }
+    else
+    {
+        // Check that the slave connections are really gone by comparing connection names. It's probably
+        // enough to just update the slave status. Checking that the connections are really gone is
+        // likely overkill, but doesn't hurt.
+        string error_msg;
+        if (do_show_slave_status(&error_msg))
+        {
+            // Insert all existing connection names to a set, then check that none of the removed ones are
+            // there.
+            std::set<string> connection_names;
+            for (auto& slave_conn : m_slave_status)
+            {
+                connection_names.insert(slave_conn.settings.name);
+            }
+            int found = 0;
+            for (auto& removed_conn : conns_to_remove_copy)
+            {
+                if (connection_names.count(removed_conn.settings.name) > 0)
+                {
+                    found++;
+                }
+            }
+
+            if (found == 0)
+            {
+                success = true;
+            }
+            else
+            {
+                // This means server is really bugging.
+                PRINT_JSON_ERROR(error_out, "'%s' still has %i removed replica connections, RESET SLAVE "
+                                            "must have failed.", name(), found);
+            }
+        }
+        else
+        {
+            PRINT_JSON_ERROR(error_out, "Failed to update replica connections of '%s': %s",
+                             name(), error_msg.c_str());
+        }
+    }
+    time_remaining -= timer.lap();
+    return success;
+}
+
+bool MariaDBServer::set_read_only(ReadOnlySetting setting, maxbase::Duration time_limit, mxb::Json& error_out)
+{
+    // MySQL: use super_read_only to demote so that even users with SUPER cannot write to a replica
+    // (setting super_read_only=1 implies read_only=1). Promotion clears read_only, which also clears
+    // super_read_only. This is stronger than MariaDB's plain read_only and the correct primary guard.
+    string cmd = (setting == ReadOnlySetting::ENABLE) ?
+        "SET GLOBAL super_read_only=1;" : "SET GLOBAL read_only=0;";
+    string error_msg;
+    bool success = execute_cmd_time_limit(cmd, time_limit, &error_msg);
+    if (!success)
+    {
+        string target_str = (setting == ReadOnlySetting::ENABLE) ? "enable" : "disable";
+        PRINT_JSON_ERROR(error_out, "Failed to %s read_only on '%s': %s", target_str.c_str(), name(),
+                         error_msg.c_str());
+    }
+    return success;
+}
+
+/**
+ * Merge slave connections to this server (promotion target). This should only
+ * be used during failover promotion.
+ *
+ * @param op Operation descriptor
+ * @param conns_to_merge Connections which should be merged
+ * @param repl_op Replication change type
+ * @return True on success
+ */
+bool MariaDBServer::merge_slave_conns(GeneralOpData& op, const SlaveStatusArray& conns_to_merge,
+                                      ReplicationOp repl_op)
+{
+    /* When promoting a server during failover, the situation is more complicated than in switchover.
+     * Connections cannot be moved to the demotion target (= failed server) as it is off. This means
+     * that the promoting server must combine the roles of both itself and the failed server. Only the
+     * slave connection replicating from the failed server has been removed. This means that
+     * the promotion and demotion targets may have identical connections (connections going to
+     * the same server id or the same host:port). These connections should not be copied or modified.
+     * It's possible that the master had different settings for a duplicate slave connection,
+     * in this case the settings on the master are lost.
+     * TODO: think if the master's settings should take priority.
+     * Also, connection names may collide between the two servers, in this case try to generate
+     * a simple name for the new connection. */
+
+    // Helper function for checking if a slave connection should be ignored.
+    auto conn_can_be_merged = [this](const SlaveStatus& slave_conn, string* ignore_reason_out) -> bool {
+        bool accepted = true;
+        auto master_id = slave_conn.master_server_id;
+        // The connection is only merged if it satisfies the copy-conditions. Merging has also
+        // additional requirements.
+        string ignore_reason;
+        if (!slave_conn.should_be_copied(&ignore_reason))
+        {
+            accepted = false;
+        }
+        else if (master_id == m_server_id)
+        {
+            // This is not an error but indicates a complicated topology. In any case, ignore this.
+            accepted = false;
+            ignore_reason = string_printf("it points to '%s' (according to server id:s).", name());
+        }
+        else if (slave_conn.settings.master_endpoint.points_to_server(*server))
+        {
+            accepted = false;
+            ignore_reason = string_printf("it points to '%s' (according to master host:port).", name());
+        }
+        else
+        {
+            // Compare to connections already existing on this server.
+            for (const SlaveStatus& my_slave_conn : m_slave_status)
+            {
+                if (my_slave_conn.seen_connected && my_slave_conn.master_server_id == master_id)
+                {
+                    accepted = false;
+                    const char format[] = "its Master_Server_Id (%" PRIi64
+                        ") matches an existing replica connection on '%s'.";
+                    ignore_reason = string_printf(format, master_id, name());
+                }
+                else if (my_slave_conn.settings.master_endpoint == slave_conn.settings.master_endpoint)
+                {
+                    accepted = false;
+                    const auto& endpoint = slave_conn.settings.master_endpoint;
+                    ignore_reason = string_printf(
+                        "its Master_Host (%s) and Master_Port (%i) match an existing "
+                        "replica connection on %s.",
+                        endpoint.host().c_str(), endpoint.port(), name());
+                }
+            }
+        }
+
+        if (!accepted)
+        {
+            *ignore_reason_out = ignore_reason;
+        }
+        return accepted;
+    };
+
+    // Need to keep track of connection names (both existing and new) to avoid using an existing name.
+    std::set<string> connection_names;
+    for (const auto& conn : m_slave_status)
+    {
+        connection_names.insert(conn.settings.name);
+    }
+
+    // Helper function which checks that a connection name is unique and modifies it if not.
+    auto check_modify_conn_name = [this, &connection_names](SlaveStatus::Settings* conn_settings) -> bool {
+        bool name_is_unique = false;
+        string conn_name = conn_settings->name;
+        if (connection_names.count(conn_name) > 0)
+        {
+            // If the name is used, generate a name using the host:port of the master,
+            // it should be unique.
+            string second_try = "To " + conn_settings->master_endpoint.to_string();
+            if (connection_names.count(second_try) > 0)
+            {
+                // Even this one exists, something is really wrong. Give up.
+                MXB_ERROR("Could not generate a unique connection name for '%s': both '%s' and '%s' are "
+                          "already taken.", name(), conn_name.c_str(), second_try.c_str());
+            }
+            else
+            {
+                MXB_WARNING("A replica connection with name '%s' already exists on '%s', using generated "
+                            "name '%s' instead.", conn_name.c_str(), name(), second_try.c_str());
+                conn_settings->name = second_try;
+                name_is_unique = true;
+            }
+        }
+        else
+        {
+            name_is_unique = true;
+        }
+        return name_is_unique;
+    };
+
+    bool error = false;
+    for (size_t i = 0; !error && (i < conns_to_merge.size()); i++)
+    {
+        // Need a copy of the array element here since it may be modified.
+        SlaveStatus slave_conn = conns_to_merge[i];
+        string ignore_reason;
+        if (conn_can_be_merged(slave_conn, &ignore_reason))
+        {
+            auto& conn_settings = slave_conn.settings;
+            if (check_modify_conn_name(&conn_settings))
+            {
+                if (create_start_slave(op, conn_settings, repl_op))
+                {
+                    connection_names.insert(conn_settings.name);
+                }
+                else
+                {
+                    error = true;
+                }
+            }
+            else
+            {
+                error = true;
+            }
+        }
+        else
+        {
+            mxb_assert(!ignore_reason.empty());
+            MXB_WARNING("%s was ignored when promoting '%s' because %s",
+                        slave_conn.settings.to_string().c_str(), name(), ignore_reason.c_str());
+        }
+    }
+
+    return !error;
+}
+
+bool MariaDBServer::copy_slave_conns(GeneralOpData& op, const SlaveStatusArray& conns_to_copy,
+                                     const MariaDBServer* replacement, ReplicationOp repl_op)
+{
+    mxb_assert(m_slave_status.empty());
+    bool start_slave_error = false;
+    for (size_t i = 0; i < conns_to_copy.size() && !start_slave_error; i++)
+    {
+        const SlaveStatus& slave_conn = conns_to_copy[i];
+        string reason_not_copied;
+        if (slave_conn.should_be_copied(&reason_not_copied))
+        {
+            SlaveStatus::Settings new_settings = slave_conn.settings; // May be modified.
+            // Any slave connection that was going to this server itself is instead directed
+            // to the replacement server.
+            bool ok_to_copy = true;
+            if (slave_conn.master_server_id == m_server_id)
+            {
+                if (replacement)
+                {
+                    new_settings.master_endpoint = EndPoint::replication_endpoint(*replacement->server);
+                }
+                else
+                {
+                    // This is only possible if replication is configured wrong, and we are
+                    // undoing a switchover demotion.
+                    ok_to_copy = false;
+                    MXB_WARNING("Server id:s of '%s' and %s are identical, not copying the connection "
+                                "to '%s'.",
+                                name(), slave_conn.settings.master_endpoint.to_string().c_str(), name());
+                }
+            }
+
+            if (ok_to_copy)
+            {
+                // The target server (this) may have been a master or slave, caller must decide role.
+                if (!create_start_slave(op, new_settings, repl_op))
+                {
+                    start_slave_error = true;
+                }
+            }
+        }
+        else
+        {
+            MXB_WARNING("%s was not copied to '%s' because %s",
+                        slave_conn.settings.to_string().c_str(), name(), reason_not_copied.c_str());
+        }
+    }
+    return !start_slave_error;
+}
+
+bool MariaDBServer::create_start_slave(GeneralOpData& op, const SlaveStatus::Settings& conn_settings,
+                                       ReplicationOp repl_op)
+{
+    maxbase::Duration& time_remaining = op.time_remaining;
+    StopWatch timer;
+    string error_msg;
+    bool success = false;
+
+    SlaveStatus::Settings new_settings = conn_settings;
+    new_settings.m_owner = name();      // So any error messages refer to this server.
+    auto change_master = generate_change_master_cmd(new_settings, repl_op);
+    bool conn_created = execute_cmd_time_limit(change_master.real_cmd, change_master.masked_cmd,
+                                               time_remaining, &error_msg, nullptr);
+    time_remaining -= timer.restart();
+    if (conn_created)
+    {
+        string start_slave = string_printf("START REPLICA FOR CHANNEL '%s';", new_settings.name.c_str());
+        bool slave_started = execute_cmd_time_limit(start_slave, time_remaining, &error_msg);
+        time_remaining -= timer.restart();
+        if (slave_started)
+        {
+            success = true;
+            MXB_NOTICE("%s created and started.", new_settings.to_string().c_str());
+        }
+        else
+        {
+            MXB_ERROR("%s could not be started: %s", new_settings.to_string().c_str(), error_msg.c_str());
+        }
+    }
+    else
+    {
+        // Will not print out pw:s unless the server adds one into its error message.
+        MXB_ERROR("%s could not be created: %s", new_settings.to_string().c_str(), error_msg.c_str());
+    }
+    return success;
+}
+
+/**
+ * Generate a CHANGE MASTER TO-query.
+ *
+ * @param conn_settings Existing slave connection settings to emulate
+ * @return Generated query
+ */
+MariaDBServer::ChangeMasterCmd
+MariaDBServer::generate_change_master_cmd(const SlaveStatus::Settings& conn_settings, ReplicationOp repl_op)
+{
+    // MySQL 8.x dialect: "CHANGE REPLICATION SOURCE TO ... SOURCE_AUTO_POSITION=1 ... FOR CHANNEL '<n>'".
+    // All operations (REDIRECT/PROMOTE/DEMOTE/CONN_SETT) use GTID auto-positioning, which removes the
+    // need for MariaDB's slave_pos/current_pos/MASTER_DEMOTE_TO_SLAVE distinctions: the replica finds
+    // the right starting point from its own gtid_executed automatically.
+    (void)repl_op;
+    string cmd_begin = string_printf("CHANGE REPLICATION SOURCE TO SOURCE_HOST = '%s', SOURCE_PORT = %i, "
+                                     "SOURCE_AUTO_POSITION = 1, ",
+                                     conn_settings.master_endpoint.host().c_str(),
+                                     conn_settings.master_endpoint.port());
+
+    if (m_settings.replication_ssl)
+    {
+        cmd_begin += "SOURCE_SSL = 1, ";    // Leave out if not set to preserve existing setting.
+    }
+    else
+    {
+        // Default MySQL 8.x auth is caching_sha2_password. Over a non-SSL replication channel the
+        // replica must fetch the primary's RSA public key to complete the handshake, otherwise the
+        // IO thread fails with "Authentication requires secure connection". Request it explicitly.
+        cmd_begin += "GET_SOURCE_PUBLIC_KEY = 1, ";
+    }
+
+    auto server_repl_custom_opts = server->replication_custom_opts();
+    const string& eff_repl_custom_opts = !server_repl_custom_opts.empty() ? server_repl_custom_opts :
+        m_settings.replication_custom_opts;
+
+    if (!eff_repl_custom_opts.empty())
+    {
+        cmd_begin.append(eff_repl_custom_opts).append(", ");
+    }
+
+    // Channel suffix. The default (unnamed) channel is "", which is valid as FOR CHANNEL ''.
+    string for_channel = string_printf(" FOR CHANNEL '%s';", conn_settings.name.c_str());
+
+    // Mask user & pw for the masked version.
+    const char user_pw[] = "SOURCE_USER = '%s', SOURCE_PASSWORD = '%s'";
+    string cleartext_cmd = cmd_begin;
+    cleartext_cmd += mxb::string_printf(user_pw, m_settings.replication_user.c_str(),
+                                        m_settings.replication_password.c_str());
+    cleartext_cmd += for_channel;
+    const char mask[] = "******";
+    string masked_cmd = move(cmd_begin);
+    masked_cmd += mxb::string_printf(user_pw, mask, mask);
+    masked_cmd += for_channel;
+
+    ChangeMasterCmd rval;
+    rval.real_cmd = move(cleartext_cmd);
+    rval.masked_cmd = move(masked_cmd);
+    return rval;
+}
+
+bool
+MariaDBServer::redirect_existing_slave_conn(GeneralOpData& op, const SlaveStatus::Settings& conn_settings,
+                                            const MariaDBServer* new_master)
+{
+    auto& error_out = op.error_out;
+    maxbase::Duration& time_remaining = op.time_remaining;
+    StopWatch timer;
+    bool success = false;
+    // Caller should be using an existing slave conn of this server.
+    mxb_assert(conn_settings.m_owner == name());
+
+    // First, just stop the slave connection.
+    const string& conn_name = conn_settings.name;
+    bool stopped = stop_slave_conn(conn_name, StopMode::STOP_ONLY, time_remaining, error_out);
+    time_remaining -= timer.restart();
+    if (stopped)
+    {
+        SlaveStatus::Settings modified_settings = conn_settings;
+        modified_settings.master_endpoint = EndPoint::replication_endpoint(*new_master->server);
+        auto change_master = generate_change_master_cmd(modified_settings, ReplicationOp::REDIRECT);
+
+        string error_msg;
+        bool changed = execute_cmd_time_limit(change_master.real_cmd, change_master.masked_cmd,
+                                              time_remaining, &error_msg, nullptr);
+        time_remaining -= timer.restart();
+        if (changed)
+        {
+            string start = string_printf("START REPLICA FOR CHANNEL '%s';", conn_name.c_str());
+            bool started = execute_cmd_time_limit(start, time_remaining, &error_msg);
+            time_remaining -= timer.restart();
+            if (started)
+            {
+                success = true;
+            }
+            else
+            {
+                PRINT_JSON_ERROR(error_out, "%s could not be started: %s",
+                                 modified_settings.to_string().c_str(), error_msg.c_str());
+            }
+        }
+        else
+        {
+            PRINT_JSON_ERROR(error_out, "%s could not be redirected to %s: %s",
+                             conn_settings.to_string().c_str(),
+                             modified_settings.master_endpoint.to_string().c_str(), error_msg.c_str());
+        }
+    }   // 'stop_slave_conn' prints its own errors
+    return success;
+}
+
+bool MariaDBServer::update_enabled_events()
+{
+    string error_msg;
+    // Get names of all enabled scheduled events on the server.
+    auto event_info = execute_query("SELECT Event_schema, Event_name FROM information_schema.EVENTS WHERE "
+                                    "Status = 'ENABLED';", &error_msg);
+    if (event_info == nullptr)
+    {
+        std::string errmsg = mxb::string_printf("Could not query events of '%s': %s",
+                                                name(), error_msg.c_str());
+
+        bool scheduler_disabled = error_msg.find("event scheduler is disabled") != std::string::npos;
+
+        if (scheduler_disabled)
+        {
+            errmsg += mxb::string_printf(" Event handling can be disabled by setting '%s' to false,"
+                                         " will keep retrying with this message suppressed.",
+                                         CN_HANDLE_EVENTS);
+        }
+
+        if (m_warn_event_handling || !scheduler_disabled)
+        {
+            MXB_ERROR("%s", errmsg.c_str());
+        }
+
+        m_warn_event_handling = !scheduler_disabled;
+        return false;
+    }
+
+    m_warn_event_handling = true;
+
+    auto db_name_ind = 0;
+    auto event_name_ind = 1;
+
+    EventNameSet full_names;
+    full_names.reserve(event_info->get_row_count());
+
+    while (event_info->next_row())
+    {
+        string full_name = event_info->get_string(db_name_ind) + "." + event_info->get_string(event_name_ind);
+        full_names.insert(full_name);   // Ignore duplicates, they shouldn't exists.
+    }
+
+    m_enabled_events = std::move(full_names);
+
+    return true;
+}
+
+/**
+ * Connect to and query/update a server.
+ *
+ * @param time_to_update_disk_space Update disk space status
+ * @param first_tick Is this the first tick? Only affect error logging
+ * @param is_topology_master Is this the master? Only affects disk space status logging.
+ */
+void MariaDBServer::update_server(bool time_to_update_disk_space, bool first_tick, bool is_topology_master,
+                                  bool reconnect)
+{
+    m_new_events.clear();
+    if (reconnect)
+    {
+        close_conn();
+    }
+    ConnectResult conn_status = ping_or_connect();
+
+    if (connection_is_ok(conn_status))
+    {
+        maybe_fetch_variables();
+        fetch_uptime();
+        set_status(SERVER_RUNNING);
+        const bool new_connection = (conn_status == ConnectResult::NEWCONN_OK);
+        if (new_connection)
+        {
+            // Is a new connection or a reconnection. Check server version.
+            update_server_version();
+            clear_locks_info();     // Lock expired due to lost connection.
+            if (m_settings.wait_timeout_normal_s > 0)
+            {
+                // Set timeout whenever making a new connection. This is not entirely necessary but causes
+                // most broken connections to close within reasonable time even if the connection did not
+                // possess a lock.
+                set_wait_timout(m_settings.wait_timeout_normal_s);
+            }
+        }
+
+        if (m_capabilities.basic_support)
+        {
+            // Check permissions if permissions failed last time or if this is a new connection.
+            if (had_status(SERVER_AUTH_ERROR) || new_connection)
+            {
+                check_permissions(new_connection);
+            }
+
+            // If permissions are ok, continue.
+            if (!has_status(SERVER_AUTH_ERROR))
+            {
+                if (time_to_update_disk_space && can_update_disk_space_status())
+                {
+                    update_disk_space_status();
+                    if (has_status(SERVER_DISK_SPACE_EXHAUSTED) && !had_status(SERVER_DISK_SPACE_EXHAUSTED))
+                    {
+                        // Server disk space status changed. Print a warning message if master/slave
+                        // conditions now block the server from getting those roles.
+                        if (is_topology_master && (m_settings.master_conds & MasterConds::MCOND_DISK_OK))
+                        {
+                            // This only works on the current master-like server. A server with
+                            // low disk space getting swapped to master and not getting master-status is not
+                            // currently logged as it would be more difficult to track.
+                            if (had_status(SERVER_MASTER))
+                            {
+                                MXB_WARNING("%s is low on disk space, removing primary status until "
+                                            "situation is resolved.", name());
+                            }
+                            else
+                            {
+                                MXB_WARNING("%s is low on disk space, it cannot get primary status until "
+                                            "situation is resolved.", name());
+                            }
+                        }
+
+                        if (m_settings.slave_conds & SlaveConds::SCOND_DISK_OK)
+                        {
+                            if (had_status(SERVER_SLAVE))
+                            {
+                                MXB_WARNING("%s is low on disk space, removing replica status until "
+                                            "situation is resolved.", name());
+                            }
+                        }
+                    }
+                }
+
+                if (m_settings.server_locks_enabled)
+                {
+                    // Update lock status every tick. This is especially required for the secondary MaxScale,
+                    // as it needs to quickly react if the primary dies.
+                    update_locks_status();
+                }
+
+                // Query MariaDBServer specific data
+                monitor_server();
+            }
+        }
+    }
+    else
+    {
+        /* The current server is not running. Clear some of the bits. User-set bits and some long-term bits
+         * can stay. */
+        clear_status(MonitorServer::SERVER_DOWN_CLEAR_BITS);
+        clear_locks_info();
+
+        if (conn_status == ConnectResult::ACCESS_DENIED)
+        {
+            set_status(SERVER_AUTH_ERROR);
+        }
+
+        /* Avoid spamming and only log if this is the first tick or if server was running last tick or
+         * if server has started to reject the monitor. If we failed to log in due to authentication failure,
+         * log that as well. */
+        if (first_tick || had_status(SERVER_RUNNING)
+            || (has_status(SERVER_AUTH_ERROR) && !had_status(SERVER_AUTH_ERROR)))
+        {
+            log_connect_error(conn_status);
+        }
+    }
+
+    /** Increase or reset the error count of the server. */
+    mon_err_count = (is_running() || is_in_maintenance()) ? 0 : mon_err_count + 1;
+}
+
+
+bool MariaDBServer::kick_out_super_users(GeneralOpData& op)
+{
+    bool success = false;
+    bool keep_trying = true;
+    int attempts = 0;
+    // Only stop once there are no more super-users logged in. If killing connections succeeds but users
+    // keep coming back, they must be repeatedly logging in.
+    do
+    {
+        StopWatch timer;
+        auto [fetch_ok, conns] = get_super_user_conns(op.error_out);
+        op.time_remaining -= timer.lap();
+        if (!conns.empty())
+        {
+            MXB_NOTICE("Detected %li super or read_only admin users logged in on %s. Kicking them out.",
+                       conns.size(), name());
+            int kills = 0;
+
+            for (const auto& user : conns)
+            {
+                string kill_query = mxb::string_printf("KILL SOFT CONNECTION %li;", user.conn_id);
+                string error_msg;
+                unsigned int error_num = 0;
+                if (execute_cmd_time_limit(kill_query, op.time_remaining, &error_msg, &error_num))
+                {
+                    kills++;
+                }
+                else if (error_num != ER_NO_SUCH_THREAD)
+                {
+                    MXB_WARNING("Could not kill connection %lu from super-user/read-only admin '%s': %s",
+                                user.conn_id, user.username.c_str(), error_msg.c_str());
+                }
+                op.time_remaining -= timer.lap();
+            }
+
+            if (kills > 0)
+            {
+                MXB_NOTICE("Killed %i super or read-only admin user connections on '%s'.", kills, name());
+            }
+        }
+
+        if (fetch_ok)
+        {
+            if (conns.empty())
+            {
+                success = true;
+            }
+            else
+            {
+                // Likely killed (or tried to kill) some connections. Check again to ensure they are gone.
+                if (attempts == 0 || (attempts < 4 && op.time_remaining > 0ms))
+                {
+                    // Wait a bit to give server some time, perhaps it takes a moment for the KILL-queries
+                    // to take effect.
+                    std::this_thread::sleep_for(500ms);
+                }
+                else
+                {
+                    // Give up. Print one username as example so that dba can believe MaxScale and perhaps
+                    // investigates further.
+                    PRINT_JSON_ERROR(op.error_out,
+                                     "Could not kick out all super or read-only admin users. %li such users "
+                                     "remain, for example '%s'. Either 'KILL CONNECTION'-query failed or "
+                                     "super-users keep logging back in.",
+                                     conns.size(), conns.front().username.c_str());
+                    keep_trying = false;
+                }
+            }
+        }
+        else
+        {
+            // Fetch failed due to unexpected reason, fail and cancel switchover.
+            keep_trying = false;
+        }
+        op.time_remaining -= timer.lap();
+        attempts++;
+    }
+    while (!success && keep_trying);
+
+    return success;
+}
+
+void MariaDBServer::update_locks_status()
+{
+    /* Read a lock status from a result row. */
+    auto read_lock_status = [this](const QueryResult& is_used_row, int ind) {
+        ServerLock rval;
+        if (is_used_row.field_is_null(ind))
+        {
+            // null means the lock is free.
+            rval.set_status(ServerLock::Status::FREE);
+        }
+        else
+        {
+            auto lock_owner_id = is_used_row.get_int(ind);
+            // Either owned by this MaxScale or another.
+            auto new_status = (lock_owner_id == conn_id()) ? ServerLock::Status::OWNED_SELF :
+                ServerLock::Status::OWNED_OTHER;
+            rval.set_status(new_status, lock_owner_id);
+        }
+        return rval;
+    };
+
+    auto report_unexpected_lock = [this](ServerLock old_status, ServerLock new_status,
+                                         const string& lock_name) {
+        bool owned_lock = (old_status.status() == ServerLock::Status::OWNED_SELF);
+        if (new_status.status() == ServerLock::Status::OWNED_SELF)
+        {
+            // This MaxScale has the lock. Print warning if it got the lock without knowing it.
+            if (!owned_lock)
+            {
+                MXB_WARNING("Acquired the lock '%s' on server '%s' without locking it.",
+                            lock_name.c_str(), name());
+            }
+        }
+        else
+        {
+            // Don't have the lock. Print a warning if lock was lost without releasing it.
+            // This may happen if connection broke and was recreated.
+            if (owned_lock)
+            {
+                string msg = string_printf("Lost the lock '%s' on server '%s' without releasing it.",
+                                           lock_name.c_str(), name());
+                if (new_status.status() == ServerLock::Status::OWNED_OTHER)
+                {
+                    msg += string_printf(" The lock is now owned by connection %li.", new_status.owner());
+                }
+                MXB_WARNING("%s", msg.c_str());
+            }
+        }
+    };
+
+    // First, check who currently has the locks. If the query fails, assume that this MaxScale does not
+    // have the locks. This is correct if connection failed.
+    string cmd = string_printf("SELECT IS_USED_LOCK('%s'), IS_USED_LOCK('%s');",
+                               SERVER_LOCK_NAME, MASTER_LOCK_NAME);
+    string err_msg;
+    ServerLock serverlock_status_new;
+    ServerLock masterlock_status_new;
+    auto res_is_used = execute_query(cmd, &err_msg);
+
+    if (res_is_used && res_is_used->get_col_count() == 2 && res_is_used->next_row())
+    {
+        serverlock_status_new = read_lock_status(*res_is_used, 0);
+        report_unexpected_lock(m_serverlock, serverlock_status_new, SERVER_LOCK_NAME);
+
+        masterlock_status_new = read_lock_status(*res_is_used, 1);
+        report_unexpected_lock(m_masterlock, masterlock_status_new, MASTER_LOCK_NAME);
+        // Masterlock is not acquired here, only status is updated.
+    }
+
+    m_serverlock = serverlock_status_new;
+    m_masterlock = masterlock_status_new;
+    if (!err_msg.empty())
+    {
+        MXB_ERROR("Failed to update lock status of server '%s'. %s", name(), err_msg.c_str());
+    }
+}
+
+/**
+ * Release a server lock.
+ *
+ * @param lock_type Which lock to release
+ * @return True if lock was released normally. False does not mean lock is held, as it may not have been
+ * held to begin with.
+ */
+bool MariaDBServer::release_lock(LockType lock_type)
+{
+    bool normal_lock = (lock_type == LockType::SERVER);
+    ServerLock* output = normal_lock ? &m_serverlock : &m_masterlock;
+    const char* lockname = normal_lock ? SERVER_LOCK_NAME : MASTER_LOCK_NAME;
+
+    // Try to release the lock.
+    string cmd = string_printf("SELECT RELEASE_LOCK('%s')", lockname);
+    string err_msg;
+    ServerLock lock_result;
+    bool rval = false;
+
+    auto res_release_lock = execute_query(cmd, &err_msg);
+    if (res_release_lock && res_release_lock->get_col_count() == 1 && res_release_lock->next_row())
+    {
+        if (res_release_lock->field_is_null(0))
+        {
+            // Lock did not exist and can be considered free.
+            lock_result.set_status(ServerLock::Status::FREE);
+        }
+        else
+        {
+            auto res_num = res_release_lock->get_int(0);
+            if (res_num == 1)
+            {
+                // Expected. Lock was owned by this connection and is released.
+                lock_result.set_status(ServerLock::Status::FREE);
+                rval = true;
+            }
+            else
+            {
+                // Lock was owned by another connection and was not freed. The owner is unknown.
+                lock_result.set_status(ServerLock::Status::OWNED_OTHER);
+            }
+        }
+    }
+    else
+    {
+        MXB_ERROR("Failed to release lock on server '%s'. %s", name(), err_msg.c_str());
+    }
+
+    *output = lock_result;
+    return rval;
+}
+
+bool MariaDBServer::get_lock(LockType lock_type)
+{
+    bool normal_lock = (lock_type == LockType::SERVER);
+    ServerLock* output = normal_lock ? &m_serverlock : &m_masterlock;
+    const char* lockname = normal_lock ? SERVER_LOCK_NAME : MASTER_LOCK_NAME;
+
+    bool rval = false;
+    // When taking the lock, also set wait_timeout in the same query. This should ensure that the timeout
+    // is set whenever this server has the lock, regardless of any auto-reconnects that may happen.
+    mxb_assert(m_settings.wait_timeout_normal_s > 0);
+    string cmd = string_printf("SET @@session.wait_timeout=%i; SELECT GET_LOCK('%s', 0);",
+                               m_settings.wait_timeout_normal_s, lockname);
+    string err_msg;
+    ServerLock lock_result;
+    auto res_get_lock = execute_query(cmd, &err_msg);
+    const int column = 0;
+
+    if (res_get_lock && res_get_lock->get_col_count() == 1 && res_get_lock->next_row())
+    {
+        // If the result is NULL, an error occurred.
+        if (!res_get_lock->field_is_null(column))
+        {
+            auto lock_res = res_get_lock->get_int(column);
+            if (lock_res == 1)
+            {
+                // Got the lock.
+                lock_result.set_status(ServerLock::Status::OWNED_SELF, con->thread_id);
+                rval = true;
+            }
+            else
+            {
+                // Someone else got to it first. Owner unknown.
+                lock_result.set_status(ServerLock::Status::OWNED_OTHER);
+            }
+        }
+    }
+    else
+    {
+        MXB_ERROR("Failed to acquire lock on server '%s'. %s", name(), err_msg.c_str());
+    }
+
+    *output = lock_result;
+    return rval;
+}
+
+bool MariaDBServer::lock_owned(LockType lock_type)
+{
+    if (lock_type == LockType::SERVER)
+    {
+        return m_serverlock.status() == ServerLock::Status::OWNED_SELF;
+    }
+    else
+    {
+        return m_masterlock.status() == ServerLock::Status::OWNED_SELF;
+    }
+}
+
+/**
+ * Release both types of locks held on the server.
+ *
+ * @return How many locks were held and then released
+ */
+int MariaDBServer::release_all_locks()
+{
+    int normal_releases = 0;
+    for (auto lock_type : {MariaDBServer::LockType::SERVER, MariaDBServer::LockType::MASTER})
+    {
+        if (lock_owned(lock_type))
+        {
+            normal_releases += release_lock(lock_type);
+        }
+    }
+    return normal_releases;
+}
+
+int64_t MariaDBServer::conn_id() const
+{
+    return con ? (int64_t)con->thread_id : -1;
+}
+
+bool MariaDBServer::marked_as_master(string* why_not) const
+{
+    bool rval = true;
+    if (m_masterlock.status() != ServerLock::Status::OWNED_OTHER)
+    {
+        rval = false;
+        if (why_not)
+        {
+            *why_not = "it's not marked as master by the primary MaxScale";
+        }
+    }
+    else if (!(m_masterlock == m_serverlock))
+    {
+        rval = false;
+        if (why_not)
+        {
+            *why_not = "the normal lock and master lock are claimed by different connection id:s";
+        }
+    }
+    return rval;
+}
+
+void MariaDBServer::clear_locks_info()
+{
+    m_serverlock.set_status(ServerLock::Status::UNKNOWN);
+    m_masterlock.set_status(ServerLock::Status::UNKNOWN);
+}
+
+ServerLock MariaDBServer::masterlock_status() const
+{
+    return m_masterlock;
+}
+
+ServerLock MariaDBServer::serverlock_status() const
+{
+    return m_serverlock;
+}
+
+ServerLock MariaDBServer::lock_status(LockType locktype) const
+{
+    return (locktype == LockType::SERVER) ? m_serverlock : m_masterlock;
+}
+
+SERVER::VersionInfo::Type MariaDBServer::server_type() const
+{
+    return server->info().type();
+}
+
+void MariaDBServer::update_rlag_state(int64_t limit)
+{
+    mxb_assert(limit >= 0);
+    using mxs::RLagState;
+    auto rlag_now = m_replication_lag;
+    // Only change the state if rlag could be read.
+    if (rlag_now != mxs::Target::RLAG_UNDEFINED)
+    {
+        auto new_state = (rlag_now > limit) ? RLagState::ABOVE_LIMIT : RLagState::BELOW_LIMIT;
+        if (new_state != m_rlag_state)
+        {
+            m_rlag_state = new_state;
+            string new_event = (new_state == RLagState::ABOVE_LIMIT) ? "rlag_above" : "rlag_below";
+            m_new_events.push_back(move(new_event));
+        }
+    }
+}
+
+const MonitorServer::EventList& MariaDBServer::new_custom_events() const
+{
+    return m_new_events;
+}
+
+const std::string& MariaDBServer::permission_test_query() const
+{
+    return m_capabilities.mysql_replica_syntax ? grant_test_query_mysql : grant_test_query;
+}
+
+bool MariaDBServer::relax_connector_timeouts(std::chrono::seconds op_timeout)
+{
+    // Limit final connector timeout. Statement timeout will be 1s less.
+    auto new_timeout_max = 41s;
+    auto new_timeout_min = 6s;
+    // Prefer a timeout a bit smaller than the remaining operation time so that one query cannot
+    // consume all the remaining time.
+    auto eff_op_timeout = op_timeout - 5s;
+
+    std::chrono::seconds new_timeout = std::clamp(eff_op_timeout, new_timeout_min, new_timeout_max);
+
+    int conn_to = -1;
+    mysql_get_optionv(con, MYSQL_OPT_READ_TIMEOUT, &conn_to);
+    // If the existing connector timeout was already larger than the requested one (or unlimited),
+    // use the old one.
+    if (conn_to == 0 || conn_to > new_timeout.count())
+    {
+        new_timeout = conn_to * 1s;
+    }
+
+    // Save the previous connection to a backup field. This keeps the old connection with its old
+    // timeouts alive and also preserves any exclusive locks the connection may hold. Do this
+    // even if using the same timeout to keep behavior similar to the normal case.
+    mxb_assert(!m_old_conn && con);
+    m_old_conn = std::exchange(con, nullptr);
+
+    auto conn_settings = m_shared.conn_settings;
+    conn_settings.read_timeout = new_timeout;
+    conn_settings.write_timeout = new_timeout;
+
+    bool rval = false;
+    auto res = ping_or_connect_to_db(conn_settings, *server, &con, &m_latest_error);
+    if (res == ConnectResult::NEWCONN_OK)
+    {
+        rval = true;
+    }
+    else
+    {
+        mysql_close(con);
+        con = nullptr;
+    }
+    return rval;
+}
+
+void MariaDBServer::restore_connector_timeouts()
+{
+    // The relax-function swaps the fields even on failure. The current connection is null in that case.
+    mxb_assert(m_old_conn);
+    if (con)
+    {
+        mysql_close(con);
+    }
+    con = std::exchange(m_old_conn, nullptr);
+}
+
+
+std::tuple<bool, std::vector<MariaDBServer::ConnInfo>>
+MariaDBServer::get_super_user_conns(mxb::Json& error_out)
+{
+    // This is meant to be only called from kick_out_super_users() during switchover demotion.
+    mxb_assert(con && m_old_conn);
+
+    std::vector<ConnInfo> super_user_conns;
+    // Select conn id and username from live connections, match with super-user accounts. Filter out
+    // replicating connections and the monitor connections (current and old). Use monitor username instead of
+    // connection id to filter out monitor connections so that connections from cooperating monitors are not
+    // killed (assuming same username). Preserve system threads as well.
+    // Global privileges are stored differently on more recent server versions so the join-clause changes.
+    const char query_fmt[] =
+        "SELECT DISTINCT P.id,P.user FROM (SELECT * FROM information_schema.PROCESSLIST WHERE "
+        "USER != '%s' AND USER != 'system user' AND COMMAND != 'Binlog Dump') AS P INNER JOIN (%s) AS U ON "
+        "(U.user = P.user);";
+    string admin_users_select;
+    if (m_capabilities.read_only_admin)
+    {
+        // Magic numbers from MariaDB Server source.
+        // See https://github.com/MariaDB/server/blob/11.1/sql/privilege.h
+        uint64_t SUPER_ACL = (1UL << 15);
+        uint64_t READ_ONLY_ADMIN_ACL = (1ULL << 33);
+        uint64_t mask = READ_ONLY_ADMIN_ACL;
+        if (!m_capabilities.separate_ro_admin)
+        {
+            // Super includes ro-admin, so need to kick them out too.
+            mask |= SUPER_ACL;
+        }
+        admin_users_select = mxb::string_printf(
+            "SELECT * FROM (SELECT user, JSON_VALUE(priv,'$.access') AS access FROM mysql.global_priv) "
+            "AS A where A.access & %li > 0", mask);
+    }
+    else
+    {
+        admin_users_select = "SELECT * FROM mysql.user WHERE Super_priv = 'Y'";
+    }
+
+    bool rval = false;
+    string error_msg;
+    unsigned int error_num;
+    string query = mxb::string_printf(query_fmt, conn_settings().username.c_str(),
+                                      admin_users_select.c_str());
+
+    auto res = execute_query(query, &error_msg, &error_num);
+    if (res)
+    {
+        rval = true;
+        int id_col = 0;
+        int user_col = 1;
+        super_user_conns.reserve(res->get_row_count());
+
+        while (res->next_row())
+        {
+            auto conn_id = res->get_int(id_col);
+            auto user = res->get_string(user_col);
+            super_user_conns.emplace_back(ConnInfo {conn_id, user});
+        }
+    }
+    else
+    {
+        // If query failed because of insufficient rights, don't consider this an error, just print
+        // a warning. Perhaps the user doesn't want the monitor doing this.
+        if (error_num == ER_DBACCESS_DENIED_ERROR || error_num == ER_TABLEACCESS_DENIED_ERROR
+            || error_num == ER_COLUMNACCESS_DENIED_ERROR)
+        {
+            rval = true;
+            MXB_WARNING("Monitor has insufficient grants to query logged in super-users on server '%s': "
+                        "%s Super-users may perform writes during the cluster manipulation operation.",
+                        name(), error_msg.c_str());
+        }
+        else
+        {
+            PRINT_JSON_ERROR(error_out, "Could not query connected super-users: %s",
+                             error_msg.c_str());
+        }
+    }
+    return {rval, super_user_conns};
+}
+
+bool MariaDBServer::check_gtid_stable(mxb::Json& error_out)
+{
+    // Look at gtid_binlog_pos, as that should exist for both a master and a relay.
+    bool gtid_stable = true;
+    string error_msg;
+    GtidList prev_gtid;
+
+    for (int i = 0; i < 3 && gtid_stable; i++)
+    {
+        if (i > 0)
+        {
+            std::this_thread::sleep_for(0.5s);
+        }
+
+        if (update_gtids(&error_msg))
+        {
+            if (i == 0)
+            {
+                prev_gtid = m_gtid_binlog_pos;
+            }
+            else if (!(m_gtid_binlog_pos == prev_gtid))
+            {
+                gtid_stable = false;
+                PRINT_JSON_ERROR(error_out,
+                                 "Gtid_Binlog_Pos of %s changed even when server was frozen "
+                                 "for demotion. Demotion cannot proceed safely. "
+                                 "Old gtid: %s New gtid: %s",
+                                 name(), prev_gtid.to_string().c_str(),
+                                 m_gtid_binlog_pos.to_string().c_str());
+            }
+        }
+        else
+        {
+            gtid_stable = false;
+            PRINT_JSON_ERROR(error_out, "Failed to update gtid:s of %s during demotion: %s.",
+                             name(), error_msg.c_str());
+        }
+    }
+    return gtid_stable;
+}
+
+void MariaDBServer::set_wait_timout(int wait_timeout)
+{
+    mxb_assert(wait_timeout > 0);
+    string errmsg;
+    string cmd = mxb::string_printf("SET @@session.wait_timeout=%i;", wait_timeout);
+    if (!execute_cmd_ex(cmd, "", QueryRetryMode::DISABLED, &errmsg, nullptr))
+    {
+        MXB_ERROR("Failed to set session wait_timeout on %s: %s", name(), errmsg.c_str());
+    }
+}
+
+void MariaDBServer::check_grants()
+{
+    if (m_settings.auto_op_configured)
+    {
+        // Do some coarse grant checking. Passes if any of the following are found. Does not guarantee
+        // that all grants are present (e.g. for switchover), but better than nothing. Demanding all
+        // grants would be overkill for simple features.
+        auto grants_res = execute_query("SHOW GRANTS;");
+        if (grants_res && grants_res->get_col_count() == 1 && grants_res->next_row())
+        {
+            string grants = grants_res->get_string(0);
+            if (grants.find("SUPER") == string::npos
+                && grants.find("READ_ONLY ADMIN") == string::npos
+                && grants.find("REPLICATION SLAVE ADMIN") == string::npos
+                && grants.find("ALL PRIVILEGES") == string::npos)
+            {
+                MXB_WARNING("%s lacks privileges on server %s for configured cluster operations. "
+                            "Please see MariaDB Monitor documentation for required grants and add "
+                            "them to '%s'.", monitor_name(), name(), conn_settings().username.c_str());
+            }
+        }
+    }
+}
+
+bool MariaDBServer::relay_log_missing_events(const GtidList& relay_log_pos,
+                                             const GtidList& target_binlog_pos) const
+{
+    return target_binlog_pos.events_ahead(relay_log_pos, GtidList::MISSING_DOMAIN_IGNORE) > 0;
+}
+
+MariaDBServer::WriteTestTblStatus MariaDBServer::check_write_test_table(const string& table)
+{
+    auto rval = WriteTestTblStatus::UNKNOWN;
+    string show_tbl_columns = mxb::string_printf("show columns from %s;", table.c_str());
+    string errmsg;
+    unsigned int errornum = 0;
+    auto res = execute_query(show_tbl_columns, &errmsg, &errornum);
+
+    bool recreate = false;
+    if (res)
+    {
+        if (res->get_col_count() >= 1 && res->get_row_count() == 3)
+        {
+            res->next_row();
+            string col1_name = res->get_string(0);
+            res->next_row();
+            string col2_name = res->get_string(0);
+            res->next_row();
+            string col3_name = res->get_string(0);
+
+            if (col1_name == "id" && col2_name == "date" && col3_name == "gtid")
+            {
+                // Looks like table has required columns.
+                MXB_NOTICE("Using existing write test table '%s'.", table.c_str());
+                rval = WriteTestTblStatus::CREATED;
+            }
+            else
+            {
+                recreate = true;
+            }
+        }
+        else
+        {
+            recreate = true;
+        }
+    }
+    else if (errornum == ER_NO_SUCH_TABLE)
+    {
+        recreate = true;
+    }
+    else
+    {
+        // Try again next tick.
+        MXB_WARNING("Could not check status of write test table '%s'. %s", table.c_str(), errmsg.c_str());
+    }
+
+    if (recreate)
+    {
+        string create_tbl = mxb::string_printf("create or replace table %s "
+                                               "(id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY NOT NULL, "
+                                               "`date` TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+                                               "`gtid` TEXT NULL);", table.c_str());
+        bool created = execute_cmd_ex(create_tbl, "", QueryRetryMode::ENABLED, &errmsg, &errornum);
+        if (created)
+        {
+            rval = WriteTestTblStatus::CREATED;
+            MXB_NOTICE("Write test table '%s' created.", table.c_str());
+        }
+        else if (mxq::mysql_is_net_error(errornum))
+        {
+            MXB_WARNING("Write test table '%s' creation failed. %s.", table.c_str(), errmsg.c_str());
+        }
+        else
+        {
+            // Unexpected error, perhaps monitor lacks privileges.
+            MXB_WARNING("Write test table '%s' creation failed. %s. Will not try again. Please fix the error "
+                        "and then restart the monitor.", table.c_str(), errmsg.c_str());
+            rval = WriteTestTblStatus::ERROR;
+        }
+    }
+    return rval;
+}
+
+bool MariaDBServer::test_writability(const string& table)
+{
+    bool rval = false;
+    GtidList old_gtid = m_gtid_binlog_pos;
+    string errmsg;
+    unsigned int errornum;
+    string write_query = mxb::string_printf("insert into %s (gtid) values (@@gtid_binlog_pos);",
+                                            table.c_str());
+    // Run the insert as a time-limited command. As test_writability() is ran failcount times
+    // before failover, repeating the query here is not necessary.
+    if (execute_cmd_time_limit(write_query, conn_settings().read_timeout, &errmsg, &errornum))
+    {
+        if (update_gtids(&errmsg))
+        {
+            if (m_gtid_binlog_pos != old_gtid)
+            {
+                MXB_NOTICE("Write test on %s succeeded, gtid_binlog_pos is now %s.",
+                           name(), m_gtid_binlog_pos.to_string().c_str());
+                rval = true;
+            }
+            else
+            {
+                MXB_ERROR("Insert into '%s' succeeded yet gtid_binlog_pos of %s did not change.",
+                          table.c_str(), name());
+            }
+        }
+        else
+        {
+            MXB_ERROR("Failed to update gtids after write test. %s Assuming write test failed.",
+                      errmsg.c_str());
+        }
+    }
+    else
+    {
+        MXB_ERROR("Failed to write to table '%s'. %s", table.c_str(), errmsg.c_str());
+    }
+    return rval;
+}
+
+void MariaDBServer::truncate_write_test_table(const string& table)
+{
+    string errmsg;
+    string query = mxb::string_printf("select count(*) from %s;", table.c_str());
+    auto res = execute_query(query, &errmsg);
+    if (res && res->next_row())
+    {
+        auto n_rows = res->get_int(0);
+        if (n_rows > 100)
+        {
+            string delete_cmd = mxb::string_printf("delete from %s order by id limit %li;",
+                                                   table.c_str(), n_rows - 20);
+            if (!execute_cmd(delete_cmd, &errmsg))
+            {
+                MXB_ERROR("Could not truncate write test table. %s", errmsg.c_str());
+            }
+        }
+    }
+    else
+    {
+        MXB_ERROR("Could not check write test table size. %s", errmsg.c_str());
+    }
+}

--- a/server/modules/monitor/mysqlrepmon/mariadbserver.hh
+++ b/server/modules/monitor/mysqlrepmon/mariadbserver.hh
@@ -1,0 +1,702 @@
+/*
+ * Copyright (c) 2018 MariaDB Corporation Ab
+ * Copyright (c) 2023 MariaDB plc, Finnish Branch
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file and at www.mariadb.com/bsl11.
+ *
+ * Change Date: 2027-09-09
+ *
+ * On the date above, in accordance with the Business Source License, use
+ * of this software will be governed by version 2 or later of the General
+ * Public License.
+ */
+#pragma once
+#include "mariadbmon_common.hh"
+#include <functional>
+#include <string>
+#include <memory>
+#include <mutex>
+#include <maxbase/stopwatch.hh>
+#include <maxbase/queryresult.hh>
+#include <maxscale/monitor.hh>
+#include "server_utils.hh"
+
+class MariaDBServer;
+// Server pointer array
+typedef std::vector<MariaDBServer*> ServerArray;
+using ServerType = SERVER::VersionInfo::Type;
+
+/**
+ * Data required for checking replication topology cycles and other graph algorithms. This data is mostly
+ * used by the monitor object, as the data only makes sense in relation to other nodes.
+ */
+struct NodeData
+{
+    // Default values for index parameters
+    static const int INDEX_NOT_VISITED = 0;
+    static const int INDEX_FIRST = 1;
+    // Default values for the cycle
+    static const int CYCLE_NONE = 0;
+    static const int CYCLE_FIRST = 1;
+    // Default value for reach
+    static const int REACH_UNKNOWN = -1;
+
+    // Bookkeeping for graph searches. May be overwritten by multiple algorithms.
+    int  index;         /* Marks the order in which this node was visited. */
+    int  lowest_index;  /* The lowest index node this node has in its subtree. */
+    bool in_stack;      /* Is this node currently is the search stack. */
+
+    // Results from algorithm runs. Should only be overwritten when server data has been queried.
+    int         cycle;          /* Which cycle is this node part of, if any. */
+    int         reach;          /* How many servers replicate from this server or its children. */
+    ServerArray parents;        /* Which nodes is this node replicating from. External masters excluded. */
+    ServerArray parents_failed; /* Broken replication sources */
+    ServerArray children;       /* Which nodes are replicating from this node. */
+    ServerArray children_failed;/* Nodes with broken replication links. */
+
+    std::vector<int64_t> external_masters;      /* Server id:s of external masters. */
+
+    NodeData();
+
+    /**
+     * Reset result data to default values. Should be ran when starting an iteration.
+     */
+    void reset_results();
+
+    /**
+     * Reset index data. Should be ran before an algorithm run.
+     */
+    void reset_indexes();
+};
+
+/**
+ * Monitor specific information about a server. Eventually, this will be the primary data structure handled
+ * by the monitor. These are initialized in @c init_server_info.
+ */
+class MariaDBServer : public mxs::MariaServer
+{
+public:
+    class SharedSettings;
+
+    MariaDBServer(SERVER* server, int config_index,
+                  const MonitorServer::SharedSettings& base_settings,
+                  const MariaDBServer::SharedSettings& settings);
+
+    class EventInfo
+    {
+    public:
+        std::string name;       /**< Event name in <database.name> form */
+        std::string definer;    /**< Definer of the event */
+        std::string status;     /**< Status of the event */
+        std::string charset;    /**< character_set_client-field */
+        std::string collation;  /**< collation_connection-field */
+    };
+
+    enum class BinlogMode
+    {
+        BINLOG_ON,
+        BINLOG_OFF
+    };
+
+    enum class SemiSyncStatus
+    {
+        UNKNOWN,
+        ON,
+        OFF,
+    };
+
+    // Class which encapsulates server capabilities depending on its version.
+    class Capabilities
+    {
+    public:
+        bool basic_support {false};         // Is the server version supported by the monitor at all?
+        bool gtid {false};                  // Supports MariaDB gtid? Required for failover etc.
+        bool slave_status_all {false};      // Supports "show all slaves status"?
+        bool mysql_replica_syntax {false};  // MySQL 8.0.22+: must use "SHOW REPLICA STATUS" etc. The
+                                            // legacy "SLAVE" spelling was removed in MySQL 8.4.
+        bool max_statement_time {false};    // Supports max_statement_time?
+        bool events {false};                // Supports event handling?
+        bool read_only_admin {false};       // Implements read-only admin priv?
+        bool separate_ro_admin {false};     // Is read-only admin separate from super?
+        bool demote_to_slave {false};       // Support for MASTER_DEMOTE_TO_SLAVE in CHANGE MASTER TO
+    };
+
+    // This class groups some miscellaneous replication related settings together.
+    class ReplicationSettings
+    {
+    public:
+        bool gtid_strict_mode = false;  /* Enable additional checks for replication */
+        bool log_bin = false;           /* Is binary logging enabled? */
+        bool log_slave_updates = false; /* Does the slave write replicated events to binlog? */
+    };
+
+    // Settings shared between the MariaDB-Monitor and the MariaDB-Servers.
+    // These are only written to when configuring the monitor.
+    class SharedSettings
+    {
+    public:
+        // Required by cluster operations
+        std::string replication_user;           /**< Username for CHANGE MASTER TO-commands */
+        std::string replication_password;       /**< Password for CHANGE MASTER TO-commands */
+        bool        replication_ssl {false};    /**< Set MASTER_SSL = 1 in CHANGE MASTER TO-commands */
+        std::string replication_custom_opts;    /**< Custom CHANGE MASTER TO options */
+
+        std::string promotion_sql_file;     /**< File with sql commands which are ran to a server being
+                                             *  promoted. */
+        std::string demotion_sql_file;      /**< File with sql commands which are ran to a server being
+                                             *  demoted. */
+
+        /* Should failover/switchover enable/disable any scheduled events on the servers during
+         * promotion/demotion? */
+        bool handle_event_scheduler {true};
+
+        /** Should the server regularly update locks status. True if either lock mode is on. */
+        bool server_locks_enabled {false};
+        int  wait_timeout_normal_s {-1};    /* wait_timeout during normal operation */
+        bool auto_op_configured {false};    /* Is any automatic cluster op enabled. Informational only.*/
+
+        std::chrono::seconds switchover_timeout {0};    /* Switchover time limit */
+
+        uint32_t master_conds;  /**< Master conditions */
+        uint32_t slave_conds;   /**< Slave conditions */
+    };
+
+    /* What position this server has in the monitor config? Used for tiebreaking between servers. */
+    int m_config_index = 0;
+
+    Capabilities m_capabilities;                    /* Server capabilities */
+
+    int64_t m_server_id = Gtid::SERVER_ID_UNKNOWN;  /* Value of @@server_id. Valid values are
+                                                     * 32bit unsigned. */
+    int64_t m_gtid_domain_id = GTID_DOMAIN_UNKNOWN; /* The value of gtid_domain_id, the domain which is used
+                                                     * for new non-replicated events. */
+
+    bool             m_read_only = false;   /* Value of @@read_only */
+    GtidList         m_gtid_current_pos;    /* Gtid of latest event. */
+    GtidList         m_gtid_binlog_pos;     /* Gtid of latest event written to binlog. */
+    SlaveStatusArray m_slave_status;        /* Data returned from SHOW (ALL) SLAVE(S) STATUS */
+    SlaveStatusArray m_old_slave_status;    /* Data from the previous loop */
+    NodeData         m_node;                /* Replication topology data */
+    SemiSyncStatus   m_ss_status = SemiSyncStatus::UNKNOWN;
+
+    /* Replication lag of the server. Used during calculation so that the actual SERVER struct is
+     * only written to once. */
+    int64_t m_replication_lag = mxs::Target::RLAG_UNDEFINED;
+
+    /* Has anything that could affect replication topology changed this iteration?
+     * Causes: server id, slave connections, read-only. */
+    bool m_topology_changed = true;
+
+    // If true, warn when querying of events fails
+    bool m_warn_event_handling = true;
+
+    /* Miscellaneous replication related settings. These are not normally queried from the server, call
+     * 'update_replication_settings' before use. */
+    ReplicationSettings m_rpl_settings;
+
+    EventNameSet m_enabled_events;          /* Enabled scheduled events */
+    bool         m_cmd_grant_fail {false};  /* Command failed due to insufficient privileges. */
+
+    /**
+     * Print server information to a json object.
+     *
+     * @return Json diagnostics object
+     */
+    json_t* to_json() const;
+
+    void update_server(bool time_to_update_disk_space, bool first_tick, bool is_topology_master,
+                       bool reconnect);
+
+    std::string print_changed_slave_connections();
+
+    /**
+     * Query this server.
+     */
+    void monitor_server();
+
+    /**
+     * Update server version. This method should be called after (re)connecting to a
+     * backend. Calling this every monitoring loop is overkill.
+     */
+    void update_server_version();
+
+    /**
+     * Calculate how many events are left in the relay log of the slave connection.
+     *
+     * @param slave_conn The slave connection to calculate for
+     * @return Number of events in relay log. Always  0 or greater.
+     */
+    uint64_t relay_log_events(const SlaveStatus& slave_conn) const;
+
+    /**
+     * execute_cmd_ex with query retry ON.
+     */
+    bool execute_cmd(const std::string& cmd, std::string* errmsg_out = nullptr);
+
+    /**
+     * execute_cmd_ex with query retry OFF.
+     */
+    bool execute_cmd_no_retry(const std::string& cmd, const std::string& masked_cmd,
+                              std::string* errmsg_out = nullptr, unsigned int* errno_out = nullptr);
+
+    /**
+     * Update server slave connection information.
+     *
+     * @param gtid_domain Which gtid domain should be parsed.
+     * @param errmsg_out Where to store an error message if query fails. Can be null.
+     * @return True on success
+     */
+    bool do_show_slave_status(std::string* errmsg_out = nullptr);
+
+    /**
+     * Query gtid_current_pos and gtid_binlog_pos and save the values to the server.
+     *
+     * @param errmsg_out Where to store an error message if query fails. Can be null.
+     * @return True if query succeeded
+     */
+    bool update_gtids(std::string* errmsg_out = nullptr);
+
+    /**
+     * Query a few miscellaneous replication settings.
+     *
+     * @param error_out Query error output
+     * @return True on success
+     */
+    bool update_replication_settings(std::string* error_out = nullptr);
+
+    /**
+     * Query and save server_id, read_only and (if 10.X) gtid_domain_id.
+     *
+     * @param errmsg_out Where to store an error message if query fails. Can be null.
+     * @return True on success.
+     */
+    bool read_server_variables(std::string* errmsg_out = nullptr);
+
+    /**
+     * Checks whether semi-sync is working correctly on the master side of things
+     */
+    void check_semisync_master_status();
+
+    /**
+     * Print warnings if gtid_strict_mode or log_slave_updates is off. Does not query the server,
+     * so 'update_replication_settings' should have been called recently to update the values.
+     */
+    void warn_replication_settings() const;
+
+    /**
+     * Wait until server catches up to demotion target. Only considers gtid domains common
+     * to this server and the target. The gtid compared to on the demotion target is 'gtid_binlog_pos'.
+     * It is not updated during this method.
+     *
+     * The gtid used for comparison on this server is 'gtid_binlog_pos' if this server has both 'log_bin'
+     * and 'log_slave_updates' on, and 'gtid_current_pos' otherwise. This server is updated during the
+     * method.
+     *
+     * @return True, if target server gtid was reached within allotted time
+     */
+    bool catchup_to_master(GeneralOpData& op, const GtidList& target);
+
+    /**
+     * Find slave connection to the target server. If the IO thread is trying to connect
+     * ("Connecting"), the connection is only accepted if the 'Master_Server_Id' is known to be correct.
+     * If the IO or the SQL thread is stopped, the connection is not returned.
+     *
+     * @param target Immediate master or relay server
+     * @return The slave status info of the slave thread, or NULL if not found or not accepted
+     */
+    const SlaveStatus* slave_connection_status(const MariaDBServer* target) const;
+
+    /**
+     * Find slave connection to the target server. Only considers host and port when selecting
+     * the connection. A matching connection is accepted even if its IO or SQL thread is stopped.
+     *
+     * @param target Immediate master or relay server
+     * @return The slave status info of the slave thread, or NULL if not found
+     */
+    const SlaveStatus* slave_connection_status_host_port(const MariaDBServer* target) const;
+
+    /**
+     * Checks if this server can replicate from master. Only considers gtid:s and only detects obvious
+     * errors. The non-detected errors will mostly be detected once the slave tries to start replicating.
+     * Before calling this, update the gtid:s of the master so that the the gtid:s of the master are more
+     * recent than those of this server.
+     *
+     * @param master_info Master server
+     * @param reason_out Details the reason for a negative result
+     * @return True if slave can replicate from master
+     */
+    bool can_replicate_from(MariaDBServer* master, std::string* reason_out) const;
+
+    /**
+     * Check if the server can be demoted by switchover.
+     *
+     * @param reason_out Output explaining why server cannot be demoted
+     * @return True if server can be demoted
+     */
+    bool can_be_demoted_switchover(SwitchoverType type, std::string* reason_out);
+
+    enum class FOBinlogPosPolicy
+    {
+        FAIL_UNKNOWN,   /*<< Block failover if primary server binlog pos is unknown. */
+        ALLOW_UNKNOWN   /*<< Allow failover even if primary server binlog pos is unknown. */
+    };
+
+    /**
+     * Check if the server can be demoted by failover.
+     *
+     * @param binlog_policy Is failover with unknown master gtid_binlog_pos allowed
+     * @param reason_out Output explaining why server cannot be demoted
+     * @return True if server can be demoted
+     */
+    bool can_be_demoted_failover(FOBinlogPosPolicy binlog_policy, std::string* reason_out) const;
+
+    /**
+     * Check if the server can be promoted by switchover or failover.
+     *
+     * @param op Switchover or failover
+     * @param demotion_target The server this should be promoted to
+     * @param reason_out Output for the reason server cannot be promoted
+     * @return True, if suggested new master is a viable promotion candidate
+     */
+    bool can_be_promoted(OperationType op, const MariaDBServer* demotion_target, std::string* reason_out);
+
+    /**
+     * Read the file contents and send them as sql queries to the server. Any data
+     * returned by the queries is discarded.
+     *
+     * @param server Server to send queries to
+     * @param path Text file path.
+     * @param error_out Error output
+     * @return True if file was read and all commands were completed successfully
+     */
+    bool run_sql_from_file(const std::string& path, mxb::Json& error_out);
+
+    /**
+     * Enable any "SLAVESIDE_DISABLED" or "DISABLED events. Event scheduler is not touched. Only events
+     * with names matching an element in the event_names set are enabled.
+     *
+     * @param binlog_mode If OFF, binlog event creation is disabled for the session during method execution.
+     * @param event_names Names of events that should be enabled
+     * @param error_out Error output
+     * @return True if all SLAVESIDE_DISABLED events were enabled
+     */
+    bool enable_events(BinlogMode binlog_mode, const EventNameSet& event_names, mxb::Json& error_out);
+
+    /**
+     * Disable any "ENABLED" events. Event scheduler is not touched.
+     *
+     * @param binlog_mode If OFF, binlog event creation is disabled for the session during method execution.
+     * @param error_out Error output
+     * @return True if all ENABLED events were disabled
+     */
+    bool disable_events(BinlogMode binlog_mode, mxb::Json& error_out);
+
+    /**
+     * Stop and delete all slave connections.
+     *
+     * @param error_out Error output
+     * @return True if successful. If false, some connections may have been successfully deleted.
+     */
+    bool reset_all_slave_conns(mxb::Json& error_out);
+
+    /**
+     * Promote this server to take role of demotion target. Remove slave connections from this server.
+     * If target is/was a master, set read-only to OFF. Copy slave connections from target.
+     *
+     * @param op Cluster operation descriptor
+     * @return True if successful
+     */
+    bool promote(GeneralOpData& op, ServerOperation& promotion, OperationType type,
+                 const MariaDBServer* demotion_target);
+
+    /**
+     * Demote this server. Removes all slave connections. If server was master, sets read_only.
+     *
+     * @param general General operation data
+     * @param demotion Demotion-specific settings
+     * @param type Which specific operation is this part of
+     * @return True if successful
+     */
+    bool demote(GeneralOpData& general, ServerOperation& demotion, OperationType type);
+
+    /**
+     * Redirect the slave connection going to old master to replicate from new master.
+     *
+     * @param op Operation descriptor
+     * @param conn_settings The connection which is redirected
+     * @param new_master The new master for the redirected connection
+     * @return True on success
+     */
+    bool redirect_existing_slave_conn(GeneralOpData& op, const SlaveStatus::Settings& conn_settings,
+                                      const MariaDBServer* new_master);
+
+    enum class ReplicationOp
+    {
+        REDIRECT,   /**< Redirecting an existing slave connection. MASTER_USE_GTID not altered. */
+        PROMOTE,    /**< Promote an existing slave, will use MASTER_USE_GTID = slave_pos */
+        DEMOTE,     /**< Demote a previous master. Either sets MASTER_USE_GTID = current_pos or
+                     * MASTER_DEMOTE_TO_SLAVE = 1 */
+        CONN_SETT,  /**< Use gtid mode from connection settings, assuming that a new connection is created. */
+    };
+
+    /**
+     * Copy slave connections to this server. This is usually needed during switchover promotion and on
+     * the demoted server. It is assumed that all slave connections of this server have
+     * been stopped & removed so there will be no conflicts with existing connections.
+     * A special rule is applied to a connection which points to this server itself: that connection
+     * is directed towards the 'replacement'. This is required to properly handle connections between
+     * the promotion and demotion targets.
+     *
+     * @param op Operation descriptor
+     * @param conns_to_copy The connections to add to the server
+     * @param replacement Which server should replace this server as replication target
+     * @param repl_op Replication change type
+     * @return True on success
+     */
+    bool copy_slave_conns(GeneralOpData& op, const SlaveStatusArray& conns_to_copy,
+                          const MariaDBServer* replacement, ReplicationOp repl_op);
+
+    /**
+     * Remove slave connections from this server.
+     *
+     * @param op Operation descriptor
+     * @params conns_to_copy The connections to remove from the server
+     * @return True on success
+     */
+    bool remove_slave_conns(GeneralOpData& op, const SlaveStatusArray& conns_to_remove);
+
+    /**
+     * Create a new slave connection on the server and start it.
+     *
+     * @param op Operation descriptor
+     * @param conn_settings Existing connection to emulate
+     * @param repl_op Replication change type
+     * @return True on success
+     */
+    bool create_start_slave(GeneralOpData& op, const SlaveStatus::Settings& conn_settings,
+                            ReplicationOp repl_op);
+
+    /**
+     * Kill the connections of any super-users except for the monitor itself.
+     *
+     * @param op Operation descriptor
+     * @return True on success. If super-users cannot be queried because of insufficient privileges,
+     * return true as it means the user does not want this feature.
+     */
+    bool kick_out_super_users(GeneralOpData& op);
+
+    enum class WriteTestTblStatus {UNKNOWN, CREATED, ERROR};
+    WriteTestTblStatus check_write_test_table(const std::string& table);
+    bool               test_writability(const std::string& table);
+    void               truncate_write_test_table(const std::string& table);
+
+    /**
+     * Is binary log on? 'update_replication_settings' should be ran before this function to query the data.
+     *
+     * @return True if server has binary log enabled
+     */
+    bool binlog_on() const;
+
+    /**
+     * Check if server is a running master.
+     *
+     * @return True if server is a master
+     */
+    bool is_master() const;
+
+    /**
+     * Check if server is a running slave.
+     *
+     * @return True if server is a slave
+     */
+    bool is_slave() const;
+
+    /**
+     * Check if server is running and not in maintenance.
+     *
+     * @return True if server is usable
+     */
+    bool is_usable() const;
+
+    /**
+     * Check if server is running.
+     *
+     * @return True if server is running
+     */
+    bool is_running() const;
+
+    /**
+     * Check if server is down.
+     *
+     * @return True if server is down
+     */
+    bool is_down() const;
+
+    /**
+     * Check if server is in maintenance.
+     */
+    bool is_in_maintenance() const;
+
+    /**
+     * Is the server a relay master.
+     */
+    bool is_relay_master() const;
+
+    /**
+     * Is the server low on disk space?
+     */
+    bool is_low_on_disk_space() const;
+
+    /**
+     * Getter for m_read_only.
+     *
+     * @return True if server is in read_only mode
+     */
+    bool is_read_only() const;
+
+    /**
+     * Returns the server name.
+     *
+     * @return Server unique name
+     */
+    const char* name() const;
+
+    /**
+     * Clear server pending status flags.
+     *
+     * @param bits Which flags to clear
+     */
+    void clear_status(uint64_t bits);
+
+    /**
+     * Set server pending status flags.
+     *
+     * @param bits Which flags to set
+     */
+    void set_status(uint64_t bits);
+
+    void update_locks_status();
+
+    enum class LockType
+    {
+        SERVER,
+        MASTER,
+    };
+    bool release_lock(LockType lock_type);
+    int  release_all_locks();
+    bool get_lock(LockType lock_type);
+    bool lock_owned(LockType lock_type);
+
+    ServerLock masterlock_status() const;
+    ServerLock serverlock_status() const;
+    ServerLock lock_status(LockType lock_type) const;
+
+    bool marked_as_master(std::string* why_not = nullptr) const;
+
+    SERVER::VersionInfo::Type server_type() const;
+
+    /**
+     * Update server replication lag state in relation to the limit. If state changes, writes an event
+     * to the custom events list.
+     *
+     * @param limit Replication lag limit, in seconds. Assumed >= 0.
+     */
+    void update_rlag_state(int64_t limit);
+
+    const EventList& new_custom_events() const override;
+    void             set_wait_timout(int wait_timeout);
+
+    bool relax_connector_timeouts(std::chrono::seconds op_timeout);
+    void restore_connector_timeouts();
+
+private:
+    using EventManipulator = std::function<void (const EventInfo& event, mxb::Json& error_out)>;
+    using EventStatusMapper = std::function<std::string (const EventInfo& event)>;
+
+    enum class StopMode
+    {
+        STOP_ONLY,
+        RESET,
+        RESET_ALL
+    };
+    enum class QueryRetryMode
+    {
+        ENABLED,
+        DISABLED
+    };
+    enum class ReadOnlySetting
+    {
+        ENABLE,
+        DISABLE
+    };
+
+    /* Protects array-like fields from concurrent access. This is only required for fields which can be
+     * read from another thread while the monitor is running. In practice, these are fields read during
+     * diagnostics-methods. Reading inside monitor thread does not need to be mutexed, as outside threads
+     * only read the values. */
+    mutable std::mutex m_arraylock;
+
+    const SharedSettings& m_settings;       /* Settings required for various operations */
+
+    ServerLock m_serverlock;        /* Server lock status */
+    ServerLock m_masterlock;        /* Master lock status */
+
+    bool m_print_update_errormsg {true};    /* Should an update error be printed? */
+
+    /* Replication lag state compared to the MariaDBMonitor-specific replication lag script event limit. */
+    mxs::RLagState m_rlag_state {mxs::RLagState::NONE};
+
+    EventList m_new_events;
+    MYSQL*    m_old_conn {nullptr}; /**< Stored old connection for duration of switchover. */
+
+    bool               update_slave_status(std::string* errmsg_out = nullptr);
+    bool               sstatus_array_topology_equal(const SlaveStatusArray& new_slave_status) const;
+    const SlaveStatus* sstatus_find_previous_row(const SlaveStatus& new_row, size_t guess);
+
+    bool stop_slave_conn(const std::string& conn_name, StopMode mode, maxbase::Duration time_limit,
+                         mxb::Json& error_out);
+
+    bool execute_cmd_ex(const std::string& cmd, const std::string& masked_cmd, QueryRetryMode mode,
+                        std::string* errmsg_out = nullptr, unsigned int* errno_out = nullptr);
+    bool execute_cmd_time_limit(const std::string& cmd, const std::string& masked_cmd,
+                                maxbase::Duration time_limit,
+                                std::string* errmsg_out, unsigned int* errnum_out);
+    bool execute_cmd_time_limit(const std::string& cmd, maxbase::Duration time_limit,
+                                std::string* errmsg_out, unsigned int* errnum_out = nullptr);
+
+    bool set_read_only(ReadOnlySetting value, maxbase::Duration time_limit, mxb::Json& error_out);
+
+    bool merge_slave_conns(GeneralOpData& op, const SlaveStatusArray& conns_to_merge, ReplicationOp repl_op);
+    bool demote_master(GeneralOpData& general, OperationType type);
+    bool check_gtid_stable(mxb::Json& error_out);
+    bool relay_log_missing_events(const GtidList& relay_log_pos, const GtidList& target_binlog_pos) const;
+
+    struct ChangeMasterCmd
+    {
+        std::string real_cmd;   /**< Real command sent to server */
+        std::string masked_cmd; /**< Version with masked credentials */
+    };
+    ChangeMasterCmd generate_change_master_cmd(const SlaveStatus::Settings& conn_settings,
+                                               ReplicationOp repl_op);
+
+    bool update_enabled_events();
+
+    bool alter_events(BinlogMode binlog_mode, const EventStatusMapper& mapper, mxb::Json& error_out);
+    void warn_event_scheduler();
+    bool events_foreach(EventManipulator& func, mxb::Json& error_out);
+    bool alter_event(const EventInfo& event, const std::string& target_status, mxb::Json& error_out);
+
+    int64_t conn_id() const;
+    void    clear_locks_info();
+
+    struct ConnInfo
+    {
+        int64_t     conn_id {-1};
+        std::string username;
+    };
+    std::tuple<bool, std::vector<ConnInfo>> get_super_user_conns(mxb::Json& error_out);
+
+    const std::string& permission_test_query() const override;
+    void               check_grants() override;
+};

--- a/server/modules/monitor/mysqlrepmon/monitor_commands.cc
+++ b/server/modules/monitor/mysqlrepmon/monitor_commands.cc
@@ -1,0 +1,3306 @@
+/*
+ * Copyright (c) 2022 MariaDB Corporation Ab
+ * Copyright (c) 2023 MariaDB plc, Finnish Branch
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file and at www.mariadb.com/bsl11.
+ *
+ * Change Date: 2027-09-09
+ *
+ * On the date above, in accordance with the Business Source License, use
+ * of this software will be governed by version 2 or later of the General
+ * Public License.
+ */
+
+#include "monitor_commands.hh"
+#include <maxbase/format.hh>
+#include <maxbase/http.hh>
+#include <maxscale/modulecmd.hh>
+#include <maxscale/utils.hh>
+#include <unistd.h>
+#include "mariadbmon.hh"
+#include "ssh_utils.hh"
+
+using maxscale::Monitor;
+using maxscale::MonitorServer;
+using std::string;
+using std::move;
+using RType = ssh_util::CmdResult::Type;
+using namespace maxscale::modulecmd;
+
+namespace
+{
+// Execution mode for commands.
+enum class ExecMode
+{
+    SYNC,   /**< Function waits for completion or error */
+    ASYNC   /**< Function only schedules the operation and will not wait */
+};
+
+const char err_passive_mode[] = "%s requested but not performed, as MaxScale is in passive mode.";
+const char failover_cmd[] = "failover";
+const char safe_failover_cmd[] = "failover-safe";
+const char switchover_cmd[] = "switchover";
+const char rejoin_cmd[] = "rejoin";
+const char reset_repl_cmd[] = "reset-replication";
+const char release_locks_cmd[] = "release-locks";
+const char cs_add_node_cmd[] = "cs-add-node";
+const char cs_remove_node_cmd[] = "cs-remove-node";
+const char cs_get_status_cmd[] = "cs-get-status";
+const char cs_start_cluster_cmd[] = "cs-start-cluster";
+const char cs_stop_cluster_cmd[] = "cs-stop-cluster";
+const char cs_set_readonly_cmd[] = "cs-set-readonly";
+const char cs_set_readwrite_cmd[] = "cs-set-readwrite";
+const char rebuild_server_cmd[] = "rebuild-server";
+const char create_backup_cmd[] = "create-backup";
+const char restore_from_backup_cmd[] = "restore-from-backup";
+const char mask[] = "******";
+
+const char link_test_msg[] = "Test message";
+const int socat_timeout_s = 5;      // TODO: configurable?
+
+// Switchover argument names.
+const char so_arg_monitor[] = "monitor";
+const char so_arg_new_primary[] = "new_primary";
+const char so_arg_old_primary[] = "old_primary";
+const char so_arg_async[] = "async";
+const char so_arg_force[] = "force";
+const char so_arg_old_prim_maint[] = "old_primary_maint";
+
+bool manual_switchover(ExecMode mode, SwitchoverType type, const ModuleCmdArgs& args, json_t** error_out);
+bool manual_switchover(ExecMode mode, SwitchoverType type, AfterDemotion after_demotion, MariaDBMonitor* mon,
+                       SERVER* promotion_target, SERVER* demotion_target, json_t** error_out);
+bool manual_failover(ExecMode mode, FailoverType fo_type, const ModuleCmdArgs& args, json_t** output);
+bool manual_rejoin(ExecMode mode, const ModuleCmdArgs& args, json_t** output);
+bool manual_reset_replication(ExecMode mode, const ModuleCmdArgs& args, json_t** output);
+bool release_locks(ExecMode mode, const ModuleCmdArgs& args, json_t** output);
+
+std::tuple<MariaDBMonitor*, string, string> read_args(const ModuleCmdArgs& args);
+std::tuple<bool, std::chrono::seconds>      get_timeout(const string& timeout_str, json_t** output);
+
+bool check_datadir_path(const string& str)
+{
+    // Check that path starts with / but also contains something else. This hopefully prevents most
+    // accidental "rm -rf /"-style mistakes.
+    return str.length() >= 2 && str[0] == '/' && str.find_first_not_of('/', 1) != string::npos;
+}
+
+const char bad_datadir[] = "Data directory '%s' is invalid. The directory should be an absolute path and "
+                           "not point to root.";
+
+/**
+ * Command handlers. These are called by the rest-api.
+ */
+
+// switchover
+bool handle_manual_switchover(const ModuleCmdArgs& args, json_t** error_out)
+{
+    return manual_switchover(ExecMode::SYNC, SwitchoverType::NORMAL, args, error_out);
+}
+
+bool handle_manual_switchover_force(const ModuleCmdArgs& args, json_t** error_out)
+{
+    return manual_switchover(ExecMode::SYNC, SwitchoverType::FORCE, args, error_out);
+}
+
+// async-switchover
+bool handle_async_switchover(const ModuleCmdArgs& args, json_t** error_out)
+{
+    return manual_switchover(ExecMode::ASYNC, SwitchoverType::NORMAL, args, error_out);
+}
+
+// switchover with key-value arguments.
+std::tuple<bool, mxb::Json> handle_manual_switchover(const KVModuleCmdArgs& args)
+{
+    Monitor* mon = args.get_monitor(so_arg_monitor);
+    mxb_assert(mon);
+    auto handle = static_cast<MariaDBMonitor*>(mon);
+
+    SERVER* new_primary = args.get_server(so_arg_new_primary);
+    SERVER* curr_primary = args.get_server(so_arg_old_primary);
+
+    bool async = args.get_bool(so_arg_async);
+    auto execmode = async ? ExecMode::ASYNC : ExecMode::SYNC;
+
+    bool force = args.get_bool(so_arg_force);
+    auto so_type = force ? SwitchoverType::FORCE : SwitchoverType::NORMAL;
+
+    bool old_prim_maint = args.get_bool(so_arg_old_prim_maint);
+    auto after_demotion = old_prim_maint ? AfterDemotion::MAINTENANCE : AfterDemotion::REDIRECT;
+
+    json_t* output = nullptr;
+    bool ret = manual_switchover(execmode, so_type, after_demotion, handle, new_primary, curr_primary,
+                                 &output);
+
+    mxb::Json out(output, mxb::Json::RefType::STEAL);
+    return {ret, std::move(out)};
+}
+
+// failover
+bool handle_manual_failover(const ModuleCmdArgs& args, json_t** error_out)
+{
+    return manual_failover(ExecMode::SYNC, FailoverType::ALLOW_TRX_LOSS, args, error_out);
+}
+
+// async-failover
+bool handle_async_failover(const ModuleCmdArgs& args, json_t** error_out)
+{
+    return manual_failover(ExecMode::ASYNC, FailoverType::ALLOW_TRX_LOSS, args, error_out);
+}
+
+// failover
+bool handle_manual_failover_safe(const ModuleCmdArgs& args, json_t** error_out)
+{
+    return manual_failover(ExecMode::SYNC, FailoverType::SAFE, args, error_out);
+}
+
+// async-failover
+bool handle_async_failover_safe(const ModuleCmdArgs& args, json_t** error_out)
+{
+    return manual_failover(ExecMode::ASYNC, FailoverType::SAFE, args, error_out);
+}
+
+// rejoin
+bool handle_manual_rejoin(const ModuleCmdArgs& args, json_t** error_out)
+{
+    return manual_rejoin(ExecMode::SYNC, args, error_out);
+}
+
+// async-rejoin
+bool handle_async_rejoin(const ModuleCmdArgs& args, json_t** error_out)
+{
+    return manual_rejoin(ExecMode::ASYNC, args, error_out);
+}
+
+// reset-replication
+bool handle_manual_reset_replication(const ModuleCmdArgs& args, json_t** error_out)
+{
+    return manual_reset_replication(ExecMode::SYNC, args, error_out);
+}
+
+// async-reset-replication
+bool handle_async_reset_replication(const ModuleCmdArgs& args, json_t** error_out)
+{
+    return manual_reset_replication(ExecMode::ASYNC, args, error_out);
+}
+
+// release-locks
+bool handle_manual_release_locks(const ModuleCmdArgs& args, json_t** output)
+{
+    return release_locks(ExecMode::SYNC, args, output);
+}
+
+// async-release-locks
+bool handle_async_release_locks(const ModuleCmdArgs& args, json_t** output)
+{
+    return release_locks(ExecMode::ASYNC, args, output);
+}
+
+bool handle_fetch_cmd_result(const ModuleCmdArgs& args, json_t** output)
+{
+    mxb_assert(args.size() == 1);
+    mxb_assert(args[0].type == ArgType::MONITOR);
+    Monitor* mon = args[0].monitor;
+    auto mariamon = static_cast<MariaDBMonitor*>(mon);
+    mariamon->fetch_cmd_result(output);
+    return true;    // result fetch always works, even if there is nothing to return
+}
+
+bool handle_cancel_cmd(const ModuleCmdArgs& args, json_t** output)
+{
+    mxb_assert(args[0].type == ArgType::MONITOR);
+    Monitor* mon = args[0].monitor;
+    auto mariamon = static_cast<MariaDBMonitor*>(mon);
+    return mariamon->cancel_cmd(output);
+}
+
+bool handle_async_cs_add_node(const ModuleCmdArgs& args, json_t** output)
+{
+    bool rval = false;
+    auto [mon, host, timeout_str] = read_args(args);
+    auto [to_ok, timeout] = get_timeout(timeout_str, output);
+
+    if (to_ok)
+    {
+        rval = mon->schedule_cs_add_node(host, timeout, output);
+    }
+    return rval;
+}
+
+bool handle_async_cs_remove_node(const ModuleCmdArgs& args, json_t** output)
+{
+    bool rval = false;
+    auto [mon, host, timeout_str] = read_args(args);
+    auto [to_ok, timeout] = get_timeout(timeout_str, output);
+
+    if (to_ok)
+    {
+        rval = mon->schedule_cs_remove_node(host, timeout, output);
+    }
+    return rval;
+}
+
+bool handle_cs_get_status(const ModuleCmdArgs& args, json_t** output)
+{
+    auto* mon = static_cast<MariaDBMonitor*>(args[0].monitor);
+    return mon->run_cs_get_status(output);
+}
+
+bool handle_async_cs_get_status(const ModuleCmdArgs& args, json_t** output)
+{
+    auto* mon = static_cast<MariaDBMonitor*>(args[0].monitor);
+    return mon->schedule_cs_get_status(output);
+}
+
+bool async_cs_run_cmd_with_timeout(const std::function<bool(MariaDBMonitor*, std::chrono::seconds)>& func,
+                                   const ModuleCmdArgs& args, json_t** output)
+{
+    bool rval = false;
+    auto* mon = static_cast<MariaDBMonitor*>(args[0].monitor);
+    string timeout_str = args[1].string;
+    auto [to_ok, timeout] = get_timeout(timeout_str, output);
+    if (to_ok)
+    {
+        rval = func(mon, timeout);
+    }
+    return rval;
+}
+
+bool handle_async_cs_start_cluster(const ModuleCmdArgs& args, json_t** output)
+{
+    auto func = [output](MariaDBMonitor* mon, std::chrono::seconds timeout) {
+        return mon->schedule_cs_start_cluster(timeout, output);
+    };
+    return async_cs_run_cmd_with_timeout(func, args, output);
+}
+
+bool handle_async_cs_stop_cluster(const ModuleCmdArgs& args, json_t** output)
+{
+    auto func = [output](MariaDBMonitor* mon, std::chrono::seconds timeout) {
+        return mon->schedule_cs_stop_cluster(timeout, output);
+    };
+    return async_cs_run_cmd_with_timeout(func, args, output);
+}
+
+bool handle_async_cs_set_readonly(const ModuleCmdArgs& args, json_t** output)
+{
+    auto func = [output](MariaDBMonitor* mon, std::chrono::seconds timeout) {
+        return mon->schedule_cs_set_readonly(timeout, output);
+    };
+    return async_cs_run_cmd_with_timeout(func, args, output);
+}
+
+bool handle_async_cs_set_readwrite(const ModuleCmdArgs& args, json_t** output)
+{
+    auto func = [output](MariaDBMonitor* mon, std::chrono::seconds timeout) {
+        return mon->schedule_cs_set_readwrite(timeout, output);
+    };
+    return async_cs_run_cmd_with_timeout(func, args, output);
+}
+
+std::tuple<bool, string> datadir_helper(const ModuleCmdArgs& args, int expected_ind, json_t** output)
+{
+    bool rval = true;
+    string datadir = (int)args.size() > expected_ind ? args[expected_ind].string : "";
+    mxb::trim(datadir);
+
+    if (!datadir.empty() && !check_datadir_path(datadir))
+    {
+        *output = mxs_json_error_append(*output, bad_datadir, datadir.c_str());
+        rval = false;
+    }
+    return {rval, std::move(datadir)};
+}
+
+bool handle_async_rebuild_server(const ModuleCmdArgs& args, json_t** output)
+{
+    auto* mon = static_cast<MariaDBMonitor*>(args[0].monitor);
+    SERVER* target = args[1].server;
+    SERVER* source = args.size() > 2 ? args[2].server : nullptr;
+    auto [datadir_ok, datadir] = datadir_helper(args, 3, output);
+    return datadir_ok ? mon->schedule_rebuild_server(target, source, datadir, output) : false;
+}
+
+bool handle_async_create_backup(const ModuleCmdArgs& args, json_t** output)
+{
+    auto* mon = static_cast<MariaDBMonitor*>(args[0].monitor);
+    SERVER* source = args[1].server;
+    string bu_name = args[2].string;
+    return mon->schedule_create_backup(source, bu_name, output);
+}
+
+bool handle_async_restore_from_backup(const ModuleCmdArgs& args, json_t** output)
+{
+    auto* mon = static_cast<MariaDBMonitor*>(args[0].monitor);
+    SERVER* target = args[1].server;
+    string bu_name = args[2].string;
+    auto [datadir_ok, datadir] = datadir_helper(args, 3, output);
+    return datadir_ok ? mon->schedule_restore_from_backup(target, bu_name, datadir, output) : false;
+}
+
+/**
+ * Run manual switchover.
+ *
+ * @param mode    Execution mode
+ * @param args    The provided arguments
+ * @param output  Pointer where to place output object
+ *
+ * @return True, if the command was executed/scheduled, false otherwise.
+ */
+bool manual_switchover(ExecMode mode, SwitchoverType type, const ModuleCmdArgs& args, json_t** error_out)
+{
+    mxb_assert((args.size() >= 1) && (args.size() <= 3));
+    mxb_assert(args[0].type == ArgType::MONITOR);
+    mxb_assert((args.size() < 2) || (args[1].type == ArgType::SERVER));
+    mxb_assert((args.size() < 3) || (args[2].type == ArgType::SERVER));
+
+    Monitor* mon = args[0].monitor;
+    auto handle = static_cast<MariaDBMonitor*>(mon);
+    SERVER* promotion_server = (args.size() >= 2) ? args[1].server : nullptr;
+    SERVER* demotion_server = (args.size() == 3) ? args[2].server : nullptr;
+
+    return manual_switchover(mode, type, AfterDemotion::REDIRECT, handle, promotion_server, demotion_server,
+                             error_out);
+}
+
+bool manual_switchover(ExecMode mode, SwitchoverType type, AfterDemotion after_demotion, MariaDBMonitor* mon,
+                       SERVER* promotion_target, SERVER* demotion_target, json_t** error_out)
+{
+    bool rval = false;
+    if (mxs::Config::get().passive.get())
+    {
+        PRINT_MXS_JSON_ERROR(error_out, err_passive_mode, "Switchover");
+    }
+    else
+    {
+        switch (mode)
+        {
+        case ExecMode::SYNC:
+            rval = mon->run_manual_switchover(type, after_demotion, promotion_target, demotion_target,
+                                              error_out);
+            break;
+
+        case ExecMode::ASYNC:
+            rval = mon->schedule_async_switchover(after_demotion, promotion_target, demotion_target,
+                                                  error_out);
+            break;
+        }
+    }
+    return rval;
+}
+
+/**
+ * Run manual failover.
+ *
+ * @paran mode Execution mode
+ * @param args Arguments given by user
+ * @param output Json error output
+ * @return True on success
+ */
+bool manual_failover(ExecMode mode, FailoverType fo_type, const ModuleCmdArgs& args, json_t** output)
+{
+    mxb_assert(args.size() == 1);
+    mxb_assert(args[0].type == ArgType::MONITOR);
+    bool rv = false;
+
+    if (mxs::Config::get().passive.get())
+    {
+        PRINT_MXS_JSON_ERROR(output, err_passive_mode, "Failover");
+    }
+    else
+    {
+        Monitor* mon = args[0].monitor;
+        auto handle = static_cast<MariaDBMonitor*>(mon);
+
+        switch (mode)
+        {
+        case ExecMode::SYNC:
+            rv = handle->run_manual_failover(fo_type, output);
+            break;
+
+        case ExecMode::ASYNC:
+            rv = handle->schedule_async_failover(fo_type, output);
+            break;
+        }
+    }
+    return rv;
+}
+
+/**
+ * Run manual rejoin.
+ *
+ * @paran mode Execution mode
+ * @param args Arguments given by user
+ * @param output Json error output
+ * @return True on success
+ */
+bool manual_rejoin(ExecMode mode, const ModuleCmdArgs& args, json_t** output)
+{
+    mxb_assert(args.size() == 2);
+    mxb_assert(args[0].type == ArgType::MONITOR);
+    mxb_assert(args[1].type == ArgType::SERVER);
+
+    bool rv = false;
+    if (mxs::Config::get().passive.get())
+    {
+        PRINT_MXS_JSON_ERROR(output, "Rejoin requested but not performed, as MaxScale is in passive mode.");
+    }
+    else
+    {
+        Monitor* mon = args[0].monitor;
+        SERVER* server = args[1].server;
+        auto handle = static_cast<MariaDBMonitor*>(mon);
+
+        switch (mode)
+        {
+        case ExecMode::SYNC:
+            rv = handle->run_manual_rejoin(server, output);
+            break;
+
+        case ExecMode::ASYNC:
+            rv = handle->schedule_async_rejoin(server, output);
+            break;
+        }
+    }
+    return rv;
+}
+
+/**
+ * Run reset replication.
+ *
+ * @paran mode Execution mode
+ * @param args Arguments given by user
+ * @param output Json error output
+ * @return True on success
+ */
+bool manual_reset_replication(ExecMode mode, const ModuleCmdArgs& args, json_t** output)
+{
+    mxb_assert(args.size() >= 1);
+    mxb_assert(args[0].type == ArgType::MONITOR);
+    mxb_assert(args.size() == 1 || (args[1].type == ArgType::SERVER));
+
+    bool rv = false;
+    if (mxs::Config::get().passive.get())
+    {
+        PRINT_MXS_JSON_ERROR(output, "Replication reset requested but not performed, as MaxScale is in "
+                                     "passive mode.");
+    }
+    else
+    {
+        Monitor* mon = args[0].monitor;
+        SERVER* server = args[1].server;
+        auto handle = static_cast<MariaDBMonitor*>(mon);
+
+        switch (mode)
+        {
+        case ExecMode::SYNC:
+            rv = handle->run_manual_reset_replication(server, output);
+            break;
+
+        case ExecMode::ASYNC:
+            rv = handle->schedule_reset_replication(server, output);
+            break;
+        }
+    }
+    return rv;
+}
+
+/**
+ * Run release locks.
+ *
+ * @paran mode Execution mode
+ * @param args Arguments given by user
+ * @param output Json error output
+ * @return True on success
+ */
+bool release_locks(ExecMode mode, const ModuleCmdArgs& args, json_t** output)
+{
+    mxb_assert(args.size() == 1);
+    mxb_assert(args[0].type == ArgType::MONITOR);
+
+    bool rv = false;
+    Monitor* mon = args[0].monitor;
+    auto mariamon = static_cast<MariaDBMonitor*>(mon);
+
+    switch (mode)
+    {
+    case ExecMode::SYNC:
+        rv = mariamon->run_release_locks(output);
+        break;
+
+    case ExecMode::ASYNC:
+        rv = mariamon->schedule_release_locks(output);
+        break;
+    }
+    return rv;
+}
+
+std::tuple<MariaDBMonitor*, string, string> read_args(const ModuleCmdArgs& args)
+{
+    mxb_assert(args[0].type == ArgType::MONITOR);
+    mxb_assert(args.size() <= 1 || args[1].type == ArgType::STRING);
+    mxb_assert(args.size() <= 2 || args[2].type == ArgType::STRING);
+
+    MariaDBMonitor* mon = static_cast<MariaDBMonitor*>(args[0].monitor);
+    string text1 = args.size() >= 2 ? args[1].string : "";
+    string text2 = args.size() >= 3 ? args[2].string : "";
+
+    return {mon, text1, text2};
+}
+
+std::tuple<bool, std::chrono::seconds> get_timeout(const string& timeout_str, json_t** output)
+{
+    std::chrono::milliseconds duration;
+    mxs::config::DurationUnit unit;
+    std::chrono::seconds timeout = 0s;
+
+    bool rv = get_suffixed_duration(timeout_str.c_str(), &duration, &unit);
+    if (rv)
+    {
+        if (unit == mxs::config::DURATION_IN_MILLISECONDS)
+        {
+            MXB_WARNING("Duration specified in milliseconds, will be converted to seconds.");
+        }
+
+        timeout = std::chrono::duration_cast<std::chrono::seconds>(duration);
+    }
+    else
+    {
+        PRINT_MXS_JSON_ERROR(output,
+                             "Timeout must be specified with a 's', 'm', or 'h' suffix. 'ms' is accepted "
+                             "but the time will be converted to seconds.");
+        rv = false;
+    }
+
+    return {rv, timeout};
+}
+}
+
+void register_monitor_commands()
+{
+    /* *uncrustify-off* */
+    ModuleCmdArgDesc monitor_arg(ArgType::MONITOR, ARG_NAME_MATCHES_DOMAIN, "Monitor name");
+    auto switchover_argv =
+    {
+        monitor_arg,
+        {ArgType::SERVER, ARG_OPTIONAL, "New primary (optional)"    },
+        {ArgType::SERVER, ARG_OPTIONAL, "Current primary (optional)"}
+    };
+
+    modulecmd_register_command(MXB_MODULE_NAME, "switchover", CmdType::WRITE,
+                               handle_manual_switchover, switchover_argv,
+                               "Switch primary server with replica");
+
+    modulecmd_register_command(MXB_MODULE_NAME, "switchover-force", CmdType::WRITE,
+                               handle_manual_switchover_force, switchover_argv,
+                               "Switch primary server with replica. Ignores most errors.");
+
+    modulecmd_register_command(MXB_MODULE_NAME, "async-switchover", CmdType::WRITE,
+                               handle_async_switchover, switchover_argv,
+                               "Schedule primary switchover. Does not wait for completion.");
+
+    auto failover_argv = {monitor_arg};
+
+    modulecmd_register_command(MXB_MODULE_NAME, failover_cmd, CmdType::WRITE,
+                               handle_manual_failover, failover_argv,
+                               "Perform primary failover");
+
+    modulecmd_register_command(MXB_MODULE_NAME, "async-failover", CmdType::WRITE,
+                               handle_async_failover, failover_argv,
+                               "Schedule primary failover. Does not wait for completion.");
+
+    modulecmd_register_command(MXB_MODULE_NAME, safe_failover_cmd, CmdType::WRITE,
+                               handle_manual_failover_safe, failover_argv,
+                               "Perform primary failover if no detected trx loss");
+
+    modulecmd_register_command(MXB_MODULE_NAME, "async-failover-safe", CmdType::WRITE,
+                               handle_async_failover_safe, failover_argv,
+                               "Schedule primary failover if no detected trx loss. Does not wait for "
+                               "completion.");
+
+    auto rejoin_argv =
+    {
+        monitor_arg,
+        {ArgType::SERVER, "Joining server"}
+    };
+
+    modulecmd_register_command(MXB_MODULE_NAME, rejoin_cmd, CmdType::WRITE,
+                               handle_manual_rejoin, rejoin_argv,
+                               "Rejoin server to a cluster");
+
+    modulecmd_register_command(MXB_MODULE_NAME, "async-rejoin", CmdType::WRITE,
+                               handle_async_rejoin, rejoin_argv,
+                               "Rejoin server to a cluster. Does not wait for completion.");
+
+    auto reset_gtid_argv =
+    {
+        monitor_arg,
+        {ArgType::SERVER, ARG_OPTIONAL, "Primary server (optional)"}
+    };
+
+    modulecmd_register_command(MXB_MODULE_NAME, reset_repl_cmd, CmdType::WRITE,
+                               handle_manual_reset_replication, reset_gtid_argv,
+                               "Delete replica connections, delete binary logs and "
+                               "set up replication (dangerous)");
+
+    modulecmd_register_command(MXB_MODULE_NAME, "async-reset-replication", CmdType::WRITE,
+                               handle_async_reset_replication, reset_gtid_argv,
+                               "Delete replica connections, delete binary logs and "
+                               "set up replication (dangerous). Does not wait for completion.");
+
+    auto release_locks_argv = {monitor_arg};
+
+    modulecmd_register_command(MXB_MODULE_NAME, release_locks_cmd, CmdType::WRITE,
+                               handle_manual_release_locks, release_locks_argv,
+                               "Release any held server locks for 1 minute.");
+
+    modulecmd_register_command(MXB_MODULE_NAME, "async-release-locks", CmdType::WRITE,
+                               handle_async_release_locks, release_locks_argv,
+                               "Release any held server locks for 1 minute. Does not wait for completion.");
+
+    auto fetch_cmd_result_argv = {monitor_arg};
+
+    modulecmd_register_command(MXB_MODULE_NAME, "fetch-cmd-result", CmdType::READ,
+                               handle_fetch_cmd_result, fetch_cmd_result_argv,
+                               "Fetch result of the last scheduled command.");
+
+    modulecmd_register_command(MXB_MODULE_NAME, "cancel-cmd", CmdType::WRITE,
+                               handle_cancel_cmd, fetch_cmd_result_argv,
+                               "Cancel the last scheduled command.");
+
+    auto csmon_add_node_argv =
+    {
+        monitor_arg,
+        {ArgType::STRING, "Hostname/IP of node to add to ColumnStore cluster"},
+        {ArgType::STRING, "Timeout"}
+    };
+
+    modulecmd_register_command(MXB_MODULE_NAME, "async-cs-add-node", CmdType::WRITE,
+                               handle_async_cs_add_node, csmon_add_node_argv,
+                               "Add a node to a ColumnStore cluster. Does not wait for completion.");
+
+    auto csmon_remove_node_argv =
+    {
+        monitor_arg,
+        {ArgType::STRING, "Hostname/IP of node to remove from ColumnStore cluster"},
+        {ArgType::STRING, "Timeout"}
+    };
+
+    modulecmd_register_command(MXB_MODULE_NAME, "async-cs-remove-node", CmdType::WRITE,
+                               handle_async_cs_remove_node, csmon_remove_node_argv,
+                               "Remove a node from a ColumnStore cluster. Does not wait for completion.");
+
+    modulecmd_register_command(MXB_MODULE_NAME, "cs-get-status", CmdType::WRITE,
+                               handle_cs_get_status, fetch_cmd_result_argv,
+                               "Get ColumnStore cluster status.");
+
+    modulecmd_register_command(MXB_MODULE_NAME, "async-cs-get-status", CmdType::WRITE,
+                               handle_async_cs_get_status, fetch_cmd_result_argv,
+                               "Get ColumnStore cluster status. Does not wait for completion.");
+
+    auto csmon_cmd_timeout_argv =
+    {
+        monitor_arg,
+        {ArgType::STRING, "Timeout"}
+    };
+
+    modulecmd_register_command(MXB_MODULE_NAME, "async-cs-start-cluster", CmdType::WRITE,
+                               handle_async_cs_start_cluster, csmon_cmd_timeout_argv,
+                               "Start ColumnStore cluster. Does not wait for completion.");
+
+    modulecmd_register_command(MXB_MODULE_NAME, "async-cs-stop-cluster", CmdType::WRITE,
+                               handle_async_cs_stop_cluster, csmon_cmd_timeout_argv,
+                               "Stop ColumnStore cluster. Does not wait for completion.");
+
+    modulecmd_register_command(MXB_MODULE_NAME, "async-cs-set-readonly", CmdType::WRITE,
+                               handle_async_cs_set_readonly, csmon_cmd_timeout_argv,
+                               "Set ColumnStore cluster read-only. Does not wait for completion.");
+
+    modulecmd_register_command(MXB_MODULE_NAME, "async-cs-set-readwrite", CmdType::WRITE,
+                               handle_async_cs_set_readwrite, csmon_cmd_timeout_argv,
+                               "Set ColumnStore cluster readwrite. Does not wait for completion.");
+
+    auto rebuild_server_argv =
+    {
+        monitor_arg,
+        {ArgType::SERVER, "Target server"},
+        {ArgType::SERVER, ARG_OPTIONAL, "Source server (optional)"},
+        {ArgType::STRING, ARG_OPTIONAL, "Target data directory (optional)"}
+    };
+
+    modulecmd_register_command(MXB_MODULE_NAME, "async-rebuild-server", CmdType::WRITE,
+                               handle_async_rebuild_server, rebuild_server_argv,
+                               "Rebuild a server with Mariabackup. Does not wait for completion.");
+
+    auto create_backup_argv =
+    {
+        monitor_arg,
+        {ArgType::SERVER, "Source server"},
+        {ArgType::STRING, "Backup name"}
+    };
+    modulecmd_register_command(MXB_MODULE_NAME, "async-create-backup", CmdType::WRITE,
+                               handle_async_create_backup, create_backup_argv,
+                               "Create a backup with Mariabackup. Does not wait for completion.");
+
+    auto restore_backup_argv =
+    {
+        monitor_arg,
+        {ArgType::SERVER,               "Target server"},
+        {ArgType::STRING,               "Backup name"},
+        {ArgType::STRING, ARG_OPTIONAL, "Target data directory (optional)"}
+    };
+    modulecmd_register_command(MXB_MODULE_NAME, "async-restore-from-backup", CmdType::WRITE,
+                               handle_async_restore_from_backup, restore_backup_argv,
+                               "Restore a server from a backup. Does not wait for completion.");
+
+    KVModuleCmdArgDesc monitor_kv_arg("monitor", ArgType::MONITOR, ARG_NAME_MATCHES_DOMAIN, "Monitor name");
+    auto switchover_kvargs = {monitor_kv_arg,
+                              {so_arg_new_primary, ArgType::SERVER, ARG_OPTIONAL, "New primary"},
+                              {so_arg_old_primary, ArgType::SERVER, ARG_OPTIONAL, "Current primary"},
+                              {so_arg_async, ArgType::BOOLEAN, ARG_OPTIONAL, "Run command asynchronously"},
+                              {so_arg_force, ArgType::BOOLEAN, ARG_OPTIONAL, "Ignore most errors"},
+                             {so_arg_old_prim_maint, ArgType::BOOLEAN, ARG_OPTIONAL,
+                              "Set old primary to maintenance instead of redirecting it."}};
+    modulecmd_register_kv_command(MXB_MODULE_NAME, "switchover", CmdType::WRITE,
+                                  handle_manual_switchover, switchover_kvargs,
+                                  "Switch primary server with replica.");
+    /* *uncrustify-on* */
+}
+
+bool MariaDBMonitor::run_manual_switchover(SwitchoverType type, AfterDemotion after_demotion,
+                                           SERVER* new_master, SERVER* current_master, json_t** error_out)
+{
+    auto func = [this, type, after_demotion, new_master, current_master](){
+        return manual_switchover(type, after_demotion, new_master, current_master);
+    };
+    return execute_manual_command(func, switchover_cmd, error_out);
+}
+
+bool MariaDBMonitor::schedule_async_switchover(AfterDemotion after_demotion, SERVER* new_master,
+                                               SERVER* current_master, json_t** error_out)
+{
+    auto func = [this, after_demotion, new_master, current_master](){
+        return manual_switchover(SwitchoverType::NORMAL, after_demotion, new_master, current_master);
+    };
+    return schedule_manual_command(func, switchover_cmd, error_out);
+}
+
+bool MariaDBMonitor::run_manual_failover(FailoverType fo_type, json_t** error_out)
+{
+    auto func = [this, fo_type](){
+        return manual_failover(fo_type);
+    };
+    string cmd_name = (fo_type == FailoverType::ALLOW_TRX_LOSS) ? failover_cmd : safe_failover_cmd;
+    return execute_manual_command(func, failover_cmd, error_out);
+}
+
+bool MariaDBMonitor::schedule_async_failover(FailoverType fo_type, json_t** error_out)
+{
+    auto func = [this, fo_type](){
+        return manual_failover(fo_type);
+    };
+    string cmd_name = (fo_type == FailoverType::ALLOW_TRX_LOSS) ? failover_cmd : safe_failover_cmd;
+    return schedule_manual_command(func, cmd_name, error_out);
+}
+
+bool MariaDBMonitor::run_manual_rejoin(SERVER* rejoin_server, json_t** error_out)
+{
+    auto func = [this, rejoin_server](){
+        return manual_rejoin(rejoin_server);
+    };
+    return execute_manual_command(func, rejoin_cmd, error_out);
+}
+
+bool MariaDBMonitor::schedule_async_rejoin(SERVER* rejoin_server, json_t** error_out)
+{
+    auto func = [this, rejoin_server](){
+        return manual_rejoin(rejoin_server);
+    };
+    return schedule_manual_command(func, rejoin_cmd, error_out);
+}
+
+bool MariaDBMonitor::run_manual_reset_replication(SERVER* master_server, json_t** error_out)
+{
+    auto func = [this, master_server](){
+        return manual_reset_replication(master_server);
+    };
+    return execute_manual_command(func, reset_repl_cmd, error_out);
+}
+
+bool MariaDBMonitor::schedule_reset_replication(SERVER* master_server, json_t** error_out)
+{
+    auto func = [this, master_server](){
+        return manual_reset_replication(master_server);
+    };
+    return schedule_manual_command(func, reset_repl_cmd, error_out);
+}
+
+bool MariaDBMonitor::run_release_locks(json_t** error_out)
+{
+    auto func = [this](){
+        return manual_release_locks();
+    };
+    return execute_manual_command(func, release_locks_cmd, error_out);
+}
+
+bool MariaDBMonitor::schedule_release_locks(json_t** error_out)
+{
+    auto func = [this](){
+        return manual_release_locks();
+    };
+    return schedule_manual_command(func, release_locks_cmd, error_out);
+}
+
+mon_op::Result MariaDBMonitor::manual_release_locks()
+{
+    // Manual commands should only run in the main monitor thread.
+    mxb_assert(mxb::Worker::get_current()->id() == m_worker->id());
+    mxb_assert(m_op_info.exec_state == mon_op::ExecState::RUNNING);
+
+    mon_op::Result rval;
+    auto& error_out = rval.output;
+
+    bool success = false;
+    if (server_locks_in_use())
+    {
+        std::atomic_int released_locks {0};
+        auto release_lock_task = [&released_locks](MariaDBServer* server) {
+            released_locks += server->release_all_locks();
+        };
+        execute_task_all_servers(release_lock_task);
+        m_locks_info.have_lock_majority.store(false, std::memory_order_relaxed);
+
+        // Set next locking attempt 1 minute to the future.
+        m_locks_info.next_lock_attempt_delay = std::chrono::minutes(1);
+        m_locks_info.last_locking_attempt.restart();
+
+        int released = released_locks.load(std::memory_order_relaxed);
+        const char LOCK_DELAY_MSG[] = "Will not attempt to reacquire locks for 1 minute.";
+        if (released > 0)
+        {
+            MXB_NOTICE("Released %i lock(s). %s", released, LOCK_DELAY_MSG);
+            success = true;
+        }
+        else
+        {
+            PRINT_JSON_ERROR(error_out, "Did not release any locks. %s", LOCK_DELAY_MSG);
+        }
+    }
+    else
+    {
+        PRINT_JSON_ERROR(error_out, "Server locks are not in use, cannot release them.");
+    }
+    rval.success = success;
+    return rval;
+}
+
+bool MariaDBMonitor::fetch_cmd_result(json_t** output)
+{
+    mxb_assert(is_main_worker());
+    using ExecState = mon_op::ExecState;
+    auto manual_cmd_state = ExecState::DONE;
+    string manual_cmd_name;
+    bool have_result = false;
+    mon_op::Result manual_cmd_result;
+
+    std::unique_lock<std::mutex> lock(m_op_info.lock);
+    if (m_op_info.result_info)
+    {
+        // Deep copy the json since ownership moves.
+        manual_cmd_result = m_op_info.result_info->res.deep_copy();
+        manual_cmd_name = m_op_info.result_info->cmd_name;
+        have_result = true;
+    }
+    else
+    {
+        // No results are available. If current operation is a manual one, then make an error message from
+        // its info. If not, then a manual op must not have been ran yet as the results of manual op are
+        // only removed when a new one is scheduled.
+        if (m_op_info.current_op_is_manual)
+        {
+            manual_cmd_name = m_op_info.op_name;
+            manual_cmd_state = m_op_info.exec_state;
+        }
+    }
+    lock.unlock();
+
+    // The string contents here must match with GUI code.
+    const char cmd_running_fmt[] = "No manual command results are available, %s is still %s.";
+    switch (manual_cmd_state)
+    {
+    case ExecState::SCHEDULED:
+        *output = mxs_json_error_append(*output, cmd_running_fmt, manual_cmd_name.c_str(), "pending");
+        break;
+
+    case ExecState::RUNNING:
+        *output = mxs_json_error_append(*output, cmd_running_fmt, manual_cmd_name.c_str(), "running");
+        break;
+
+    case ExecState::DONE:
+        if (have_result)
+        {
+            // If command has its own output, return that. Otherwise, report success or error.
+            if (manual_cmd_result.output.object_size() > 0)
+            {
+                *output = manual_cmd_result.output.release();
+            }
+            else if (manual_cmd_result.success)
+            {
+                *output = json_sprintf("%s completed successfully.", manual_cmd_name.c_str());
+            }
+            else
+            {
+                // Command failed, but printed no results.
+                *output = json_sprintf("%s failed.", manual_cmd_name.c_str());
+            }
+        }
+        else
+        {
+            // Command has not been ran.
+            *output = mxs_json_error_append(*output, "No manual command results are available.");
+        }
+        break;
+    }
+    return true;
+}
+
+bool MariaDBMonitor::cancel_cmd(json_t** output)
+{
+    mxb_assert(is_main_worker());
+    using ExecState = mon_op::ExecState;
+
+    bool canceled = false;
+    std::lock_guard<std::mutex> guard(m_op_info.lock);
+    auto op_state = m_op_info.exec_state.load();
+    if (op_state == ExecState::SCHEDULED)
+    {
+        m_op_info.scheduled_op = nullptr;
+        MXB_NOTICE("Scheduled %s canceled.", m_op_info.op_name.c_str());
+        m_op_info.op_name.clear();
+        m_op_info.exec_state = ExecState::DONE;
+        m_op_info.current_op_is_manual = false;
+        canceled = true;
+    }
+    else if (op_state == ExecState::RUNNING)
+    {
+        // Cannot cancel a running operation from main thread. Set a flag instead.
+        m_op_info.cancel_op = true;
+        canceled = true;
+    }
+    else
+    {
+        *output = mxs_json_error_append(*output, "No manual command is scheduled or running.");
+    }
+    return canceled;
+}
+
+bool MariaDBMonitor::schedule_cs_add_node(const std::string& host, std::chrono::seconds timeout,
+                                          json_t** error_out)
+{
+    auto func = [this, host, timeout]() {
+        return manual_cs_add_node(host, timeout);
+    };
+    return schedule_manual_command(func, cs_add_node_cmd, error_out);
+}
+
+bool MariaDBMonitor::schedule_cs_remove_node(const std::string& host, std::chrono::seconds timeout,
+                                             json_t** error_out)
+{
+    auto func = [this, host, timeout]() {
+        return manual_cs_remove_node(host, timeout);
+    };
+    return schedule_manual_command(func, cs_remove_node_cmd, error_out);
+}
+
+bool MariaDBMonitor::run_cs_get_status(json_t** output)
+{
+    auto func = [this]() {
+        return manual_cs_get_status();
+    };
+    return execute_manual_command(func, cs_get_status_cmd, output);
+}
+
+bool MariaDBMonitor::schedule_cs_get_status(json_t** output)
+{
+    auto func = [this]() {
+        return manual_cs_get_status();
+    };
+    return schedule_manual_command(func, cs_get_status_cmd, output);
+}
+
+bool MariaDBMonitor::schedule_cs_start_cluster(std::chrono::seconds timeout, json_t** error_out)
+{
+    auto func = [this, timeout]() {
+        return manual_cs_start_cluster(timeout);
+    };
+    return schedule_manual_command(func, cs_start_cluster_cmd, error_out);
+}
+
+bool MariaDBMonitor::schedule_cs_stop_cluster(std::chrono::seconds timeout, json_t** error_out)
+{
+    auto func = [this, timeout]() {
+        return manual_cs_stop_cluster(timeout);
+    };
+    return schedule_manual_command(func, cs_stop_cluster_cmd, error_out);
+}
+
+bool MariaDBMonitor::schedule_cs_set_readonly(std::chrono::seconds timeout, json_t** error_out)
+{
+    auto func = [this, timeout]() {
+        return manual_cs_set_readonly(timeout);
+    };
+    return schedule_manual_command(func, cs_set_readonly_cmd, error_out);
+}
+
+bool MariaDBMonitor::schedule_cs_set_readwrite(std::chrono::seconds timeout, json_t** error_out)
+{
+    auto func = [this, timeout]() {
+        return manual_cs_set_readwrite(timeout);
+    };
+    return schedule_manual_command(func, cs_set_readwrite_cmd, error_out);
+}
+
+MariaDBMonitor::CsRestResult MariaDBMonitor::check_cs_rest_result(const mxb::http::Response& resp)
+{
+    bool rval = false;
+    string err_str;
+    mxb::Json json_data(mxb::Json::Type::UNDEFINED);
+
+    if (resp.is_success())
+    {
+        // The response body should be json text. Parse it.
+        if (json_data.load_string(resp.body))
+        {
+            rval = true;
+        }
+        else
+        {
+            err_str = mxb::string_printf("REST-API call succeeded yet returned data was not JSON. %s",
+                                         json_data.error_msg().c_str());
+        }
+    }
+    else
+    {
+        auto rc_desc = mxb::http::Response::to_string(resp.code);
+
+        if (resp.is_fatal())
+        {
+            err_str = mxb::string_printf("REST-API call failed. Error %d: %s", resp.code, rc_desc);
+        }
+        else
+        {
+            err_str = mxb::string_printf("Error %d: %s", resp.code, rc_desc);
+        }
+
+        // The response body is json, try parse it and get CS error information.
+        mxb::Json cs_error;
+        if (cs_error.load_string(resp.body))
+        {
+            auto cs_err_desc = cs_error.get_string("error");
+            if (!cs_err_desc.empty())
+            {
+                err_str.append(" ColumnStore error: ").append(cs_err_desc);
+            }
+        }
+    }
+
+    return {rval, err_str, json_data};
+}
+
+mon_op::Result
+MariaDBMonitor::manual_cs_add_node(const std::string& node_host, std::chrono::seconds timeout)
+{
+    /* *uncrustify-off* */
+    RestDataFields input = {{"timeout", std::to_string(timeout.count())},
+                            {"node"   , mxb::string_printf("\"%s\"", node_host.c_str())}};
+    /* *uncrustify-on* */
+    auto [ok, rest_error, rest_output] = run_cs_rest_cmd(HttpCmd::PUT, "node", input, timeout);
+
+    mon_op::Result rval;
+    if (ok)
+    {
+        rval.success = true;
+        rval.output = move(rest_output);
+    }
+    else
+    {
+        string errmsg = mxb::string_printf("Could not add node '%s' to the ColumnStore cluster. %s",
+                                           node_host.c_str(), rest_error.c_str());
+        PRINT_JSON_ERROR(rval.output, "%s", errmsg.c_str());
+    }
+    return rval;
+}
+
+mon_op::Result
+MariaDBMonitor::manual_cs_remove_node(const std::string& node_host, std::chrono::seconds timeout)
+{
+    /* *uncrustify-off* */
+    RestDataFields input = {{"timeout", std::to_string(timeout.count())},
+                            {"node"   , mxb::string_printf("\"%s\"", node_host.c_str())}};
+    /* *uncrustify-on* */
+    auto [ok, rest_error, rest_output] = run_cs_rest_cmd(HttpCmd::DELETE, "node", input, timeout);
+
+    mon_op::Result rval;
+    if (ok)
+    {
+        rval.success = true;
+        rval.output = move(rest_output);
+    }
+    else
+    {
+        string errmsg = mxb::string_printf("Could not remove node '%s' from the ColumnStore cluster: %s",
+                                           node_host.c_str(), rest_error.c_str());
+        PRINT_JSON_ERROR(rval.output, "%s", errmsg.c_str());
+    }
+    return rval;
+}
+
+mon_op::Result MariaDBMonitor::manual_cs_get_status()
+{
+    auto [ok, rest_error, rest_output] = run_cs_rest_cmd(HttpCmd::GET, "status", {}, 0s);
+
+    mon_op::Result rval;
+    if (ok)
+    {
+        rval.success = true;
+        rval.output = move(rest_output);
+    }
+    else
+    {
+        string errmsg = mxb::string_printf("Could not fetch status from the ColumnStore cluster: %s",
+                                           rest_error.c_str());
+        PRINT_JSON_ERROR(rval.output, "%s", errmsg.c_str());
+    }
+    return rval;
+}
+
+mon_op::Result MariaDBMonitor::manual_cs_start_cluster(std::chrono::seconds timeout)
+{
+    RestDataFields input = {{"timeout", std::to_string(timeout.count())}};
+    auto [ok, rest_error, rest_output] = run_cs_rest_cmd(HttpCmd::PUT, "start", input, timeout);
+
+    mon_op::Result rval;
+    if (ok)
+    {
+        rval.success = true;
+        rval.output = move(rest_output);
+    }
+    else
+    {
+        string errmsg = mxb::string_printf("Could not start ColumnStore cluster: %s", rest_error.c_str());
+        PRINT_JSON_ERROR(rval.output, "%s", errmsg.c_str());
+    }
+    return rval;
+}
+
+mon_op::Result MariaDBMonitor::manual_cs_stop_cluster(std::chrono::seconds timeout)
+{
+    RestDataFields input = {{"timeout", std::to_string(timeout.count())}};
+    auto [ok, rest_error, rest_output] = run_cs_rest_cmd(HttpCmd::PUT, "shutdown", input, timeout);
+
+    mon_op::Result rval;
+    if (ok)
+    {
+        rval.success = true;
+        rval.output = move(rest_output);
+    }
+    else
+    {
+        string errmsg = mxb::string_printf("Could not stop ColumnStore cluster: %s", rest_error.c_str());
+        PRINT_JSON_ERROR(rval.output, "%s", errmsg.c_str());
+    }
+    return rval;
+}
+
+mon_op::Result MariaDBMonitor::manual_cs_set_readonly(std::chrono::seconds timeout)
+{
+    /* *uncrustify-off* */
+    RestDataFields input = {{"timeout", std::to_string(timeout.count())},
+                            {"mode"   , "\"readonly\""}};
+    /* *uncrustify-on* */
+    auto [ok, rest_error, rest_output] = run_cs_rest_cmd(HttpCmd::PUT, "mode-set", input, timeout);
+
+    mon_op::Result rval;
+    if (ok)
+    {
+        rval.success = true;
+        rval.output = move(rest_output);
+    }
+    else
+    {
+        string errmsg = mxb::string_printf("Could not set ColumnStore cluster to read-only mode: %s",
+                                           rest_error.c_str());
+        PRINT_JSON_ERROR(rval.output, "%s", errmsg.c_str());
+    }
+    return rval;
+}
+
+mon_op::Result MariaDBMonitor::manual_cs_set_readwrite(std::chrono::seconds timeout)
+{
+    /* *uncrustify-off* */
+    RestDataFields input = {{"timeout", std::to_string(timeout.count())},
+                            {"mode"   , "\"readwrite\""}};
+    /* *uncrustify-on* */
+    auto [ok, rest_error, rest_output] = run_cs_rest_cmd(HttpCmd::PUT, "mode-set", input, timeout);
+
+    mon_op::Result rval;
+    if (ok)
+    {
+        rval.success = true;
+        rval.output = move(rest_output);
+    }
+    else
+    {
+        string errmsg = mxb::string_printf("Could not set ColumnStore cluster to read-write mode: %s",
+                                           rest_error.c_str());
+        PRINT_JSON_ERROR(rval.output, "%s", errmsg.c_str());
+    }
+    return rval;
+}
+
+MariaDBMonitor::CsRestResult
+MariaDBMonitor::run_cs_rest_cmd(HttpCmd httcmd, const std::string& rest_cmd, const RestDataFields& data,
+                                std::chrono::seconds cs_timeout)
+{
+    auto& srvs = m_servers;
+    if (srvs.empty())
+    {
+        return {false, "No valid server to send ColumnStore REST-API command found",
+                mxb::Json(mxb::Json::Type::UNDEFINED)};
+    }
+    else
+    {
+        // Send the command to the first server. TODO: send to master instead?
+        string url = mxb::string_printf("https://%s:%li%s/cluster/%s",
+                                        srvs.front()->server->address(), m_settings.cs_admin_port,
+                                        m_settings.cs_admin_base_path.c_str(), rest_cmd.c_str());
+        string body = "{";
+        string sep;
+        for (const auto& elem : data)
+        {
+            body.append(sep).append("\"").append(elem.first).append("\": ").append(elem.second);
+            sep = ", ";
+        }
+        body += "}";
+
+        // Set the timeout to larger than the timeout specified to the ColumnStore daemon. The timeout surely
+        // expires first in the daemon and only then in the HTTP library.
+        mxb::http::Config http_config = m_http_config;
+        http_config.timeout = cs_timeout + std::chrono::seconds(mxb::http::DEFAULT_TIMEOUT);
+
+        maybe_set_wait_timeout_all_servers(http_config.timeout);
+        mxb::http::Response response;
+
+        switch (httcmd)
+        {
+        case HttpCmd::GET:
+            response = mxb::http::get(url, http_config);
+            break;
+
+        case HttpCmd::PUT:
+            response = mxb::http::put(url, body, http_config);
+            break;
+
+        case HttpCmd::DELETE:
+            response = mxb::http::del(url, body, http_config);
+            break;
+        }
+
+        reset_wait_timeout_all_servers();
+        return check_cs_rest_result(response);
+    }
+}
+
+bool MariaDBMonitor::schedule_rebuild_server(SERVER* target, SERVER* source, const std::string& datadir,
+                                             json_t** error_out)
+{
+    auto op = std::make_unique<mon_op::RebuildServer>(*this, target, source, datadir);
+    return schedule_manual_command(move(op), rebuild_server_cmd, error_out);
+}
+
+bool MariaDBMonitor::schedule_create_backup(SERVER* source, const std::string& bu_name, json_t** error_out)
+{
+    auto op = std::make_unique<mon_op::CreateBackup>(*this, source, bu_name);
+    return schedule_manual_command(std::move(op), create_backup_cmd, error_out);
+}
+
+bool MariaDBMonitor::schedule_restore_from_backup(SERVER* target, const std::string& bu_name,
+                                                  const std::string& datadir, json_t** error_out)
+{
+    auto op = std::make_unique<mon_op::RestoreFromBackup>(*this, target, bu_name, datadir);
+    return schedule_manual_command(std::move(op), restore_from_backup_cmd, error_out);
+}
+
+namespace mon_op
+{
+bool RebuildServer::check_preconditions()
+{
+    auto& error_out = m_result.output;
+    MariaDBServer* target = m_mon.get_server(m_target_srv);
+    if (!target)
+    {
+        PRINT_JSON_ERROR(error_out, "%s is not monitored by %s, cannot rebuild it.",
+                         m_target_srv->name(), m_mon.name());
+    }
+
+    MariaDBServer* source = nullptr;
+    if (m_source_srv)
+    {
+        source = m_mon.get_server(m_source_srv);
+        if (!source)
+        {
+            PRINT_JSON_ERROR(error_out, "%s is not monitored by %s, cannot use it as rebuild source.",
+                             m_source_srv->name(), m_mon.name());
+        }
+    }
+    else if (target)
+    {
+        // User did not give a source server, so autoselect. Prefer a slave.
+        source = autoselect_source_srv(target);
+        if (!source)
+        {
+            PRINT_JSON_ERROR(error_out, "Could not autoselect rebuild source server. A valid source must "
+                                        "be either a primary or replica.");
+        }
+    }
+
+    bool rval = false;
+    if (target && source)
+    {
+        bool target_ok = check_server_is_valid_target(target);
+        bool source_ok = true;
+        bool settings_ok = true;
+
+        if (!check_server_is_valid_source(source))
+        {
+            source_ok = false;
+        }
+
+        if (!check_ssh_settings())
+        {
+            settings_ok = false;
+        }
+
+        if (target_ok && source_ok && settings_ok)
+        {
+            m_target = target;
+            m_source = source;
+            rval = true;
+        }
+    }
+    return rval;
+}
+
+bool BackupOperation::run_cmd_on_target(const std::string& cmd, const std::string& desc)
+{
+    bool rval = false;
+    auto res = ssh_util::run_cmd(*m_target_ses, cmd, m_ssh_timeout);
+    if (res.type == RType::OK && res.rc == 0)
+    {
+        rval = true;
+    }
+    else
+    {
+        string errmsg = ssh_util::form_cmd_error_msg(res, cmd.c_str());
+        PRINT_JSON_ERROR(m_result.output, "Could not %s on %s. %s",
+                         desc.c_str(), m_target_name.c_str(), errmsg.c_str());
+    }
+    return rval;
+}
+
+bool BackupOperation::check_rebuild_tools(const char* srvname, ssh::Session& ssh)
+{
+    const char socat_cmd[] = "socat -V";
+    const char pigz_cmd[] = "pigz -V";
+    const char mbu_cmd[] = "mariabackup -v";
+
+    auto socat_res = ssh_util::run_cmd(ssh, socat_cmd, m_ssh_timeout);
+    auto pigz_res = ssh_util::run_cmd(ssh, pigz_cmd, m_ssh_timeout);
+    auto mbu_res = ssh_util::run_cmd(ssh, mbu_cmd, m_ssh_timeout);
+
+    auto& error_out = m_result.output;
+    bool all_ok = true;
+    auto check = [srvname, &all_ok, &error_out](const ssh_util::CmdResult& res, const char* tool,
+                                                const char* cmd) {
+        if (res.type == RType::OK)
+        {
+            if (res.rc != 0)
+            {
+                string fail_reason = ssh_util::form_cmd_error_msg(res, cmd);
+                PRINT_JSON_ERROR(error_out, "%s lacks '%s', which is required for backup operations. %s",
+                                 srvname, tool, fail_reason.c_str());
+                all_ok = false;
+            }
+        }
+        else
+        {
+            string fail_reason = ssh_util::form_cmd_error_msg(res, cmd);
+            PRINT_JSON_ERROR(error_out, "Could not check that %s has '%s', which is required for backup "
+                                        "operations. %s", srvname, tool, fail_reason.c_str());
+            all_ok = false;
+        }
+    };
+
+    check(socat_res, "socat", socat_cmd);
+    check(pigz_res, "pigz", pigz_cmd);
+    check(mbu_res, "mariabackup", mbu_cmd);
+    return all_ok;
+}
+
+bool BackupOperation::check_free_listen_port(const char* srvname, ssh::Session& ses, int port)
+{
+    bool success = true;
+    auto& error_out = m_result.output;
+
+    auto get_port_pids = [&]() {
+        std::vector<int> pids;
+        // lsof needs to be run as sudo to see ports, even from the same user. This part could be made
+        // optional if users are not willing to give MaxScale sudo-privs.
+        auto port_pid_cmd = mxb::string_printf("sudo lsof -n -P -i TCP:%i -s TCP:LISTEN | tr -s ' ' "
+                                               "| cut --fields=2 --delimiter=' ' | tail -n+2", port);
+        auto port_res = ssh_util::run_cmd(ses, port_pid_cmd, m_ssh_timeout);
+        if (port_res.type == RType::OK && port_res.rc == 0)
+        {
+            if (!port_res.output.empty())
+            {
+                auto lines = mxb::strtok(port_res.output, "\n");
+                for (auto& line : lines)
+                {
+                    int pid = 0;
+                    if (mxb::get_int(line.c_str(), &pid))
+                    {
+                        pids.push_back(pid);
+                    }
+                    else
+                    {
+                        PRINT_JSON_ERROR(error_out, "Could not parse pid from text '%s'.", line.c_str());
+                        success = false;
+                    }
+                }
+            }
+        }
+        else
+        {
+            string fail_reason = ssh_util::form_cmd_error_msg(port_res, port_pid_cmd.c_str());
+            PRINT_JSON_ERROR(error_out, "Could not read pid of process using port %i on %s. %s",
+                             port, srvname, fail_reason.c_str());
+            success = false;
+        }
+        return pids;
+    };
+
+    auto pids = get_port_pids();
+    if (success)
+    {
+        for (auto pid : pids)
+        {
+            MXB_WARNING("Port %i on %s is used by process %i, trying to kill it.",
+                        port, srvname, pid);
+            auto kill_cmd = mxb::string_printf("kill -s SIGKILL %i", pid);
+            auto kill_res = ssh_util::run_cmd(ses, kill_cmd, m_ssh_timeout);
+            if (kill_res.type != RType::OK || kill_res.rc != 0)
+            {
+                string fail_reason = ssh_util::form_cmd_error_msg(kill_res, kill_cmd.c_str());
+                PRINT_JSON_ERROR(error_out, "Failed to kill process %i on %s. %s",
+                                 pid, srvname, fail_reason.c_str());
+                success = false;
+            }
+        }
+
+        if (success && !pids.empty())
+        {
+            // Sleep a little in case the kill takes a while to take effect. Then check the port again.
+            sleep(1);
+            auto pids2 = get_port_pids();
+            if (success && !pids2.empty())
+            {
+                PRINT_JSON_ERROR(error_out, "Port %i is still in use on %s. Cannot use it as a backup "
+                                            "source.", port, srvname);
+                success = false;
+            }
+        }
+    }
+
+    return success;
+}
+
+SimpleOp::SimpleOp(CmdMethod func)
+    : m_func(move(func))
+{
+}
+
+bool SimpleOp::run()
+{
+    mxb_assert(m_result.output.object_size() == 0);
+    m_result = m_func();
+    return true;
+}
+
+Result SimpleOp::result()
+{
+    return m_result;
+}
+
+void SimpleOp::cancel()
+{
+    // Can only end up here if the op is canceled right after it transitioned to running state but before
+    // any of it was ran. In any case, nothing to do.
+}
+
+BackupOperation::BackupOperation(MariaDBMonitor& mon, std::string datadir)
+    : m_mon(mon)
+    , m_custom_datadir(std::move(datadir))
+    , m_mbu_use_memory(m_mon.m_settings.mbu_use_memory)
+{
+    m_ssh_timeout = m_mon.m_settings.ssh_timeout;
+    m_source_port = m_mon.m_settings.rebuild_port;
+}
+
+void BackupOperation::set_source(string name, string host)
+{
+    m_source_name = std::move(name);
+    m_source_host = std::move(host);
+}
+
+void BackupOperation::set_target(string name, string host)
+{
+    m_target_name = std::move(name);
+    m_target_host = std::move(host);
+}
+
+ssh_util::SSession BackupOperation::init_ssh_session(const char* name, const string& host)
+{
+    const auto& sett = m_mon.m_settings;
+    auto [ses, errmsg_con] = ssh_util::init_ssh_session(host, sett.ssh_port, sett.ssh_user, sett.ssh_keyfile,
+                                                        sett.ssh_host_check, m_ssh_timeout);
+
+    if (!ses)
+    {
+        PRINT_JSON_ERROR(m_result.output, "SSH connection to %s failed. %s", name, errmsg_con.c_str());
+    }
+    return ses;
+}
+
+RebuildServer::RebuildServer(MariaDBMonitor& mon, SERVER* target, SERVER* source, std::string datadir)
+    : BackupOperation(mon, std::move(datadir))
+    , m_target_srv(target)
+    , m_source_srv(source)
+{
+}
+
+bool RebuildServer::run()
+{
+    bool command_complete = false;
+    bool advance = true;
+    while (advance)
+    {
+        switch (m_state)
+        {
+        case State::INIT:
+            advance = state_init();
+            break;
+
+        case State::TEST_DATALINK:
+            advance = state_test_datalink();
+            break;
+
+        case State::SERVE_BACKUP:
+            advance = state_serve_backup();
+            break;
+
+        case State::PREPARE_TARGET:
+            advance = state_prepare_target();
+            break;
+
+        case State::START_TRANSFER:
+            advance = state_start_transfer();
+            break;
+
+        case State::WAIT_TRANSFER:
+            advance = state_wait_transfer();
+            break;
+
+        case State::CHECK_DATADIR_SIZE:
+            state_check_datadir();
+            break;
+
+        case State::START_BACKUP_PREPARE:
+            advance = state_start_backup_prepare();
+            break;
+
+        case State::WAIT_BACKUP_PREPARE:
+            advance = state_wait_backup_prepare();
+            break;
+
+        case State::START_TARGET:
+            advance = state_start_target();
+            break;
+
+        case State::START_REPLICATION:
+            advance = state_start_replication();
+            break;
+
+        case State::DONE:
+            m_result.success = true;
+            m_state = State::CLEANUP;
+            break;
+
+        case State::CLEANUP:
+            state_cleanup();
+            command_complete = true;
+            advance = false;
+            break;
+        }
+    }
+
+    return command_complete;
+}
+
+void RebuildServer::cancel()
+{
+    switch (m_state)
+    {
+    case State::INIT:
+        // No need to do anything.
+        break;
+
+    case State::WAIT_TRANSFER:
+    case State::WAIT_BACKUP_PREPARE:
+        state_cleanup();
+        break;
+
+    default:
+        mxb_assert(!true);
+    }
+}
+
+Result BackupOperation::result()
+{
+    return m_result;
+}
+
+bool BackupOperation::init_operation()
+{
+    const char* source_name = m_source_name.c_str();
+    const char* target_name = m_target_name.c_str();
+
+    bool init_ok = false;
+
+    // Base the wait_timeout on ssh timeout multiplied by minimum number of commands ran
+    // before returning to monitoring loop.
+    m_mon.maybe_set_wait_timeout_all_servers(10 * m_ssh_timeout);
+
+    // Ok so far. Initiate SSH-sessions to both servers.
+    auto target_ses = init_ssh_session(m_target_name.c_str(), m_target_host);
+    auto source_ses = init_ssh_session(m_source_name.c_str(), m_source_host);
+
+    if (target_ses && source_ses)
+    {
+        bool have_tools = true;
+
+        // Check installed tools.
+        bool target_tools = check_rebuild_tools(target_name, *target_ses);
+        bool source_tools = check_rebuild_tools(source_name, *source_ses);
+
+        if (target_tools && source_tools)
+        {
+            if (check_free_listen_port(source_name, *source_ses, m_source_port))
+            {
+                m_target_ses = std::move(target_ses);
+                m_source_ses = std::move(source_ses);
+                init_ok = true;
+            }
+        }
+    }
+    return init_ok;
+}
+
+bool RebuildServer::state_init()
+{
+    m_state = State::CLEANUP;
+    if (check_preconditions())
+    {
+        set_source(m_source->name(), m_source->server->address());
+        set_target(m_target->name(), m_target->server->address());
+
+        if (init_operation())
+        {
+            m_source_slaves_old = m_source->m_slave_status;     // Backup slave conns
+            m_state = State::TEST_DATALINK;
+        }
+    }
+    return true;
+}
+
+bool BackupOperation::test_datalink()
+{
+    using Status = ssh_util::AsyncCmd::Status;
+    auto source_name = m_source_name.c_str();
+    auto target_name = m_target_name.c_str();
+    auto& error_out = m_result.output;
+
+    bool success = false;
+    // Test the datalink between source and target by streaming a message.
+    string test_serve_cmd = mxb::string_printf("socat -u EXEC:'echo %s' TCP-LISTEN:%i,reuseaddr",
+                                               link_test_msg, m_source_port);
+    auto [cmd_handle, ssh_errmsg] = ssh_util::start_async_cmd(m_source_ses, test_serve_cmd);
+    if (cmd_handle)
+    {
+        // According to testing, the listen port sometimes takes a bit of time to actually open.
+        // To account for this, try to connect a few times before giving up.
+        string test_receive_cmd = mxb::string_printf("socat -u TCP:%s:%i,connect-timeout=%i STDOUT",
+                                                     m_source_host.c_str(), m_source_port, socat_timeout_s);
+        ssh_util::CmdResult res;
+        const int max_tries = 5;
+        for (int i = 0; i < max_tries; i++)
+        {
+            res = ssh_util::run_cmd(*m_target_ses, test_receive_cmd, m_ssh_timeout);
+            if (res.type == RType::OK)
+            {
+                if (res.rc == 0)
+                {
+                    m_port_open_delay = i * 1s;
+                    break;
+                }
+                else if (i + 1 < max_tries)
+                {
+                    sleep(1);
+                }
+            }
+            else
+            {
+                // Unexpected error.
+                break;
+            }
+        }
+        if (res.type == RType::OK && res.rc == 0)
+        {
+            mxb::trim(res.output);
+            bool data_ok = (res.output == link_test_msg);
+            // Wait for the source to quit. Usually happens immediately.
+            auto source_status = Status::BUSY;
+            for (int i = 0; i < max_tries; i++)
+            {
+                source_status = cmd_handle->update_status();
+                if (source_status == Status::BUSY && (i + 1 < max_tries))
+                {
+                    sleep(1);
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            if (data_ok && source_status == Status::READY)
+            {
+                success = true;
+            }
+            else
+            {
+                if (!data_ok)
+                {
+                    PRINT_JSON_ERROR(error_out, "Received '%s' when '%s' was expected when testing data "
+                                                "streaming from %s to %s.",
+                                     res.output.c_str(), link_test_msg, source_name, target_name);
+                }
+                if (source_status == Status::BUSY)
+                {
+                    PRINT_JSON_ERROR(error_out, "Data stream serve command '%s' did not stop on %s even "
+                                                "after data was transferred",
+                                     test_receive_cmd.c_str(), source_name);
+                }
+                else if (source_status == Status::SSH_FAIL)
+                {
+                    PRINT_JSON_ERROR(error_out, "Failed to check transfer status on %s. %s",
+                                     source_name, cmd_handle->error_output().c_str());
+                }
+            }
+        }
+        else
+        {
+            string errmsg = ssh_util::form_cmd_error_msg(res, test_receive_cmd.c_str());
+            PRINT_JSON_ERROR(m_result.output, "Could not receive test data on %s. %s",
+                             target_name, errmsg.c_str());
+        }
+    }
+    else
+    {
+        PRINT_JSON_ERROR(error_out, "Failed to test data streaming from %s. %s",
+                         source_name, ssh_errmsg.c_str());
+    }
+    return success;
+}
+
+bool BackupOperation::serve_backup(const string& mariadb_user, const string& mariadb_pw)
+{
+    auto source_name = m_source_name.c_str();
+    // Start serving the backup stream. The source will wait for a new connection.
+    const int parallel = m_mon.m_settings.mbu_parallel;
+    const char stream_fmt[] = "sudo mariabackup --user=%s --password=%s --backup --safe-slave-backup "
+                              "--target-dir=/tmp --stream=xbstream --parallel=%i "
+                              "| pigz -c | socat - TCP-LISTEN:%i,reuseaddr";
+    string stream_cmd = mxb::string_printf(stream_fmt, mariadb_user.c_str(), mariadb_pw.c_str(),
+                                           parallel, m_source_port);
+    auto [cmd_handle, ssh_errmsg] = ssh_util::start_async_cmd(m_source_ses, stream_cmd);
+
+    auto& error_out = m_result.output;
+    bool rval = false;
+    if (cmd_handle)
+    {
+        m_mon.m_cluster_modified = true;    // Starting mariabackup can affect server states.
+        m_source_slaves_stopped = true;
+
+        // Wait a bit, then check that command started successfully and is still running.
+        sleep(1);
+        auto status = cmd_handle->update_status();
+
+        if (status == ssh_util::AsyncCmd::Status::BUSY)
+        {
+            rval = true;
+            m_source_cmd = std::move(cmd_handle);
+            MXB_NOTICE("%s serving backup on port %i.", source_name, m_source_port);
+            // Wait a bit more to ensure listen port is open.
+            sleep(m_port_open_delay.count() + 1);
+        }
+        else if (status == ssh_util::AsyncCmd::Status::READY)
+        {
+            // The stream serve operation ended before it should. Print all output available.
+            // The ssh-command includes username & pw so mask those in the message.
+            string masked_cmd = mxb::string_printf(stream_fmt, mask, mask, parallel, m_source_port);
+
+            int rc = cmd_handle->rc();
+
+            string message = mxb::string_printf(
+                "Failed to stream data from %s. Command '%s' stopped before data was streamed. Return "
+                "value %i. Output: '%s' Error output: '%s'", source_name, masked_cmd.c_str(), rc,
+                cmd_handle->output().c_str(), cmd_handle->error_output().c_str());
+
+            PRINT_JSON_ERROR(error_out, "%s", message.c_str());
+        }
+        else
+        {
+            ssh_errmsg = mxb::string_printf("Failed to read output. %s",
+                                            cmd_handle->error_output().c_str());
+        }
+    }
+
+    if (!ssh_errmsg.empty())
+    {
+        mxb_assert(!m_source_cmd);
+        PRINT_JSON_ERROR(error_out, "Failed to start streaming data from %s. %s",
+                         source_name, ssh_errmsg.c_str());
+    }
+    return rval;
+}
+
+bool BackupOperation::check_ssh_settings()
+{
+    bool settings_ok = true;
+    const char settings_err_fmt[] = "'%s' is not set. Backup operations require ssh access to servers.";
+    if (m_mon.m_settings.ssh_user.empty())
+    {
+        PRINT_JSON_ERROR(m_result.output, settings_err_fmt, CONFIG_SSH_USER);
+        settings_ok = false;
+    }
+    if (m_mon.m_settings.ssh_keyfile.empty())
+    {
+        // TODO: perhaps allow no authentication
+        PRINT_JSON_ERROR(m_result.output, settings_err_fmt, CONFIG_SSH_KEYFILE);
+        settings_ok = false;
+    }
+    return settings_ok;
+}
+
+bool BackupOperation::check_backup_storage_settings()
+{
+    bool settings_ok = true;
+    const char settings_err[] = "'%s' is not set. Backup operations require a valid value for this "
+                                "setting.";
+    if (m_mon.m_settings.backup_storage_addr.empty())
+    {
+        PRINT_JSON_ERROR(m_result.output, settings_err, CONFIG_BACKUP_ADDR);
+        settings_ok = false;
+    }
+    if (m_mon.m_settings.backup_storage_path.empty())
+    {
+        PRINT_JSON_ERROR(m_result.output, settings_err, CONFIG_BACKUP_PATH);
+        settings_ok = false;
+    }
+    return settings_ok;
+}
+
+bool BackupOperation::check_server_is_valid_target(const MariaDBServer* target)
+{
+    auto& error_out = m_result.output;
+    bool target_ok = true;
+    const char wrong_state_fmt[] = "Server '%s' is already a %s, cannot rebuild it.";
+
+    // The following do not actually prevent rebuilding, they are just safeguards against user errors.
+    if (target->is_master())
+    {
+        PRINT_JSON_ERROR(error_out, wrong_state_fmt, target->name(), "primary");
+        target_ok = false;
+    }
+    else if (target->is_relay_master())
+    {
+        PRINT_JSON_ERROR(error_out, wrong_state_fmt, target->name(), "relay");
+        target_ok = false;
+    }
+    else if (target->is_slave())
+    {
+        PRINT_JSON_ERROR(error_out, wrong_state_fmt, target->name(), "slave");
+        target_ok = false;
+    }
+    return target_ok;
+}
+
+bool BackupOperation::check_server_is_valid_source(const MariaDBServer* source)
+{
+    bool source_ok = true;
+    if (!source->is_slave() && !source->is_master())
+    {
+        PRINT_JSON_ERROR(m_result.output, "Server '%s' is neither a primary or replica, cannot use it "
+                                          "as source.", source->name());
+        source_ok = false;
+    }
+    return source_ok;
+}
+
+bool BackupOperation::prepare_target(MariaDBServer* target)
+{
+    bool target_prepared = false;
+    mxb_assert(m_eff_datadir.empty());
+
+    if (m_custom_datadir.empty())
+    {
+        const char default_datadir[] = "/var/lib/mysql";
+
+        if (target->is_running())
+        {
+            // Ask the target server for its data directory setting.
+            string errmsg;
+            const string query = "select @@datadir;";
+            auto res = target->execute_query(query, &errmsg);
+            if (res && res->next_row() && res->get_col_count() > 0)
+            {
+                string dir_res = res->get_string(0);
+                // Even though this came from the server, do not accept blindly. Better be safe than sorry.
+                if (check_datadir_path(dir_res))
+                {
+                    if (dir_res.back() == '/')
+                    {
+                        dir_res.pop_back();
+                    }
+                    m_eff_datadir = dir_res;
+                    MXB_NOTICE("Detected data directory '%s' on %s.",
+                               m_eff_datadir.c_str(), m_target_name.c_str());
+                }
+                else
+                {
+                    PRINT_JSON_ERROR(m_result.output, "Data directory '%s' reported by %s is invalid. "
+                                                      "The value should be an absolute path.",
+                                     dir_res.c_str(), m_target_name.c_str());
+                }
+            }
+            else if (res)
+            {
+                // Weird error, cancel operation.
+                PRINT_JSON_ERROR(m_result.output, "Empty response to '%s' from %s.",
+                                 query.c_str(), m_target_name.c_str());
+            }
+            else
+            {
+                // Query should not fail.
+                PRINT_JSON_ERROR(m_result.output, "Failed to detect data directory on %s, %s.",
+                                 m_target_name.c_str(), errmsg.c_str());
+            }
+        }
+        else
+        {
+            m_eff_datadir = default_datadir;
+            MXB_WARNING("%s is not running, cannot query data directory. Assuming '%s'. If this is wrong, "
+                        "data directory must be manually given in the command.",
+                        m_target_name.c_str(), default_datadir);
+        }
+    }
+    else
+    {
+        // User gave custom directory. Path should have been checked already.
+        if (check_datadir_path(m_custom_datadir))
+        {
+            m_eff_datadir = m_custom_datadir;
+            MXB_NOTICE("Using user supplied data directory '%s' on %s.",
+                       m_eff_datadir.c_str(), m_target_name.c_str());
+        }
+        else
+        {
+            mxb_assert(!true);
+            PRINT_JSON_ERROR(m_result.output, bad_datadir, m_custom_datadir.c_str());
+        }
+    }
+
+    if (!m_eff_datadir.empty())
+    {
+        string clear_datadir = mxb::string_printf("sudo rm -rf %s/*", m_eff_datadir.c_str());
+        // Check that the rm-command length is correct. A safeguard against later changes which could
+        // cause MaxScale to delete all files (sudo rm -rf *). Datadir may need to be configurable or read
+        // from server. rm must be run as sudo since the directory and files is owned by "mysql". Even group
+        // access would not suffice as server does not give write access to group members.
+        if (clear_datadir.length() >= (12 + 2 + 2))
+        {
+            if (run_cmd_on_target("sudo systemctl stop mariadb", "stop MariaDB Server")
+                && run_cmd_on_target(clear_datadir, "empty data directory"))
+            {
+                MXB_NOTICE("MariaDB Server %s stopped, data and log directories cleared.",
+                           m_target_name.c_str());
+                target_prepared = true;
+            }
+        }
+        else
+        {
+            mxb_assert(!true);
+            PRINT_JSON_ERROR(m_result.output, "Invalid rm-command (this should not happen!)");
+        }
+    }
+
+    return target_prepared;
+}
+
+bool RebuildServer::state_prepare_target()
+{
+    m_state = prepare_target(m_target) ? State::START_TRANSFER : State::CLEANUP;
+    return true;
+}
+
+bool BackupOperation::start_transfer(const string& destination, TargetOwner target_owner)
+{
+    bool transfer_started = false;
+
+    // Connect to source and start stream the backup.
+    const char receive_fmt[] = "socat -u TCP:%s:%i,connect-timeout=%i STDOUT | pigz -dc "
+                               "| %smbstream -x --directory=%s";
+    const char* maybe_sudo = (target_owner == TargetOwner::ROOT) ? "sudo " : "";
+    string receive_cmd = mxb::string_printf(receive_fmt, m_source_host.c_str(), m_source_port,
+                                            socat_timeout_s, maybe_sudo, destination.c_str());
+
+    bool rval = false;
+    auto [cmd_handle, ssh_errmsg] = ssh_util::start_async_cmd(m_target_ses, receive_cmd);
+    if (cmd_handle)
+    {
+        transfer_started = true;
+        m_target_cmd = std::move(cmd_handle);
+        MXB_NOTICE("Backup transfer from %s to %s started.", m_source_name.c_str(), m_target_name.c_str());
+    }
+    else
+    {
+        PRINT_JSON_ERROR(m_result.output, "Failed to start receiving data to %s. %s",
+                         m_target_name.c_str(), ssh_errmsg.c_str());
+    }
+    return transfer_started;
+}
+
+bool RebuildServer::state_start_transfer()
+{
+    m_state = start_transfer(m_eff_datadir, TargetOwner::ROOT) ? State::WAIT_TRANSFER : State::CLEANUP;
+    return true;
+}
+
+BackupOperation::StateResult BackupOperation::wait_transfer()
+{
+    using Status = ssh_util::AsyncCmd::Status;
+    auto& error_out = m_result.output;
+    const char* target_name = m_target_name.c_str();
+
+    bool wait_again = false;
+    bool target_success = false;
+
+    auto target_status = m_target_cmd->update_status();
+    if (target_status == Status::BUSY)
+    {
+        // Target is receiving more data, keep waiting.
+        wait_again = true;
+    }
+    else
+    {
+        if (target_status == Status::READY)
+        {
+            if (m_target_cmd->rc() == 0)
+            {
+                // Transfer ended with rval 0. This does not guarantee success since the return value of a
+                // multistage command is the return value of the last part. Print any error messages here
+                // and in the next step, check that the target directory is not empty.
+                target_success = true;
+                MXB_NOTICE("Backup transferred to %s.", target_name);
+                if (!m_target_cmd->output().empty())
+                {
+                    MXB_NOTICE("Output from %s: %s", target_name, m_target_cmd->output().c_str());
+                }
+                if (!m_target_cmd->error_output().empty())
+                {
+                    MXB_WARNING("Error output from %s: %s", target_name,
+                                m_target_cmd->error_output().c_str());
+                }
+            }
+            else
+            {
+                PRINT_JSON_ERROR(error_out, "Failed to receive backup on %s. Error %i: '%s'.",
+                                 target_name, m_target_cmd->rc(),
+                                 m_target_cmd->error_output().c_str());
+            }
+        }
+        else
+        {
+            PRINT_JSON_ERROR(error_out, "Failed to check backup transfer status on %s. %s",
+                             target_name, m_target_cmd->error_output().c_str());
+        }
+        m_target_cmd = nullptr;
+    }
+
+    // Update source status even if not used right now.
+    auto source_status = m_source_cmd->update_status();
+    if (!wait_again)
+    {
+        // Target has finished, check if source has as well.
+        if (source_status == Status::BUSY)
+        {
+            // Weird, source is still sending. Ignore and continue. Check it again during cleanup.
+        }
+        else
+        {
+            // Both stopped.
+            if (source_status == Status::READY)
+            {
+                report_source_stream_status();
+            }
+            else
+            {
+                PRINT_JSON_ERROR(error_out, "Failed to check backup transfer status on %s. %s",
+                                 m_source_name.c_str(), m_source_cmd->error_output().c_str());
+            }
+            m_source_cmd = nullptr;
+        }
+    }
+
+    return wait_again ? StateResult::AGAIN : (target_success ? StateResult::OK : StateResult::ERROR);
+}
+
+bool RebuildServer::state_wait_transfer()
+{
+    auto res = wait_transfer();
+    bool rval = false;
+    switch (res)
+    {
+    case StateResult::OK:
+        rval = true;
+        m_state = State::CHECK_DATADIR_SIZE;
+        break;
+
+    case StateResult::AGAIN:
+        break;
+
+    case StateResult::ERROR:
+        rval = true;
+        m_state = State::CLEANUP;
+        break;
+    }
+    return rval;
+}
+
+bool BackupOperation::check_datadir(std::shared_ptr<ssh::Session> ses, const string& datadir_path)
+{
+    auto& output = m_result.output;
+    const string search_file = "backup-my.cnf";
+    bool file_found = false;
+    auto bu_check_func = [&file_found, &search_file](const ssh_util::FileInfo& info) {
+        if (info.name == search_file)
+        {
+            file_found = true;
+            return false;
+        }
+        return true;
+    };
+
+    bool success = false;
+    if (check_directory_entries(ses, m_target_name, datadir_path, bu_check_func))
+    {
+        if (file_found)
+        {
+            success = true;
+        }
+        else
+        {
+            PRINT_JSON_ERROR(output, "Directory '%s' on %s does not contain file '%s'. Transfer must "
+                                     "have failed.", datadir_path.c_str(), m_target_name.c_str(),
+                             search_file.c_str());
+        }
+    }
+    else
+    {
+        PRINT_JSON_ERROR(output, "Could not check contents of '%s' on %s.",
+                         datadir_path.c_str(), m_target_name.c_str());
+    }
+
+    return success;
+}
+
+bool RebuildServer::state_start_backup_prepare()
+{
+    m_state = start_backup_prepare() ? State::WAIT_BACKUP_PREPARE : State::CLEANUP;
+    return true;
+}
+
+bool BackupOperation::start_backup_prepare()
+{
+    bool prepare_started = false;
+    // This step can fail if the previous step failed to write files. Just looking at the return value
+    // of "mbstream" is not reliable.
+    const char prepare_fmt[] = "sudo mariabackup --prepare --target-dir=%s";
+    const char prepare_use_memory_fmt[] = "sudo mariabackup --prepare --use-memory=%s --target-dir=%s";
+    string prepare_cmd = m_mbu_use_memory.empty() ? mxb::string_printf(prepare_fmt, m_eff_datadir.c_str()) :
+        mxb::string_printf(prepare_use_memory_fmt, m_mbu_use_memory.c_str(),
+                           m_eff_datadir.c_str());
+
+    auto [cmd_handle, ssh_errmsg] = ssh_util::start_async_cmd(m_target_ses, prepare_cmd);
+
+    if (cmd_handle)
+    {
+        prepare_started = true;
+        m_target_cmd = std::move(cmd_handle);
+        MXB_NOTICE("Processing backup on %s.", m_target_name.c_str());
+        // Wait a bit. This increases the likelihood that the command completes during this monitor tick.
+        sleep(1);
+    }
+    else
+    {
+        PRINT_JSON_ERROR(m_result.output, "Failed to start processing backup data on %s. %s",
+                         m_target_name.c_str(), ssh_errmsg.c_str());
+    }
+
+    return prepare_started;
+}
+
+bool RestoreFromBackup::state_wait_backup_prepare()
+{
+    auto res = wait_backup_prepare();
+    bool rval = false;
+    switch (res)
+    {
+    case StateResult::OK:
+        rval = true;
+        m_state = State::START_TARGET;
+        break;
+
+    case StateResult::AGAIN:
+        break;
+
+    case StateResult::ERROR:
+        rval = true;
+        m_state = State::CLEANUP;
+        break;
+    }
+    return rval;
+}
+
+BackupOperation::StateResult BackupOperation::wait_backup_prepare()
+{
+    const char* target_name = m_target_name.c_str();
+    using Status = ssh_util::AsyncCmd::Status;
+    auto& error_out = m_result.output;
+    bool wait_again = false;
+    bool target_success = false;
+
+    auto target_status = m_target_cmd->update_status();
+    if (target_status == Status::BUSY)
+    {
+        // Target is still processing, keep waiting.
+        wait_again = true;
+    }
+    else
+    {
+        if (target_status == Status::READY)
+        {
+            if (m_target_cmd->rc() == 0)
+            {
+                target_success = true;
+                MXB_NOTICE("Backup processed on %s.", target_name);
+            }
+            else
+            {
+                PRINT_JSON_ERROR(error_out, "Failed to process backup on %s. Error %i: '%s'.",
+                                 target_name, m_target_cmd->rc(),
+                                 m_target_cmd->error_output().c_str());
+            }
+        }
+        else
+        {
+            PRINT_JSON_ERROR(error_out, "Failed to check backup processing status on %s. %s",
+                             target_name, m_target_cmd->error_output().c_str());
+        }
+        m_target_cmd = nullptr;
+    }
+
+    return wait_again ? StateResult::AGAIN : (target_success ? StateResult::OK : StateResult::ERROR);
+}
+
+bool BackupOperation::start_target()
+{
+    bool server_started = false;
+    // chown must be run as sudo since changing user to something else than self.
+    string chown_cmd = mxb::string_printf("sudo chown -R mysql:mysql %s", m_eff_datadir.c_str());
+    // Check that the chown-command length is correct. Mainly a safeguard against later changes which could
+    // cause MaxScale to change owner of every file on the system.
+    if (chown_cmd.length() >= (26 + 2))
+    {
+        if (run_cmd_on_target(chown_cmd, "change ownership of datadir contents")
+            && run_cmd_on_target("sudo systemctl start mariadb", "start MariaDB Server"))
+        {
+            server_started = true;
+            m_mon.m_cluster_modified = true;
+        }
+    }
+    else
+    {
+        mxb_assert(!true);
+        PRINT_JSON_ERROR(m_result.output, "Invalid chown command (this should not happen!)");
+    }
+    return server_started;
+}
+
+bool BackupOperation::start_replication(MariaDBServer* target, MariaDBServer* repl_master)
+{
+    string gtid;
+    // The gtid of the rebuilt server may not be correct, read it from xtrabackup_binlog_info.
+    string read_gtid_cmd = mxb::string_printf("sudo cat %s/xtrabackup_binlog_info | tr -s ' ' | "
+                                              "cut --fields=3 | tail -n 1", m_eff_datadir.c_str());
+    auto res = ssh_util::run_cmd(*m_target_ses, read_gtid_cmd, m_ssh_timeout);
+    if (res.type == RType::OK && res.rc == 0)
+    {
+        // Check that the result at least looks a bit like a gtid.
+        int n_dash = std::count(res.output.begin(), res.output.end(), '-');
+        if (n_dash >= 2)
+        {
+            gtid = res.output;
+            mxb::trim(gtid);
+        }
+        else
+        {
+            PRINT_JSON_ERROR(m_result.output,
+                             "Command '%s' returned invalid result '%s' on %s. Expected a gtid string.",
+                             read_gtid_cmd.c_str(), res.output.c_str(), target->name());
+        }
+    }
+    else
+    {
+        string errmsg = ssh_util::form_cmd_error_msg(res, read_gtid_cmd.c_str());
+        PRINT_JSON_ERROR(m_result.output, "Could not read gtid on %s. %s", target->name(), errmsg.c_str());
+    }
+
+    bool replication_attempted = false;
+    bool replication_confirmed = false;
+    if (!gtid.empty())
+    {
+        target->update_server(false, false, false, false);
+        if (target->is_running())
+        {
+            string errmsg;
+            string set_gtid = mxb::string_printf("set global gtid_slave_pos='%s';", gtid.c_str());
+            if (target->execute_cmd(set_gtid, &errmsg))
+            {
+                // Just configured gtid_slave_pos, so use it to start replication.
+                GeneralOpData op(OpStart::MANUAL, m_result.output, m_ssh_timeout);
+                SlaveStatus::Settings slave_sett("", repl_master->server,
+                                                 SlaveStatus::Settings::GtidMode::SLAVE);
+
+                if (target->create_start_slave(op, slave_sett, MariaDBServer::ReplicationOp::CONN_SETT))
+                {
+                    replication_attempted = true;
+                }
+            }
+            else
+            {
+                PRINT_JSON_ERROR(m_result.output, "Could not set gtid_slave_pos on %s after rebuild. %s",
+                                 target->name(), errmsg.c_str());
+            }
+        }
+        else
+        {
+            PRINT_JSON_ERROR(m_result.output, "Could not connect to %s after rebuild.", target->name());
+        }
+
+        if (replication_attempted)
+        {
+            // Wait a bit and then check that replication works. This only affects the log message.
+            // Simplified from MariaDBMonitor::wait_cluster_stabilization().
+            std::this_thread::sleep_for(500ms);
+            string errmsg;
+            if (target->do_show_slave_status(&errmsg))
+            {
+                auto slave_conn = target->slave_connection_status_host_port(repl_master);
+                if (slave_conn)
+                {
+                    if (slave_conn->slave_io_running == SlaveStatus::SLAVE_IO_YES
+                        && slave_conn->slave_sql_running == true)
+                    {
+                        replication_confirmed = true;
+                        MXB_NOTICE("%s replicating from %s.", target->name(), repl_master->name());
+                    }
+                    else
+                    {
+                        MXB_WARNING("%s did not start replicating from %s. IO/SQL running: %s/%s.",
+                                    target->name(), repl_master->name(),
+                                    SlaveStatus::slave_io_to_string(slave_conn->slave_io_running).c_str(),
+                                    slave_conn->slave_sql_running ? "Yes" : "No");
+                    }
+                }
+                else
+                {
+                    MXB_WARNING("Could not check replication from %s to %s: replica connection not found.",
+                                repl_master->name(), target->name());
+                }
+            }
+            else
+            {
+                MXB_WARNING("Could not check replication from %s to %s: %s",
+                            repl_master->name(), target->name(), errmsg.c_str());
+            }
+        }
+    }
+    else
+    {
+        PRINT_JSON_ERROR(m_result.output, "Could not start replication on %s.", target->name());
+    }
+    return replication_confirmed;
+}
+
+void BackupOperation::cleanup(MariaDBServer* source, const SlaveStatusArray& source_slaves_old)
+{
+    mxb_assert(source_slaves_old.empty() || source);
+    const char* source_name = m_source_name.c_str();
+    using Status = ssh_util::AsyncCmd::Status;
+    // Target cmd may exist if rebuild is canceled while waiting for transfer/prepare.
+    if (m_target_cmd)
+    {
+        m_target_cmd->update_status();
+        m_target_cmd = nullptr;
+    }
+
+    // Ensure that the source server is no longer serving the backup.
+    if (m_source_cmd)
+    {
+        auto source_status = m_source_cmd->update_status();
+        if (source_status == Status::BUSY)
+        {
+            MXB_WARNING("%s is serving backup data stream even after transfer has ended. "
+                        "Closing ssh channel.", source_name);
+        }
+        else if (source_status == Status::READY)
+        {
+            report_source_stream_status();
+        }
+        else
+        {
+            PRINT_JSON_ERROR(m_result.output, "Failed to check backup transfer status on %s. %s",
+                             source_name, m_source_cmd->error_output().c_str());
+        }
+        m_source_cmd = nullptr;
+    }
+
+    if (m_source_ses)
+    {
+        check_free_listen_port(source_name, *m_source_ses, m_source_port);
+    }
+
+    if (m_source_slaves_stopped && !source_slaves_old.empty())
+    {
+        // Source server replication was stopped when starting Mariabackup. Mariabackup does not restart the
+        // connections if it quits in error or is killed. Check that any slave connections are running as
+        // before.
+        source->update_server(false, false, false, false);
+        if (source->is_running())
+        {
+            const auto& new_slaves = source->m_slave_status;
+            if (new_slaves.size() == source_slaves_old.size())
+            {
+                for (size_t i = 0; i < new_slaves.size(); i++)
+                {
+                    const auto& old_slave = source_slaves_old[i];
+                    const auto& new_slave = new_slaves[i];
+                    bool was_running = (old_slave.slave_io_running != SlaveStatus::SLAVE_IO_NO)
+                        && old_slave.slave_sql_running;
+                    bool is_running = (new_slave.slave_io_running != SlaveStatus::SLAVE_IO_NO)
+                        && new_slave.slave_sql_running;
+                    if (was_running && !is_running)
+                    {
+                        auto& slave_name = old_slave.settings.name;
+                        MXB_NOTICE("Replica connection '%s' is not running on %s, starting it.",
+                                   slave_name.c_str(), source_name);
+                        string start_slave = mxb::string_printf("START SLAVE '%s';", slave_name.c_str());
+                        source->execute_cmd(start_slave);
+                    }
+                }
+            }
+        }
+    }
+
+    m_mon.reset_wait_timeout_all_servers();
+}
+
+MariaDBServer* BackupOperation::autoselect_source_srv(const MariaDBServer* target)
+{
+    MariaDBServer* rval = nullptr;
+    for (auto* cand : m_mon.m_servers)
+    {
+        if (cand != target && (cand->is_master() || cand->is_slave()))
+        {
+            // Anything is better than nothing, a slave is better than master.
+            if (!rval || (rval->is_master() && cand->is_slave()))
+            {
+                rval = cand;
+            }
+            else if (rval->is_slave() && cand->is_slave())
+            {
+                // From two slaves, select one with highest gtid.
+                const auto& curr_gtid = rval->m_gtid_current_pos;
+                const auto& cand_gtid = cand->m_gtid_current_pos;
+                if (cand_gtid.events_ahead(curr_gtid, GtidList::MISSING_DOMAIN_IGNORE) > 0)
+                {
+                    rval = cand;
+                }
+            }
+        }
+    }
+    return rval;
+}
+
+void BackupOperation::report_source_stream_status()
+{
+    const char* source_name = m_source_name.c_str();
+    int rc = m_source_cmd->rc();
+    if (rc == 0)
+    {
+        // Send command completed successfully. Print any output from the command as INFO-level, since it
+        // can be a lot and is usually uninteresting.
+        if (!m_source_cmd->output().empty())
+        {
+            MXB_INFO("Backup send output from %s: %s", source_name, m_source_cmd->output().c_str());
+        }
+        if (!m_source_cmd->error_output().empty())
+        {
+            MXB_INFO("Backup send error output from %s: %s", source_name,
+                     m_source_cmd->error_output().c_str());
+        }
+    }
+    else
+    {
+        PRINT_JSON_ERROR(m_result.output, "Backup send failure on %s. Error %i: '%s'.",
+                         source_name, m_source_cmd->rc(),
+                         m_source_cmd->error_output().c_str());
+    }
+}
+
+bool BackupOperation::check_directory_entries(std::shared_ptr<ssh::Session> ses, const std::string& srv_name,
+                                              const string& path, const DirCheckFunc& check_func)
+{
+    bool fetch_success = false;
+    auto& output = m_result.output;
+
+    auto [sftp, errmsg] = ssh_util::start_sftp_ses(std::move(ses));
+    if (sftp)
+    {
+        auto [dir_contents, dir_errmsg] = sftp->list_directory(path);
+        if (dir_errmsg.empty())
+        {
+            fetch_success = true;
+            for (const auto& elem : dir_contents)
+            {
+                if (!check_func(elem))
+                {
+                    break;
+                }
+            }
+        }
+        else
+        {
+            PRINT_JSON_ERROR(output, "Error fetching contents of '%s': %s", path.c_str(), dir_errmsg.c_str());
+        }
+    }
+    else
+    {
+        PRINT_JSON_ERROR(output, "Error starting sftp session on %s: %s", srv_name.c_str(), errmsg.c_str());
+    }
+
+    return fetch_success;
+}
+
+int BackupOperation::source_port() const
+{
+    return m_source_port;
+}
+
+bool RebuildServer::state_test_datalink()
+{
+    m_state = test_datalink() ? State::SERVE_BACKUP : State::CLEANUP;
+    return true;
+}
+
+bool RebuildServer::state_serve_backup()
+{
+    auto& cs = m_source->conn_settings();
+    m_state = serve_backup(cs.username, cs.password) ? State::PREPARE_TARGET : State::CLEANUP;
+    return true;
+}
+
+void RebuildServer::state_check_datadir()
+{
+    m_state = check_datadir(m_target_ses, m_eff_datadir) ? State::START_BACKUP_PREPARE :
+        State::CLEANUP;
+}
+
+void RebuildServer::state_cleanup()
+{
+    cleanup(m_source, m_source_slaves_old);
+}
+
+bool RebuildServer::state_wait_backup_prepare()
+{
+    auto res = wait_backup_prepare();
+    bool rval = false;
+    switch (res)
+    {
+    case StateResult::OK:
+        rval = true;
+        m_state = State::START_TARGET;
+        break;
+
+    case StateResult::AGAIN:
+        break;
+
+    case StateResult::ERROR:
+        rval = true;
+        m_state = State::CLEANUP;
+        break;
+    }
+    return rval;
+}
+
+bool RebuildServer::state_start_target()
+{
+    m_state = start_target() ? State::START_REPLICATION : State::CLEANUP;
+    return true;
+}
+
+bool RebuildServer::state_start_replication()
+{
+    // If monitor has a master, replicate from it. Otherwise, replicate from the source server.
+    auto master = m_mon.m_master;
+    auto repl_master = (master && master->is_master()) ? master : m_source;
+    m_state = start_replication(m_target, repl_master) ? State::DONE : State::CLEANUP;
+    return true;
+}
+
+Result Result::deep_copy() const
+{
+    return {success, output.deep_copy()};
+}
+
+CreateBackup::CreateBackup(MariaDBMonitor& mon, SERVER* source, std::string bu_name)
+    : BackupOperation(mon, "")
+    , m_source_srv(source)
+    , m_bu_name(std::move(bu_name))
+{
+    mxb_assert(!m_bu_name.empty());
+}
+
+bool CreateBackup::run()
+{
+    bool command_complete = false;
+    bool advance = true;
+    while (advance)
+    {
+        switch (m_state)
+        {
+        case State::INIT:
+            advance = state_init();
+            break;
+
+        case State::CHECK_BACKUP_STORAGE:
+            advance = state_check_backup_storage();
+            break;
+
+        case State::TEST_DATALINK:
+            advance = state_test_datalink();
+            break;
+
+        case State::SERVE_BACKUP:
+            advance = state_serve_backup();
+            break;
+
+        case State::START_TRANSFER:
+            advance = state_start_transfer();
+            break;
+
+        case State::WAIT_TRANSFER:
+            advance = state_wait_transfer();
+            break;
+
+        case State::CHECK_BACKUP_SIZE:
+            state_check_backup();
+            break;
+
+        case State::DONE:
+            m_result.success = true;
+            m_state = State::CLEANUP;
+            break;
+
+        case State::CLEANUP:
+            state_cleanup();
+            command_complete = true;
+            advance = false;
+            break;
+        }
+    }
+
+    return command_complete;
+}
+
+bool CreateBackup::state_init()
+{
+    m_state = State::CLEANUP;
+    if (check_preconditions())
+    {
+        set_source(m_source->name(), m_source->server->address());
+        set_target("backup storage", m_mon.m_settings.backup_storage_addr);
+
+        if (init_operation())
+        {
+            m_source_slaves_old = m_source->m_slave_status;     // Backup slave conns
+            m_state = State::CHECK_BACKUP_STORAGE;
+        }
+    }
+    return true;
+}
+
+bool CreateBackup::state_check_backup_storage()
+{
+    // Check that the backup storage directory exists and that it does not already contain a backup with
+    // the same name.
+    bool success = false;
+    auto& output = m_result.output;
+    string bu_storage_path = m_mon.m_settings.backup_storage_path;
+
+    bool dir_free = true;
+    auto check_dir_free_func = [this, &dir_free](const ssh_util::FileInfo& info) {
+        if (info.name == m_bu_name)
+        {
+            dir_free = false;
+            return false;
+        }
+        return true;
+    };
+
+    if (check_directory_entries(m_target_ses, m_target_name, bu_storage_path, check_dir_free_func))
+    {
+        string full_path = bu_storage_path + "/" + m_bu_name;
+        if (dir_free)
+        {
+            string mkdir = mxb::string_printf("mkdir %s", full_path.c_str());
+            if (run_cmd_on_target(mkdir, "create backup directory"))
+            {
+                success = true;
+                m_bu_path = full_path;
+            }
+        }
+        else
+        {
+            PRINT_JSON_ERROR(output, "Backup storage directory '%s' already exists on %s. Cannot save "
+                                     "backup.", full_path.c_str(), m_target_name.c_str());
+        }
+    }
+
+    m_state = success ? State::TEST_DATALINK : State::CLEANUP;
+    return true;
+}
+
+bool CreateBackup::state_test_datalink()
+{
+    m_state = test_datalink() ? State::SERVE_BACKUP : State::CLEANUP;
+    return true;
+}
+
+bool CreateBackup::state_serve_backup()
+{
+    auto& cs = m_source->conn_settings();
+    m_state = serve_backup(cs.username, cs.password) ? State::START_TRANSFER :
+        State::CLEANUP;
+    return true;
+}
+
+void CreateBackup::state_cleanup()
+{
+    cleanup(m_source, m_source_slaves_old);
+}
+
+bool CreateBackup::check_preconditions()
+{
+    bool rval = false;
+    auto& error_out = m_result.output;
+
+    MariaDBServer* source = m_mon.get_server(m_source_srv);
+    if (source)
+    {
+        bool source_ok = check_server_is_valid_source(source);
+        bool settings_ok = true;
+
+        if (!check_ssh_settings())
+        {
+            settings_ok = false;
+        }
+
+        if (!check_backup_storage_settings())
+        {
+            settings_ok = false;
+        }
+
+        if (source_ok && settings_ok)
+        {
+            m_source = source;
+            rval = true;
+        }
+    }
+    else
+    {
+        PRINT_JSON_ERROR(error_out, "%s is not monitored by %s, cannot use it as backup source.",
+                         m_source_srv->name(), m_mon.name());
+    }
+
+    return rval;
+}
+
+void CreateBackup::cancel()
+{
+    switch (m_state)
+    {
+    case State::INIT:
+        // No need to do anything.
+        break;
+
+    case State::WAIT_TRANSFER:
+        state_cleanup();
+        break;
+
+    default:
+        mxb_assert(!true);
+    }
+}
+
+bool CreateBackup::state_start_transfer()
+{
+    m_state = start_transfer(m_bu_path, TargetOwner::NORMAL) ? State::WAIT_TRANSFER : State::CLEANUP;
+    return true;
+}
+
+bool CreateBackup::state_wait_transfer()
+{
+    auto res = wait_transfer();
+    bool rval = false;
+    switch (res)
+    {
+    case StateResult::OK:
+        rval = true;
+        m_state = State::CHECK_BACKUP_SIZE;
+        break;
+
+    case StateResult::AGAIN:
+        break;
+
+    case StateResult::ERROR:
+        rval = true;
+        m_state = State::CLEANUP;
+        break;
+    }
+    return rval;
+}
+
+void CreateBackup::state_check_backup()
+{
+    m_state = check_datadir(m_target_ses, m_bu_path) ? State::DONE : State::CLEANUP;
+}
+
+RestoreFromBackup::RestoreFromBackup(MariaDBMonitor& mon, SERVER* target, string bu_name, std::string datadir)
+    : BackupOperation(mon, std::move(datadir))
+    , m_target_srv(target)
+    , m_bu_name(std::move(bu_name))
+{
+    mxb_assert(!m_bu_name.empty());
+}
+
+bool RestoreFromBackup::run()
+{
+    bool command_complete = false;
+    bool advance = true;
+    while (advance)
+    {
+        switch (m_state)
+        {
+        case State::INIT:
+            advance = state_init();
+            break;
+
+        case State::CHECK_BACKUP_STORAGE:
+            advance = state_check_backup_storage();
+            break;
+
+        case State::TEST_DATALINK:
+            advance = state_test_datalink();
+            break;
+
+        case State::SERVE_BACKUP:
+            advance = state_serve_backup();
+            break;
+
+        case State::PREPARE_TARGET:
+            advance = state_prepare_target();
+            break;
+
+        case State::START_TRANSFER:
+            advance = state_start_transfer();
+            break;
+
+        case State::WAIT_TRANSFER:
+            advance = state_wait_transfer();
+            break;
+
+        case State::CHECK_DATADIR_SIZE:
+            state_check_datadir();
+            break;
+
+        case State::START_BACKUP_PREPARE:
+            advance = state_start_backup_prepare();
+            break;
+
+        case State::WAIT_BACKUP_PREPARE:
+            advance = state_wait_backup_prepare();
+            break;
+
+        case State::START_TARGET:
+            advance = state_start_target();
+            break;
+
+        case State::START_REPLICATION:
+            advance = state_start_replication();
+            break;
+
+        case State::DONE:
+            m_result.success = true;
+            m_state = State::CLEANUP;
+            break;
+
+        case State::CLEANUP:
+            state_cleanup();
+            command_complete = true;
+            advance = false;
+            break;
+        }
+    }
+
+    return command_complete;
+}
+
+void RestoreFromBackup::cancel()
+{
+    switch (m_state)
+    {
+    case State::INIT:
+        // No need to do anything.
+        break;
+
+    case State::WAIT_TRANSFER:
+    case State::WAIT_BACKUP_PREPARE:
+        state_cleanup();
+        break;
+
+    default:
+        mxb_assert(!true);
+    }
+}
+
+bool RestoreFromBackup::state_init()
+{
+    m_state = State::CLEANUP;
+    if (check_preconditions())
+    {
+        set_source("backup storage", m_mon.m_settings.backup_storage_addr);
+        set_target(m_target->name(), m_target->server->address());
+
+        if (init_operation())
+        {
+            m_state = State::CHECK_BACKUP_STORAGE;
+        }
+    }
+    return true;
+}
+
+bool RestoreFromBackup::check_preconditions()
+{
+    auto& error_out = m_result.output;
+    MariaDBServer* target = m_mon.get_server(m_target_srv);
+    if (!target)
+    {
+        PRINT_JSON_ERROR(error_out, "%s is not monitored by %s, cannot rebuild it.",
+                         m_target_srv->name(), m_mon.name());
+    }
+
+    bool rval = false;
+    if (target)
+    {
+        bool target_ok = check_server_is_valid_target(target);
+        bool settings_ok = true;
+
+        if (!check_ssh_settings())
+        {
+            settings_ok = false;
+        }
+
+        if (!check_backup_storage_settings())
+        {
+            settings_ok = false;
+        }
+
+        if (target_ok && settings_ok)
+        {
+            m_target = target;
+            rval = true;
+        }
+    }
+    return rval;
+}
+
+bool RestoreFromBackup::state_test_datalink()
+{
+    m_state = test_datalink() ? State::SERVE_BACKUP : State::CLEANUP;
+    return true;
+}
+
+bool RestoreFromBackup::state_check_backup_storage()
+{
+    bool success = false;
+    auto& output = m_result.output;
+    const string& bu_storage_path = m_mon.m_settings.backup_storage_path;
+
+    bool bu_dir_found = false;
+    bool bu_dir_ok = true;
+    auto bu_storage_check_func = [&](const ssh_util::FileInfo& info) {
+        bool check_next = true;
+        const string& ssh_user = m_mon.m_settings.ssh_user;
+
+        if (info.name == m_bu_name)
+        {
+            bu_dir_found = true;
+            if (info.owner != ssh_user)
+            {
+                bu_dir_ok = false;
+                PRINT_JSON_ERROR(output, "Backup storage directory '%s/%s' is not owned by '%s'. "
+                                         "Cannot use backup.", bu_storage_path.c_str(),
+                                 m_bu_name.c_str(), ssh_user.c_str());
+            }
+            if (info.type != ssh_util::FileType::DIR)
+            {
+                bu_dir_ok = false;
+                PRINT_JSON_ERROR(output, "Backup storage path '%s/%s' is not a directory. "
+                                         "Cannot use backup.", bu_storage_path.c_str(),
+                                 m_bu_name.c_str());
+            }
+            check_next = false;
+        }
+        return check_next;
+    };
+
+    if (check_directory_entries(m_source_ses, m_source_name, bu_storage_path, bu_storage_check_func))
+    {
+        if (!bu_dir_found)
+        {
+            PRINT_JSON_ERROR(output, "Main backup storage directory '%s' does not contain '%s'. "
+                                     "Cannot use backup.", bu_storage_path.c_str(), m_bu_name.c_str());
+        }
+        else if (bu_dir_ok)
+        {
+            // Finally, check that "backup-my.cnf" exists.
+            const string search_file = "backup-my.cnf";
+            bool file_found = false;
+            auto bu_check_func = [&file_found, &search_file](const ssh_util::FileInfo& info) {
+                if (info.name == search_file)
+                {
+                    file_found = true;
+                    return false;
+                }
+                return true;
+            };
+
+            string full_path = bu_storage_path + "/" + m_bu_name;
+            if (check_directory_entries(m_source_ses, m_source_name, full_path, bu_check_func))
+            {
+                if (file_found)
+                {
+                    success = true;
+                    m_bu_path = full_path;
+                }
+                else
+                {
+                    PRINT_JSON_ERROR(output, "Directory '%s' does not contain file '%s'. Cannot use "
+                                             "backup.", full_path.c_str(), search_file.c_str());
+                }
+            }
+        }
+    }
+
+    m_state = success ? State::TEST_DATALINK : State::CLEANUP;
+    return true;
+}
+
+bool RestoreFromBackup::state_serve_backup()
+{
+    auto source_name = m_source_name.c_str();
+    // Start serving the backup stream. The source will wait for a new connection. Since MariaDB Server is
+    // not running on this machine, serve the data directory as a tar archive.
+    const char stream_fmt[] = "tar -zc -C %s . | socat - TCP-LISTEN:%i,reuseaddr";
+    string stream_cmd = mxb::string_printf(stream_fmt, m_bu_path.c_str(), source_port());
+    auto [cmd_handle, ssh_errmsg] = ssh_util::start_async_cmd(m_source_ses, stream_cmd);
+
+    auto& error_out = m_result.output;
+    bool success = false;
+    if (cmd_handle)
+    {
+        // Wait a bit, then check that command started successfully and is still running.
+        sleep(1);
+        auto status = cmd_handle->update_status();
+
+        if (status == ssh_util::AsyncCmd::Status::BUSY)
+        {
+            success = true;
+            m_source_cmd = std::move(cmd_handle);
+            MXB_NOTICE("%s serving backup on port %i.", source_name, source_port());
+        }
+        else if (status == ssh_util::AsyncCmd::Status::READY)
+        {
+            // The stream serve operation ended before it should. Print all output available.
+            int rc = cmd_handle->rc();
+            string message = mxb::string_printf(
+                "Failed to stream data from %s. Command '%s' stopped before data was streamed. Return "
+                "value %i. Output: '%s' Error output: '%s'", source_name, stream_cmd.c_str(), rc,
+                cmd_handle->output().c_str(), cmd_handle->error_output().c_str());
+
+            PRINT_JSON_ERROR(error_out, "%s", message.c_str());
+        }
+        else
+        {
+            ssh_errmsg = mxb::string_printf("Failed to read output. %s",
+                                            cmd_handle->error_output().c_str());
+        }
+    }
+
+    if (!ssh_errmsg.empty())
+    {
+        mxb_assert(!m_source_cmd);
+        PRINT_JSON_ERROR(error_out, "Failed to start streaming data from %s. %s",
+                         source_name, ssh_errmsg.c_str());
+    }
+
+    m_state = success ? State::PREPARE_TARGET : State::CLEANUP;
+    return true;
+}
+
+bool RestoreFromBackup::state_prepare_target()
+{
+    m_state = prepare_target(m_target) ? State::START_TRANSFER : State::CLEANUP;
+    return true;
+}
+
+bool RestoreFromBackup::state_start_transfer()
+{
+    bool transfer_started = false;
+    // Connect to source and start stream the backup.
+    const char receive_fmt[] = "socat -u TCP:%s:%i,connect-timeout=%i STDOUT | sudo tar -xz -C %s/";
+    string receive_cmd = mxb::string_printf(receive_fmt, m_source_host.c_str(), source_port(),
+                                            socat_timeout_s, m_eff_datadir.c_str());
+
+    bool rval = false;
+    auto [cmd_handle, ssh_errmsg] = ssh_util::start_async_cmd(m_target_ses, receive_cmd);
+    if (cmd_handle)
+    {
+        transfer_started = true;
+        m_target_cmd = std::move(cmd_handle);
+        MXB_NOTICE("Backup transfer from %s to %s started.", m_source_name.c_str(), m_target_name.c_str());
+    }
+    else
+    {
+        PRINT_JSON_ERROR(m_result.output, "Failed to start receiving data to %s. %s",
+                         m_target_name.c_str(), ssh_errmsg.c_str());
+    }
+
+    m_state = transfer_started ? State::WAIT_TRANSFER : State::CLEANUP;
+    return true;
+}
+
+bool RestoreFromBackup::state_wait_transfer()
+{
+    auto res = wait_transfer();
+    bool rval = false;
+    switch (res)
+    {
+    case StateResult::OK:
+        rval = true;
+        m_state = State::CHECK_DATADIR_SIZE;
+        break;
+
+    case StateResult::AGAIN:
+        break;
+
+    case StateResult::ERROR:
+        rval = true;
+        m_state = State::CLEANUP;
+        break;
+    }
+    return rval;
+}
+
+void RestoreFromBackup::state_check_datadir()
+{
+    m_state = check_datadir(m_target_ses, m_eff_datadir) ? State::START_BACKUP_PREPARE :
+        State::CLEANUP;
+}
+
+bool RestoreFromBackup::state_start_backup_prepare()
+{
+    m_state = start_backup_prepare() ? State::WAIT_BACKUP_PREPARE : State::CLEANUP;
+    return true;
+}
+
+bool RestoreFromBackup::state_start_target()
+{
+    m_state = start_target() ? State::START_REPLICATION : State::CLEANUP;
+    return true;
+}
+
+bool RestoreFromBackup::state_start_replication()
+{
+    // If monitor has a valid master, replicate from it. Otherwise, skip this step.
+    auto master = m_mon.m_master;
+    if (master && master->is_master())
+    {
+        m_state = start_replication(m_target, master) ? State::DONE : State::CLEANUP;
+    }
+    else
+    {
+        MXB_WARNING("No primary for monitor %s, not starting replication on %s.",
+                    m_mon.name(), m_target_name.c_str());
+        m_state = State::DONE;
+    }
+    return true;
+}
+
+void RestoreFromBackup::state_cleanup()
+{
+    cleanup(nullptr, {});
+}
+}

--- a/server/modules/monitor/mysqlrepmon/monitor_commands.hh
+++ b/server/modules/monitor/mysqlrepmon/monitor_commands.hh
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) 2022 MariaDB Corporation Ab
+ * Copyright (c) 2023 MariaDB plc, Finnish Branch
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file and at www.mariadb.com/bsl11.
+ *
+ * Change Date: 2027-09-09
+ *
+ * On the date above, in accordance with the Business Source License, use
+ * of this software will be governed by version 2 or later of the General
+ * Public License.
+ */
+
+#pragma once
+#include "mariadbmon_common.hh"
+#include <condition_variable>
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include "ssh_utils.hh"
+#include "server_utils.hh"
+
+class SERVER;
+class MariaDBServer;
+class MariaDBMonitor;
+
+namespace mon_op
+{
+
+struct Result
+{
+    Result deep_copy() const;
+
+    bool success {false};
+
+    // Error printing functions interpret an "undefined" json-object as null and won't print to it.
+    mxb::Json output {mxb::Json::Type::OBJECT};
+};
+
+/**
+ * This class represents two related things: manual commands (such as manual failover) and long-running
+ * automatic commands (such as automatic rebuild-server). These two types are similar in the sense that
+ * both block the scheduling of further manual commands and are ran at the end of a monitor tick.
+ */
+class Operation
+{
+public:
+    Operation(const Operation&) = delete;
+    Operation& operator=(const Operation&) = delete;
+
+    Operation() = default;
+    virtual ~Operation() = default;
+
+    virtual bool   run() = 0;
+    virtual Result result() = 0;
+    virtual void   cancel() = 0;
+};
+
+using SOperation = std::unique_ptr<Operation>;
+
+enum class ExecState
+{
+    SCHEDULED,
+    RUNNING,
+    DONE
+};
+
+struct ResultInfo
+{
+    Result      res;
+    std::string cmd_name;
+};
+
+/**
+ * Stores info on the currently scheduled/running operation. Deals mostly with manual commands. Long-
+ * running automatic ops may modify some fields to prevent the user to schedule another op.
+ */
+struct OperationInfo
+{
+    std::mutex lock;        /**< Most fields must be protected from concurrent access. */
+    SOperation scheduled_op;/**< Manually scheduled operation. */
+
+    /** State of manual op or long-running auto op. Both cannot be scheduled/running simultaneously. */
+    std::atomic<ExecState> exec_state {ExecState::DONE};
+    /**< True if monitor stop was requested. Prevents starting another operation. */
+    std::atomic_bool monitor_stopping {true};
+    std::atomic_bool cancel_op {false};     /**< True if cancel has been requested for a running op */
+
+    std::string op_name;    /**< Either name of the scheduled op or name of current long-running auto op. */
+
+    bool current_op_is_manual {false};      /** True if the currently scheduled/running op is manual. */
+
+    std::condition_variable     result_ready_notifier;
+    std::unique_ptr<ResultInfo> result_info;
+};
+
+using CmdMethod = std::function<Result (void)>;
+
+/**
+ * An operation, likely manual, which completes in one monitor iteration. Does not have internal state.
+ */
+class SimpleOp : public Operation
+{
+public:
+    explicit SimpleOp(CmdMethod func);
+
+    bool   run() override;
+    Result result() override;
+    void   cancel() override;
+
+private:
+    CmdMethod m_func;
+    Result    m_result;
+};
+
+class BackupOperation : public Operation
+{
+public:
+    BackupOperation(MariaDBMonitor& mon, std::string datadir);
+    Result result() override;
+
+protected:
+    enum class StateResult {OK, AGAIN, ERROR};
+    enum class TargetOwner {ROOT, NORMAL};
+
+    bool        init_operation();
+    bool        test_datalink();
+    bool        serve_backup(const std::string& mariadb_user, const std::string& mariadb_pw);
+    bool        start_transfer(const std::string& destination, TargetOwner target_owner);
+    StateResult wait_transfer();
+    bool        start_backup_prepare();
+    StateResult wait_backup_prepare();
+    bool        start_target();
+    bool        start_replication(MariaDBServer* target, MariaDBServer* repl_master);
+    bool        check_datadir(std::shared_ptr<ssh::Session> ses, const std::string& datadir_path);
+    void        cleanup(MariaDBServer* source, const SlaveStatusArray& source_slaves_old);
+
+    ssh_util::SSession init_ssh_session(const char* name, const std::string& host);
+    bool               check_rebuild_tools(const char* srvname, ssh::Session& ssh);
+    bool               check_free_listen_port(const char* srvname, ssh::Session& ssh, int port);
+    bool               check_ssh_settings();
+    bool               check_backup_storage_settings();
+    bool               check_server_is_valid_target(const MariaDBServer* target);
+    bool               check_server_is_valid_source(const MariaDBServer* source);
+    void               report_source_stream_status();
+    MariaDBServer*     autoselect_source_srv(const MariaDBServer* target);
+    bool               run_cmd_on_target(const std::string& cmd, const std::string& desc);
+    bool               prepare_target(MariaDBServer* target);
+
+    using DirCheckFunc = std::function<bool (const ssh_util::FileInfo&)>;
+    bool check_directory_entries(std::shared_ptr<ssh::Session> ses, const std::string& srv_name,
+                                 const std::string& path, const DirCheckFunc& check_func);
+
+    void set_source(std::string name, std::string host);
+    void set_target(std::string name, std::string host);
+
+    int source_port() const;
+
+    MariaDBMonitor&      m_mon;
+    std::chrono::seconds m_ssh_timeout {0};
+    std::chrono::seconds m_port_open_delay {0};
+    bool                 m_source_slaves_stopped {false};
+    Result               m_result;
+
+    std::string                         m_source_name;
+    std::string                         m_source_host;
+    ssh_util::SSession                  m_source_ses;
+    std::unique_ptr<ssh_util::AsyncCmd> m_source_cmd;
+
+    std::string                         m_target_name;
+    std::string                         m_target_host;
+    std::string                         m_eff_datadir;
+    ssh_util::SSession                  m_target_ses;
+    std::unique_ptr<ssh_util::AsyncCmd> m_target_cmd;
+
+private:
+    std::string m_custom_datadir;
+    std::string m_mbu_use_memory;
+    int         m_source_port {0};
+};
+
+class RebuildServer : public BackupOperation
+{
+public:
+    RebuildServer(MariaDBMonitor& mon, SERVER* target, SERVER* source, std::string datadir);
+
+    bool run() override;
+    void cancel() override;
+
+private:
+    SERVER*          m_target_srv {nullptr};
+    SERVER*          m_source_srv {nullptr};
+    MariaDBServer*   m_target {nullptr};
+    MariaDBServer*   m_source {nullptr};
+    SlaveStatusArray m_source_slaves_old;
+
+    enum class State
+    {
+        INIT,
+        TEST_DATALINK,
+        SERVE_BACKUP,
+        PREPARE_TARGET,
+        START_TRANSFER,
+        WAIT_TRANSFER,
+        CHECK_DATADIR_SIZE,
+        START_BACKUP_PREPARE,
+        WAIT_BACKUP_PREPARE,
+        START_TARGET,
+        START_REPLICATION,
+        DONE,
+        CLEANUP,
+    };
+    State m_state {State::INIT};
+
+    bool state_init();
+    bool state_test_datalink();
+    bool state_serve_backup();
+    bool state_prepare_target();
+    bool state_start_transfer();
+    bool state_wait_transfer();
+    void state_check_datadir();
+    bool state_start_backup_prepare();
+    bool state_wait_backup_prepare();
+    bool state_start_target();
+    bool state_start_replication();
+    void state_cleanup();
+
+    bool check_preconditions();
+};
+
+class CreateBackup : public BackupOperation
+{
+public:
+    CreateBackup(MariaDBMonitor& mon, SERVER* source, std::string bu_name);
+
+    bool run() override;
+    void cancel() override;
+
+private:
+    SERVER*          m_source_srv {nullptr};
+    MariaDBServer*   m_source {nullptr};
+    SlaveStatusArray m_source_slaves_old;
+    std::string      m_bu_name;
+    std::string      m_bu_path;
+
+    enum class State
+    {
+        INIT,
+        TEST_DATALINK,
+        CHECK_BACKUP_STORAGE,
+        SERVE_BACKUP,
+        START_TRANSFER,
+        WAIT_TRANSFER,
+        CHECK_BACKUP_SIZE,
+        DONE,
+        CLEANUP,
+    };
+    State m_state {State::INIT};
+
+    bool state_init();
+    bool state_test_datalink();
+    bool state_check_backup_storage();
+    bool state_serve_backup();
+    bool state_start_transfer();
+    bool state_wait_transfer();
+    void state_check_backup();
+    void state_cleanup();
+
+    bool check_preconditions();
+};
+
+class RestoreFromBackup : public BackupOperation
+{
+public:
+    RestoreFromBackup(MariaDBMonitor& mon, SERVER* target, std::string bu_name, std::string datadir);
+
+    bool run() override;
+    void cancel() override;
+
+private:
+    SERVER*        m_target_srv {nullptr};
+    MariaDBServer* m_target {nullptr};
+    std::string    m_bu_name;
+    std::string    m_bu_path;
+
+    enum class State
+    {
+        INIT,
+        TEST_DATALINK,
+        CHECK_BACKUP_STORAGE,
+        SERVE_BACKUP,
+        PREPARE_TARGET,
+        START_TRANSFER,
+        WAIT_TRANSFER,
+        CHECK_DATADIR_SIZE,
+        START_BACKUP_PREPARE,
+        WAIT_BACKUP_PREPARE,
+        START_TARGET,
+        START_REPLICATION,
+        DONE,
+        CLEANUP,
+    };
+    State m_state {State::INIT};
+
+    bool state_init();
+    bool state_test_datalink();
+    bool state_check_backup_storage();
+    bool state_serve_backup();
+    bool state_prepare_target();
+    bool state_start_transfer();
+    bool state_wait_transfer();
+    void state_check_datadir();
+    bool state_start_backup_prepare();
+    bool state_wait_backup_prepare();
+    bool state_start_target();
+    bool state_start_replication();
+    void state_cleanup();
+
+    bool check_preconditions();
+};
+}

--- a/server/modules/monitor/mysqlrepmon/server_utils.cc
+++ b/server/modules/monitor/mysqlrepmon/server_utils.cc
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2018 MariaDB Corporation Ab
+ * Copyright (c) 2023 MariaDB plc, Finnish Branch
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file and at www.mariadb.com/bsl11.
+ *
+ * Change Date: 2027-09-09
+ *
+ * On the date above, in accordance with the Business Source License, use
+ * of this software will be governed by version 2 or later of the General
+ * Public License.
+ */
+#include "server_utils.hh"
+
+#include <algorithm>
+#include <cinttypes>
+#include <maxbase/format.hh>
+#include <maxbase/assert.hh>
+#include "mariadbserver.hh"
+
+using std::string;
+using std::move;
+using maxbase::string_printf;
+
+namespace
+{
+// Used for Slave_IO_Running
+const char YES[] = "Yes";
+const char PREPARING[] = "Preparing";
+const char CONNECTING[] = "Connecting";
+const char NO[] = "No";
+}
+
+SlaveStatus::SlaveStatus(const std::string& owner)
+    : settings(owner)
+{
+}
+
+string SlaveStatus::to_string() const
+{
+    // Print all of this on the same line to make things compact. Are the widths reasonable? The format is
+    // not quite array-like since usually there is just one row. May be changed later.
+    // Form the components of the line.
+    string running_states = string_printf("%s/%s",
+                                          slave_io_to_string(slave_io_running).c_str(),
+                                          slave_sql_running ? "Yes" : "No");
+
+    string rval = string_printf(
+        "  Host: %22s, IO/SQL running: %7s, Master ID: %4ld, Gtid_IO_Pos: %s, R.Lag: %ld",
+        settings.master_endpoint.to_string().c_str(),
+        running_states.c_str(),
+        master_server_id,
+        gtid_io_pos.to_string().c_str(),
+        seconds_behind_master);
+    return rval;
+}
+
+std::string SlaveStatus::Settings::to_string() const
+{
+    if (name.empty())
+    {
+        return string_printf("Replica connection from %s to %s",
+                             m_owner.c_str(), master_endpoint.to_string().c_str());
+    }
+    else
+    {
+        return string_printf("Replica connection '%s' from %s to %s",
+                             name.c_str(), m_owner.c_str(), master_endpoint.to_string().c_str());
+    }
+}
+
+json_t* SlaveStatus::to_json() const
+{
+    json_t* result = json_object();
+    json_object_set_new(result, "connection_name", json_string(settings.name.c_str()));
+    json_object_set_new(result, "master_host", json_string(settings.master_endpoint.host().c_str()));
+    json_object_set_new(result, "master_port", json_integer(settings.master_endpoint.port()));
+    json_object_set_new(result, "slave_io_running",
+                        json_string(slave_io_to_string(slave_io_running).c_str()));
+    json_object_set_new(result, "slave_sql_running", json_string(slave_sql_running ? "Yes" : "No"));
+    json_object_set_new(result, "seconds_behind_master",
+                        seconds_behind_master == mxs::Target::RLAG_UNDEFINED ? json_null() :
+                        json_integer(seconds_behind_master));
+    json_object_set_new(result, "master_server_id", json_integer(master_server_id));
+    json_object_set_new(result, "last_io_error", json_string(last_io_error.c_str()));
+    json_object_set_new(result, "last_sql_error", json_string(last_sql_error.c_str()));
+    json_object_set_new(result, "gtid_io_pos", json_string(gtid_io_pos.to_string().c_str()));
+    const char* gtid_mode_str = (settings.gtid_mode == Settings::GtidMode::SLAVE) ? "Slave_Pos" :
+                                (settings.gtid_mode == Settings::GtidMode::CURRENT) ? "Current_Pos" : "No";
+    json_object_set_new(result, "using_gtid", json_string(gtid_mode_str));
+    if (master_server)
+    {
+        json_object_set_new(result, "master_server_name", json_string(master_server->name()));
+    }
+    return result;
+}
+
+bool SlaveStatus::equal(const SlaveStatus& rhs) const
+{
+    // Strictly speaking, the following should depend on the 'assume_unique_hostnames',
+    // but the situations it would make a difference are so rare they can be ignored.
+    return slave_io_running == rhs.slave_io_running
+           && slave_sql_running == rhs.slave_sql_running
+           && settings.master_endpoint == rhs.settings.master_endpoint
+           && settings.name == rhs.settings.name
+           && master_server_id == rhs.master_server_id;
+}
+
+SlaveStatus::slave_io_running_t SlaveStatus::slave_io_from_string(const std::string& str)
+{
+    slave_io_running_t rval = SLAVE_IO_NO;
+    if (str == YES)
+    {
+        rval = SLAVE_IO_YES;
+    }
+    // Interpret "Preparing" as "Connecting". It's not quite clear if the master server id has been read
+    // or if server versions between master and slave have been checked, so better be on the safe side.
+    else if (str == CONNECTING || str == PREPARING)
+    {
+        rval = SLAVE_IO_CONNECTING;
+    }
+    else if (str != NO)
+    {
+        MXB_ERROR("Unexpected value for Slave_IO_Running: '%s'.", str.c_str());
+    }
+    return rval;
+}
+
+string SlaveStatus::slave_io_to_string(SlaveStatus::slave_io_running_t slave_io)
+{
+    string rval;
+    switch (slave_io)
+    {
+    case SlaveStatus::SLAVE_IO_YES:
+        rval = YES;
+        break;
+
+    case SlaveStatus::SLAVE_IO_CONNECTING:
+        rval = CONNECTING;
+        break;
+
+    case SlaveStatus::SLAVE_IO_NO:
+        rval = NO;
+        break;
+
+    default:
+        mxb_assert(!false);
+    }
+    return rval;
+}
+
+bool SlaveStatus::should_be_copied(string* ignore_reason_out) const
+{
+    bool accepted = true;
+    auto master_id = master_server_id;
+    // The connection is only copied if it is running or at least has been seen running.
+    // Also, target should not be this server.
+    string ignore_reason;
+    if (!slave_sql_running)
+    {
+        accepted = false;
+        ignore_reason = "its replica sql thread is not running.";
+    }
+    else if (!seen_connected)
+    {
+        accepted = false;
+        ignore_reason = "it has not been seen connected to master.";
+    }
+    else if (master_id <= 0)
+    {
+        accepted = false;
+        ignore_reason = string_printf("its Master_Server_Id (%li) is invalid .", master_id);
+    }
+
+    if (!accepted)
+    {
+        *ignore_reason_out = ignore_reason;
+    }
+    return accepted;
+}
+
+SlaveStatus::Settings::Settings(string name, EndPoint target, GtidMode gtid_mode, string owner)
+    : name(move(name))
+    , master_endpoint(move(target))
+    , gtid_mode(gtid_mode)
+    , m_owner(move(owner))
+{
+}
+
+SlaveStatus::Settings::Settings(const std::string& name, const SERVER* target, GtidMode gtid_mode)
+    : Settings(name, EndPoint::replication_endpoint(*target), gtid_mode, "")
+{
+}
+
+SlaveStatus::Settings::Settings(string owner)
+    : m_owner(move(owner))
+{
+}
+
+ServerOperation::ServerOperation(MariaDBServer* target, TargetType target_type,
+                                 SlaveStatusArray conns_to_copy, EventNameSet events_to_enable)
+    : target(target)
+    , target_type(target_type)
+    , conns_to_copy(move(conns_to_copy))
+    , events_to_enable(move(events_to_enable))
+{
+}
+
+ServerOperation::ServerOperation(MariaDBServer* target, TargetType target_type)
+    : ServerOperation(target, target_type, SlaveStatusArray(), EventNameSet())
+{
+}
+
+GeneralOpData::GeneralOpData(OpStart start, mxb::Json& error, maxbase::Duration time_remaining)
+    : start(start)
+    , error_out(error)
+    , time_remaining(time_remaining)
+{
+}
+
+EndPoint::EndPoint(const std::string& host, int port)
+    : m_host(host, port)
+{
+}
+
+EndPoint EndPoint::replication_endpoint(const SERVER& server)
+{
+    const char* priv_addr = server.private_address();
+    const char* addr = *priv_addr ? priv_addr : server.address();
+    return EndPoint(addr, server.port());
+}
+
+EndPoint::EndPoint()
+    : EndPoint("", PORT_UNKNOWN)
+{
+}
+
+bool EndPoint::operator==(const EndPoint& rhs) const
+{
+    return m_host.address() == rhs.m_host.address() && m_host.port() == rhs.m_host.port();
+}
+
+std::string EndPoint::to_string() const
+{
+    return mxb::string_printf("[%s]:%d", m_host.address().c_str(), m_host.port());
+}
+
+bool EndPoint::points_to_server(const SERVER& srv) const
+{
+    // Ports must match, and the address must match either server normal or private address.
+    return (m_host.port() == srv.port())
+           && (m_host.address() == srv.address() || m_host.address() == srv.private_address());
+}
+
+void ServerLock::set_status(Status new_status, int64_t owner_id)
+{
+    m_owner_id = (new_status == Status::UNKNOWN || new_status == Status::FREE) ? CONN_ID_UNKNOWN : owner_id;
+    m_status = new_status;
+}
+
+int64_t ServerLock::owner() const
+{
+    return m_owner_id;
+}
+
+ServerLock::Status ServerLock::status() const
+{
+    return m_status;
+}
+
+bool ServerLock::operator==(const ServerLock& rhs) const
+{
+    return m_status == rhs.m_status && m_owner_id == rhs.m_owner_id && m_owner_id != CONN_ID_UNKNOWN;
+}
+
+bool ServerLock::is_free() const
+{
+    return m_status == Status::FREE;
+}
+
+int round_to_seconds(mxb::Duration dur)
+{
+    return mxb::to_secs(dur) + 0.5;
+}

--- a/server/modules/monitor/mysqlrepmon/server_utils.hh
+++ b/server/modules/monitor/mysqlrepmon/server_utils.hh
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2018 MariaDB Corporation Ab
+ * Copyright (c) 2023 MariaDB plc, Finnish Branch
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file and at www.mariadb.com/bsl11.
+ *
+ * Change Date: 2027-09-09
+ *
+ * On the date above, in accordance with the Business Source License, use
+ * of this software will be governed by version 2 or later of the General
+ * Public License.
+ */
+#pragma once
+#include "mariadbmon_common.hh"
+
+#include <unordered_set>
+#include <string>
+#include <vector>
+#include <maxbase/host.hh>
+#include <maxbase/stopwatch.hh>
+#include <maxscale/server.hh>
+#include <maxscale/protocol/mariadb/gtid.hh>
+
+class MariaDBServer;
+
+using mariadb::Gtid;
+using mariadb::GtidList;
+
+// Helper class for host-port combinations
+class EndPoint
+{
+public:
+    EndPoint(const std::string& host, int port);
+    EndPoint();
+
+    /**
+     * Create endpoint usable for creating a replication connection. Uses private address if defined.
+     *
+     * @param server Target server
+     * @return Endpoint
+     */
+    static EndPoint replication_endpoint(const SERVER& server);
+
+    std::string host() const
+    {
+        return m_host.address();
+    }
+
+    int port() const
+    {
+        return m_host.port();
+    }
+
+    bool operator==(const EndPoint& rhs) const;
+    bool operator!=(const EndPoint& rhs) const
+    {
+        return !(*this == rhs);
+    }
+
+    std::string to_string() const;
+
+    /**
+     * Does the endpoint point to the server?
+     */
+    bool points_to_server(const SERVER& srv) const;
+
+private:
+    mxb::Host m_host;   /* Address and port */
+};
+
+
+// Contains data returned by one row of SHOW ALL SLAVES STATUS
+class SlaveStatus
+{
+public:
+    explicit SlaveStatus(const std::string& owner);
+
+    enum slave_io_running_t
+    {
+        SLAVE_IO_YES,
+        SLAVE_IO_CONNECTING,
+        SLAVE_IO_NO,
+    };
+
+    // Helper class for containing slave connection settings. These are modifiable by
+    // a CHANGE MASTER TO-command and should not change on their own. The owning server
+    // is included to simplify log message creation.
+    struct Settings
+    {
+        enum class GtidMode
+        {
+            NONE,       /* No gtid. */
+            CURRENT,    /* Current_Pos */
+            SLAVE       /* Slave_Pos */
+        };
+
+        Settings(std::string name, EndPoint target, GtidMode gtid_mode, std::string owner);
+        Settings(const std::string& name, const SERVER* target, GtidMode gtid_mode);
+        explicit Settings(std::string owner);
+
+        /**
+         * Create a short description in the form of "Slave connection from <owner> to <[host]:port>."
+         *
+         * @return Description
+         */
+        std::string to_string() const;
+
+        std::string name;                       /* Slave connection name. Must be unique for the server. */
+        EndPoint    master_endpoint;            /* Master server address & port */
+        GtidMode    gtid_mode {GtidMode::NONE}; /* Gtid-mode */
+        std::string m_owner;                    /* Name of the owning server. Used for logging. */
+    };
+
+    Settings settings;      /* User-defined settings for the slave connection. */
+
+    /* If the master is a monitored server, it's written here. */
+    const MariaDBServer* master_server {nullptr};
+    /* Has this slave connection been seen connected, meaning that the master server id is correct? */
+    bool seen_connected = false;
+
+    int64_t master_server_id = Gtid::SERVER_ID_UNKNOWN; /* The master's server_id value. Valid ids are
+                                                         * 32bit unsigned. -1 is unread/error. */
+    slave_io_running_t slave_io_running = SLAVE_IO_NO;  /* Slave I/O thread running state: "Yes",
+                                                         * "Connecting" or "No" */
+    bool        slave_sql_running = false;              /* Slave SQL thread running state, true if "Yes" */
+    GtidList    gtid_io_pos;                            /* Gtid I/O position of the slave thread. */
+    int64_t     last_io_errno {0};                      /* Last I/O error number */
+    std::string last_io_error;                          /* Last IO error encountered. */
+    std::string last_sql_error;                         /* Last SQL error encountered. */
+    int64_t     received_heartbeats = 0;                /* How many heartbeats the connection has
+                                                         * received */
+
+    int64_t seconds_behind_master = mxs::Target::RLAG_UNDEFINED;    /* How much behind the slave is. */
+
+    /* Time of the latest gtid event or heartbeat the slave connection has received, timed by the monitor. */
+    maxbase::TimePoint last_data_time = maxbase::Clock::now();
+
+    std::string to_string() const;
+    json_t*     to_json() const;
+
+    bool equal(const SlaveStatus& rhs) const;
+
+    static slave_io_running_t slave_io_from_string(const std::string& str);
+    static std::string        slave_io_to_string(slave_io_running_t slave_io);
+    bool                      should_be_copied(std::string* ignore_reason_out) const;
+};
+
+using SlaveStatusArray = std::vector<SlaveStatus>;
+using EventNameSet = std::unordered_set<std::string>;
+
+enum class OperationType
+{
+    SWITCHOVER,         /**< Normal switchover */
+    SWITCHOVER_FORCE,   /**< Forced switchover. Ignores several errors. */
+    FAILOVER,           /**< Failover. Allow data loss when unavoidable. */
+    FAILOVER_SAFE,      /**< Failover. Cancel if certain that data would be lost. */
+    REJOIN,
+    UNDO_DEMOTION       /**< Performed when switchover fails in its first stages. */
+};
+
+enum class OpStart {MANUAL, AUTO};
+enum class SwitchoverType {NORMAL, AUTO, FORCE};
+enum class AfterDemotion
+{
+    REDIRECT,       /**< After demotion, redirect old master to replicate from new. Standard behavior. */
+    MAINTENANCE     /**< After demotion, set old master to maintenance. Useful when upgrading servers. */
+};
+enum class FailoverType {SAFE, ALLOW_TRX_LOSS, WRITE_TEST_FAIL};
+
+class GeneralOpData
+{
+public:
+    OpStart           start {OpStart::MANUAL};  // How operation was started
+    mxb::Json&        error_out;                // Json error output
+    maxbase::Duration time_remaining;           // How much time remains to complete the operation
+
+    GeneralOpData(OpStart start, mxb::Json& error, maxbase::Duration time_remaining);
+};
+
+// Operation data which concerns a single server
+class ServerOperation
+{
+public:
+    enum TargetType
+    {
+        MASTER, /**< Swapping master. Either demoting a master or promoting a new master. */
+        RELAY   /**< Just swapping a relay with a relay/replica. */
+    };
+
+    MariaDBServer* const   target;              // Target server
+    const TargetType       target_type {MASTER};// Was the target a master / should it become one
+    const SlaveStatusArray conns_to_copy;       // Slave connections the target should copy/merge
+    const EventNameSet     events_to_enable;    // Scheduled event names last seen on master.
+
+    ServerOperation(MariaDBServer* target, TargetType target_type, SlaveStatusArray conns_to_copy,
+                    EventNameSet events_to_enable);
+
+    ServerOperation(MariaDBServer* target, TargetType target_type);
+};
+
+/* Server lock status descriptor */
+class ServerLock
+{
+public:
+    enum class Status
+    {
+        UNKNOWN,        /* Unknown/error */
+        FREE,           /* Lock is unclaimed */
+        OWNED_SELF,     /* Lock is claimed by current monitor */
+        OWNED_OTHER,    /* Lock is claimed by other monitor/MaxScale */
+    };
+
+    void    set_status(Status new_status, int64_t owner_id = CONN_ID_UNKNOWN);
+    int64_t owner() const;
+    Status  status() const;
+    bool    is_free() const;
+
+    bool operator==(const ServerLock& rhs) const;
+private:
+    int64_t m_owner_id {CONN_ID_UNKNOWN};
+    Status  m_status {Status::UNKNOWN};
+};
+
+int round_to_seconds(mxb::Duration dur);
+
+namespace MasterConds
+{
+const uint32_t MCOND_NONE = 0;
+const uint32_t MCOND_CONNECTING_S = 1 << 0;
+const uint32_t MCOND_CONNECTED_S = 1 << 1;
+const uint32_t MCOND_RUNNING_S = 1 << 2;
+const uint32_t MCOND_COOP_M = 1 << 3;
+const uint32_t MCOND_DISK_OK = 1 << 4;
+}
+
+namespace SlaveConds
+{
+const uint32_t SCOND_NONE = 0;
+const uint32_t SCOND_LINKED_M = 1 << 0;
+const uint32_t SCOND_RUNNING_M = 1 << 1;
+const uint32_t SCOND_WRITABLE_M = 1 << 2;
+const uint32_t SCOND_COOP_M = 1 << 3;
+const uint32_t SCOND_DISK_OK = 1 << 4;
+}

--- a/server/modules/monitor/mysqlrepmon/ssh_utils.cc
+++ b/server/modules/monitor/mysqlrepmon/ssh_utils.cc
@@ -1,0 +1,414 @@
+/*
+ * Copyright (c) 2022 MariaDB Corporation Ab
+ * Copyright (c) 2023 MariaDB plc, Finnish Branch
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file and at www.mariadb.com/bsl11.
+ *
+ * Change Date: 2027-09-09
+ *
+ * On the date above, in accordance with the Business Source License, use
+ * of this software will be governed by version 2 or later of the General
+ * Public License.
+ */
+
+#include "ssh_utils.hh"
+#include <utility>
+#include <libssh/libsshpp.hpp>
+#include <libssh/sftp.h>
+#include <maxbase/format.hh>
+#include <maxbase/stopwatch.hh>
+
+using std::string;
+using std::move;
+
+namespace
+{
+std::tuple<ssh_key, std::string> read_private_key(const string& keyfile)
+{
+    ssh_key privkey {nullptr};
+    string errmsg;
+    int key_res = ssh_pki_import_privkey_file(keyfile.c_str(), nullptr, nullptr, nullptr, &privkey);
+    if (key_res != SSH_OK)
+    {
+        if (key_res == SSH_EOF)
+        {
+            errmsg = mxb::string_printf("File does not exist or permission denied.");
+        }
+        else
+        {
+            // TODO: The library has a logging callback for more detailed error messages.
+            errmsg = "Miscellaneous error.";
+        }
+    }
+    return {privkey, errmsg};
+}
+}
+
+namespace ssh_util
+{
+
+std::tuple<SSession, std::string>
+init_ssh_session(const string& host, int port, const string& user, const string& keyfile,
+                 bool check_host, std::chrono::milliseconds timeout)
+{
+    auto [privkey, key_errmsg] = read_private_key(keyfile);
+    if (!privkey)
+    {
+        return {nullptr,
+                mxb::string_printf("Failed to read private key from file '%s'. %s",
+                                   keyfile.c_str(), key_errmsg.c_str())};
+    }
+
+    SSession rval;
+    string errmsg;
+
+    try
+    {
+        auto ses = std::make_unique<ssh::Session>();
+        ses->setOption(SSH_OPTIONS_HOST, host.c_str());
+        ses->setOption(SSH_OPTIONS_PORT, &port);
+        ses->setOption(SSH_OPTIONS_USER, user.c_str());
+        long timeout_ms = timeout.count();
+        long timeout_s = timeout_ms / 1000;
+        long timeout_us = 1000 * (timeout_ms % 1000);
+        ses->setOption(SSH_OPTIONS_TIMEOUT, &timeout_s);
+        ses->setOption(SSH_OPTIONS_TIMEOUT_USEC, &timeout_us);
+
+        ses->connect();
+
+        bool host_ok = false;
+        if (check_host)
+        {
+            int pubkey_res = ses->isServerKnown();
+            if (pubkey_res == SSH_KNOWN_HOSTS_OK)
+            {
+                // Server is known. Authenticate.
+                host_ok = true;
+            }
+            else
+            {
+                errmsg = "Public key of server was not found in known_hosts file. Either connect to the "
+                         "server manually or disable key checking.";
+            }
+        }
+        else
+        {
+            host_ok = true;
+        }
+
+        if (host_ok)
+        {
+            ses->userauthPublickey(privkey);
+            rval = move(ses);
+        }
+    }
+    catch (ssh::SshException& e)
+    {
+        errmsg = mxb::string_printf("Error %i: %s", e.getCode(), e.getError().c_str());
+    }
+    ssh_key_free(privkey);
+
+    return {move(rval), move(errmsg)};
+}
+
+CmdResult run_cmd(ssh::Session& ses, const std::string& cmd, std::chrono::milliseconds timeout)
+{
+    CmdResult rval;
+    mxb::StopWatch timer;
+
+    // Open a channel and a channel session, then start command.
+    ssh::Channel channel(ses);
+    try
+    {
+        channel.openSession();
+        channel.requestExec(cmd.c_str());
+
+        auto read_output = [&](bool read_error_stream) {
+            auto& output = read_error_stream ? rval.error_output : rval.output;
+
+            size_t bufsize = 1024;
+            char buf[bufsize];
+
+            auto time_left = timeout - timer.split();
+            int time_left_ms = std::chrono::duration_cast<std::chrono::milliseconds>(time_left).count();
+            // LibSSH interprets negative timeouts as infinite.
+            int time_left_eff_ms = std::max(time_left_ms, 1);
+
+            // Errors throw, so no need to handle here.
+            int read = channel.read(buf, bufsize, read_error_stream, time_left_eff_ms);
+            if (read > 0)
+            {
+                output.append(buf, read);
+                if ((size_t)read == bufsize)
+                {
+                    // If read the max amount, continue reading non-blocking.
+                    do
+                    {
+                        read = channel.readNonblocking(buf, bufsize, read_error_stream);
+                        if (read > 0)
+                        {
+                            output.append(buf, read);
+                        }
+                    }
+                    while (read > 0);
+                }
+            }
+        };
+
+        bool keep_reading = true;
+        while (keep_reading)
+        {
+            // Read both stdout and stderr.
+            read_output(false);
+            read_output(true);
+
+            // Either all data was read or timed out. Check the time in case blocking read was interrupted.
+            if (channel.isEof() || timer.split() > timeout)
+            {
+                keep_reading = false;
+            }
+        }
+
+        channel.close();
+
+        // Only read exit status if all output was read.
+        if (channel.isEof())
+        {
+            rval.rc = channel.getExitStatus();      // This can block, deal with it later.
+            rval.type = CmdResult::Type::OK;
+        }
+        else
+        {
+            rval.type = CmdResult::Type::TIMEOUT;
+        }
+    }
+    catch (ssh::SshException& e)
+    {
+        rval.error_output = mxb::string_printf("Error %i: %s", e.getCode(), e.getError().c_str());
+    }
+
+    return rval;
+}
+
+AsyncCmd::AsyncCmd(std::shared_ptr<ssh::Session> ses, std::unique_ptr<ssh::Channel> chan)
+    : m_ses(move(ses))
+    , m_chan(move(chan))
+    , m_status(Status::BUSY)
+{
+}
+
+AsyncCmd::Status AsyncCmd::update_status()
+{
+    if (m_status != Status::BUSY)
+    {
+        return m_status;
+    }
+
+    auto read_output = [&](bool read_error) {
+        auto& output = read_error ? m_error_output : m_output;
+        size_t bufsize = 1024;
+        char buf[bufsize];
+
+        int read;
+        do
+        {
+            read = m_chan->readNonblocking(buf, bufsize, read_error);
+            if (read > 0)
+            {
+                output.append(buf, read);
+            }
+            // If read <= 0, nothing was available yet or remote end sent eof.
+        }
+        while (read > 0);
+    };
+
+    try
+    {
+        // Read all available data from both streams, then check for eof.
+        read_output(false);
+        read_output(true);
+
+        if (m_chan->isEof())
+        {
+            m_chan->close();
+            m_rc = m_chan->getExitStatus();
+            m_status = Status::READY;
+        }
+    }
+    catch (ssh::SshException& e)
+    {
+        m_error_output = mxb::string_printf("Error %i: %s", e.getCode(), e.getError().c_str());
+        m_status = Status::SSH_FAIL;
+    }
+
+    return m_status;
+}
+
+AsyncCmd::~AsyncCmd()
+{
+    if (m_status == Status::BUSY)
+    {
+        // If the remote command did not complete, try sending a signal to it before disconnecting.
+        // Typical commands terminate on disconnect, but "socat" will stay running. Sending a signal
+        // increases the likelihood that the process will actually end. TODO: see if this actually does
+        // anything.
+        try
+        {
+            m_chan->requestSendSignal("KILL");
+        }
+        catch (ssh::SshException& e)
+        {
+        }
+    }
+}
+
+const std::string& AsyncCmd::output() const
+{
+    return m_output;
+}
+
+const std::string& AsyncCmd::error_output() const
+{
+    return m_error_output;
+}
+
+int AsyncCmd::rc() const
+{
+    return m_rc;
+}
+
+std::tuple<std::unique_ptr<AsyncCmd>, std::string>
+start_async_cmd(std::shared_ptr<ssh::Session> ses, const std::string& cmd)
+{
+    // Open a channel and a channel session, then start command.
+    auto channel = std::make_unique<ssh::Channel>(*ses);
+    try
+    {
+        channel->openSession();
+        channel->requestExec(cmd.c_str());
+        auto async_cmd = std::make_unique<AsyncCmd>(move(ses), move(channel));
+        return {move(async_cmd), ""};
+    }
+    catch (ssh::SshException& e)
+    {
+        return {nullptr, mxb::string_printf("Error %i: %s", e.getCode(), e.getError().c_str())};
+    }
+}
+
+string form_cmd_error_msg(const CmdResult& res, const char* cmd)
+{
+    using RType = CmdResult::Type;
+    string rval;
+    if (res.type == RType::OK)
+    {
+        if (res.rc == 0)
+        {
+            rval = mxb::string_printf("Command '%s' succeeded.", cmd);
+        }
+        else
+        {
+            rval = mxb::string_printf("Command '%s' failed with error %i: '%s'", cmd, res.rc,
+                                      res.error_output.c_str());
+        }
+    }
+    else if (res.type == RType::TIMEOUT)
+    {
+        rval = mxb::string_printf("Command '%s' timed out.", cmd);
+    }
+    else
+    {
+        rval = mxb::string_printf("Failed to send command '%s'. %s", cmd, res.error_output.c_str());
+    }
+    return rval;
+}
+
+std::tuple<std::unique_ptr<SFTPSession>, std::string> start_sftp_ses(std::shared_ptr<ssh::Session> ses)
+{
+    std::unique_ptr<SFTPSession> new_ses;
+    string errmsg;
+
+    sftp_session sftp_ses = sftp_new(ses->getCSession());
+    if (sftp_ses)
+    {
+        int rc = sftp_init(sftp_ses);
+        if (rc == SSH_OK)
+        {
+            new_ses = std::make_unique<SFTPSession>(std::move(ses), sftp_ses);
+        }
+        else
+        {
+            errmsg = mxb::string_printf("Error initializing SFTP session: code %d.",
+                                        sftp_get_error(sftp_ses));
+            sftp_free(sftp_ses);
+        }
+    }
+    else
+    {
+        errmsg = mxb::string_printf("Error allocating SFTP session: %s", ssh_get_error(ses->getCSession()));
+    }
+    return {std::move(new_ses), std::move(errmsg)};
+}
+
+SFTPSession::SFTPSession(std::shared_ptr<ssh::Session> ses, sftp_session_struct* sftp)
+    : m_ses(std::move(ses))
+    , m_sftp(sftp)
+{
+}
+
+SFTPSession::~SFTPSession()
+{
+    if (m_sftp)
+    {
+        sftp_free(m_sftp);
+    }
+}
+
+std::tuple<std::vector<FileInfo>, std::string> SFTPSession::list_directory(const std::string& path)
+{
+    std::vector<FileInfo> rval;
+    string errmsg;
+
+    auto cses = m_ses->getCSession();
+    sftp_dir dir = sftp_opendir(m_sftp, path.c_str());
+    if (dir)
+    {
+        std::vector<FileInfo> dir_contents;
+        sftp_attributes attr {nullptr};
+        while ((attr = sftp_readdir(m_sftp, dir)) != nullptr)
+        {
+            auto attr_type = attr->type;
+            auto type = (attr_type == SSH_FILEXFER_TYPE_REGULAR) ? FileType::REG :
+                (attr_type == SSH_FILEXFER_TYPE_DIRECTORY) ? FileType::DIR : FileType::OTHER;
+
+            FileInfo info {attr->name, attr->owner, attr->size, type};
+            dir_contents.emplace_back(std::move(info));
+            sftp_attributes_free(attr);
+        }
+
+        if (sftp_dir_eof(dir))
+        {
+            int rc = sftp_closedir(dir);
+            if (rc == SSH_OK)
+            {
+                rval = std::move(dir_contents);
+            }
+            else
+            {
+                errmsg = mxb::string_printf("Can't close directory: %s", ssh_get_error(cses));
+            }
+        }
+        else
+        {
+            errmsg = mxb::string_printf("Can't list directory: %s", ssh_get_error(cses));
+            sftp_closedir(dir);
+        }
+    }
+    else
+    {
+        errmsg = mxb::string_printf("Directory not opened: %s", ssh_get_error(cses));
+    }
+
+    return {std::move(rval), std::move(errmsg)};
+}
+}

--- a/server/modules/monitor/mysqlrepmon/ssh_utils.hh
+++ b/server/modules/monitor/mysqlrepmon/ssh_utils.hh
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2022 MariaDB Corporation Ab
+ * Copyright (c) 2023 MariaDB plc, Finnish Branch
+ *
+ * Use of this software is governed by the Business Source License included
+ * in the LICENSE.TXT file and at www.mariadb.com/bsl11.
+ *
+ * Change Date: 2027-09-09
+ *
+ * On the date above, in accordance with the Business Source License, use
+ * of this software will be governed by version 2 or later of the General
+ * Public License.
+ */
+
+#pragma once
+#include <maxscale/ccdefs.hh>
+#include <chrono>
+#include <memory>
+#include <vector>
+
+struct sftp_session_struct;
+
+namespace ssh
+{
+class Session;
+class Channel;
+}
+
+namespace ssh_util
+{
+// LibSSH defines the Session-class, which may be shared between multiple channels (i.e. running commands).
+// Store it in a shared_ptr to ensure proper destruction.
+using SSession = std::shared_ptr<ssh::Session>;
+
+/**
+ * Start an SSH session. Reads private key from file, connects to server and authenticates. The server must
+ * already be listed in the known_hosts-file.
+ *
+ * @param host Host address
+ * @param port Host port
+ * @param user Username
+ * @param keyfile Private key file
+ * @param timeout Connection timeout
+ * @return If success, the session. On error, an error message.
+ */
+std::tuple<SSession, std::string>
+init_ssh_session(const std::string& host, int port, const std::string& user,
+                 const std::string& keyfile, bool check_host, std::chrono::milliseconds timeout);
+
+struct CmdResult
+{
+    enum class Type
+    {
+        OK,         /**< Command was sent and output + return code fetched */
+        SSH_FAIL,   /**< Failed to send command or read result */
+        TIMEOUT     /**< Command timed out */
+    };
+
+    Type        type {Type::SSH_FAIL};  /**< Result type */
+    int         rc {-1};                /**< If command completed, its return code */
+    std::string output;                 /**< Command standard output */
+    std::string error_output;           /**< Command error output or ssh error message */
+};
+
+CmdResult run_cmd(ssh::Session& ses, const std::string& cmd, std::chrono::milliseconds timeout);
+
+class AsyncCmd
+{
+public:
+    AsyncCmd(std::shared_ptr<ssh::Session> ses, std::unique_ptr<ssh::Channel> chan);
+    ~AsyncCmd();
+
+    enum class Status {READY, SSH_FAIL, BUSY};
+    Status update_status();
+
+    const std::string& output() const;
+    const std::string& error_output() const;
+    int                rc() const;
+
+private:
+    // The session can be shared between multiple channels, each running a command.
+    std::shared_ptr<ssh::Session> m_ses;
+    std::unique_ptr<ssh::Channel> m_chan;
+
+    int         m_rc {-1};              /**< If command completed, its return code */
+    std::string m_output;               /**< Command standard output */
+    std::string m_error_output;         /**< Command error output or ssh error message */
+    Status      m_status {Status::SSH_FAIL};
+};
+
+/**
+ * Start an async ssh command.
+ *
+ * @param ses Existing ssh session
+ * @param cmd The command to execute
+ * @return If successful, the object. On failure, an error string.
+ */
+std::tuple<std::unique_ptr<AsyncCmd>, std::string>
+start_async_cmd(std::shared_ptr<ssh::Session> ses, const std::string& cmd);
+
+std::string form_cmd_error_msg(const CmdResult& res, const char* cmd);
+
+enum class FileType {REG, DIR, OTHER};
+struct FileInfo
+{
+    std::string name;
+    std::string owner;
+    uint64_t    size {0};
+    FileType    type {FileType::OTHER};
+};
+
+// Helper class for sftp operations
+class SFTPSession
+{
+public:
+    SFTPSession(std::shared_ptr<ssh::Session> ses, sftp_session_struct* sftp);
+    ~SFTPSession();
+    SFTPSession(const SFTPSession& rhs) = delete;
+    SFTPSession& operator=(const SFTPSession& rhs) = delete;
+
+    std::tuple<std::vector<FileInfo>, std::string> list_directory(const std::string& path);
+
+private:
+    std::shared_ptr<ssh::Session> m_ses;
+    sftp_session_struct*          m_sftp {nullptr};
+};
+std::tuple<std::unique_ptr<SFTPSession>, std::string> start_sftp_ses(std::shared_ptr<ssh::Session> ses);
+}


### PR DESCRIPTION
## Summary

This draft adds a MySQL-specific replication monitor for MySQL 8.x/8.4:

- accept `SHOW REPLICA STATUS` when `mariadbmon` monitors MySQL 8.4;
- add `mysqlrepmon`, using MySQL replication commands and UUID GTIDs;
- support automatic failover, switchover, and rejoin with
  `SOURCE_AUTO_POSITION = 1`;
- document requirements, grants, and a minimal configuration;
- use MaxScale's configured libssh dependency in the new module.

## Motivation

MySQL 8.4 removed `SHOW SLAVE STATUS`, and its replication-control syntax and
UUID-based GTID sets differ from MariaDB's. The existing MariaDB monitor cannot
therefore perform the complete MySQL 8.4 failover/rejoin workflow unchanged.

The new module keeps the MySQL dialect isolated while reusing the established
MariaDB Monitor orchestration code.

## Validation

Built from a clean checkout based on the current `develop` branch:

```text
cmake -S . -B build -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_INSTALL_PREFIX=/tmp/maxscale-pr-install
cmake --build build --target connector-c --clean-first -j2
cmake --build build --target mysqlrepmon mariadbmon test_cycle_find -j2
ctest --test-dir build --output-on-failure \
  -R '^test_mariadbmon_cycle_find$'
```

Result: both monitor modules built successfully and the selected CTest passed
(`1/1`).

The functional commits were also deployed in a three-node MySQL 8.4.10 lab:

- the replica topology was detected;
- stopping the primary promoted a replica;
- the remaining replica was redirected to the promoted primary;
- the old primary automatically rejoined as a replica after restart;
- a second failover completed with all three nodes converged to the same
  `gtid_executed` set.

Read/write client-session continuity was verified separately with the
readwritesplit router configured with `master_reconnection=true` and
`master_failure_mode=fail_on_write`.

## Review notes / current limitation

This is intentionally a draft integration proposal. The MySQL GTID adapter
currently maps each UUID to a process-local synthetic domain and reduces its
interval set to the highest transaction number. That is sufficient for the
contiguous GTID histories exercised by the lab, but it does not faithfully
represent GTID sets containing gaps. The representation and candidate
comparison need maintainer review and dedicated unit/integration coverage
before this should be considered production-ready.

The module currently starts as a MySQL-dialect sibling of `mariadbmon`, which
also leaves room for a follow-up refactor to share more implementation without
duplicating the monitor sources.

I am contributing the new code of the whole pull request, including one or
several files that are either new files or modified ones, under the BSD-new
license.
